### PR TITLE
build: allow running arbitrary commands on container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY src         ./src
 COPY tests       ./tests
 COPY phpunit.xml ./
 
-ENTRYPOINT ["vendor/bin/pest", "--coverage-clover", "coverage.xml"]
+CMD ["vendor/bin/pest", "--coverage-clover", "coverage.xml"]
 
 
 ###
@@ -46,4 +46,4 @@ ENTRYPOINT ["vendor/bin/pest", "--coverage-clover", "coverage.xml"]
 ###
 FROM base AS dev
 
-ENTRYPOINT ["sleep", "infinity"]
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
Hierdoor kan je dit doen:

```shell
docker compose run php composer update
```
Wat dan eenmalig de container opstart en dat commando uitvoert. Als je ENTRYPOINT gebruikt probeert hij de argumenten (`composer`, `update`) mee te geven aan het entrypoint.