### PR TITLE
fix(api): fix error when composer can't be used normally

### DIFF
--- a/config/pdk-dependencies.php
+++ b/config/pdk-dependencies.php
@@ -7,6 +7,12 @@ use function DI\factory;
 use function DI\value;
 
 return [
+    'pdkVersion'                => factory(function (): string {
+        $composerJson = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true);
+
+        return $composerJson['version'];
+    }),
+
     /**
      * The minimum PHP version required to run the app.
      */

--- a/src/Api/Service/MyParcelApiService.php
+++ b/src/Api/Service/MyParcelApiService.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\Api\Service;
 
-use Composer\InstalledVersions;
-use MyParcelNL\Pdk\Base\Pdk;
+use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Facade\Settings;
 use MyParcelNL\Pdk\Settings\Model\AccountSettings;
 
@@ -34,9 +33,9 @@ class MyParcelApiService extends AbstractApiService
     {
         $userAgentStrings = [];
         $userAgents       = array_merge(
-            \MyParcelNL\Pdk\Facade\Pdk::get('userAgent'),
+            Pdk::get('userAgent'),
             [
-                'MyParcelNL-PDK' => InstalledVersions::getPrettyVersion(Pdk::PACKAGE_NAME),
+                'MyParcelNL-PDK' => Pdk::get('pdkVersion'),
                 'php'            => PHP_VERSION,
             ]
         );


### PR DESCRIPTION
- get composer version from json instead of a composer class for maximum compatibility
