### PR TITLE
feat: include delivery options translations in context

### DIFF
--- a/config/pdk-default.php
+++ b/config/pdk-default.php
@@ -136,7 +136,7 @@ return [
      * Carriers filtered by those allowed in the current platform.
      */
 
-    'carriers'           => factory(function (): CarrierCollection {
+    'carriers'                         => factory(function (): CarrierCollection {
         /** @var CarrierCollection $allCarriers */
         $allCarriers      = Pdk::get('allCarriers');
         $platformCarriers = new Collection(Platform::get('carriers'));
@@ -149,14 +149,15 @@ return [
     /**
      * Language to default to when no language is set.
      */
-    'defaultLanguage'    => value('en'),
+    'defaultLanguage'                  => value('en'),
 
     /**
      * Languages present in the translations directory after the build process.
      */
-    'availableLanguages' => value([
-        'en',
-        'nl',
-        'fr',
-    ]),
+    'availableLanguages'               => value(['en', 'nl', 'fr']),
+
+    /**
+     * The prefix to use for delivery options translations.
+     */
+    'translationPrefixDeliveryOptions' => value('delivery_options_'),
 ];

--- a/tests/Bootstrap/MockLanguageService.php
+++ b/tests/Bootstrap/MockLanguageService.php
@@ -9,7 +9,10 @@ use MyParcelNL\Pdk\Language\Contract\LanguageServiceInterface;
 class MockLanguageService implements LanguageServiceInterface
 {
     private const TRANSLATIONS = [
-        'apple_tree' => 'Appelboom',
+        'apple_tree'                     => 'Appelboom',
+        'delivery_options'               => 'Delivery options',
+        'delivery_options_morning'       => 'Ochtend',
+        'some_delivery_options_broccoli' => 'Broccoli',
     ];
 
     /**
@@ -57,7 +60,7 @@ class MockLanguageService implements LanguageServiceInterface
      */
     public function translate(string $key, ?string $language = null): string
     {
-        return self::TRANSLATIONS[$key] ?? $key;
+        return $this->getTranslations()[$key] ?? $key;
     }
 
     /**

--- a/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_delivery_options_config__1.json
+++ b/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_delivery_options_config__1.json
@@ -1,33 +1,7 @@
 {
   "checkout": {
     "strings": {
-      "addressNotFound": "delivery_options_address_not_found",
-      "cc": "delivery_options_cc",
-      "city": "delivery_options_city",
-      "closed": "delivery_options_closed",
-      "deliveryEveningTitle": "delivery_options_delivery_type_evening_title",
-      "deliveryMorningTitle": "delivery_options_delivery_type_morning_title",
-      "deliverySameDayTitle": "delivery_options_delivery_type_same_day_title",
-      "deliveryStandardTitle": "delivery_options_delivery_type_standard_title",
-      "deliveryTitle": "delivery_options_delivery_title",
-      "discount": "delivery_options_discount",
-      "free": "delivery_options_free",
-      "from": "delivery_options_from",
-      "loadMore": "delivery_options_load_more",
-      "mondayDeliveryTitle": "delivery_options_monday_delivery_title",
-      "number": "delivery_options_number",
-      "onlyRecipientTitle": "delivery_options_only_recipient_title",
-      "openingHours": "delivery_options_opening_hours",
-      "options": "delivery_options_options",
-      "packageTypeDigitalStamp": "delivery_options_package_type_digital_stamp",
-      "packageTypeMailbox": "delivery_options_package_type_mailbox",
-      "pickUpFrom": "delivery_options_pick_up_from",
-      "pickupLocationsListButton": "delivery_options_pickup_locations_list_button",
-      "pickupLocationsMapButton": "delivery_options_pickup_locations_map_button",
-      "pickupTitle": "delivery_options_pickup_title",
-      "postalCode": "delivery_options_postal_code",
-      "saturdayDeliveryTitle": "delivery_options_saturday_delivery_title",
-      "signatureTitle": "delivery_options_signature_title"
+      "morning": "Ochtend"
     },
     "settings": {
       "actions": {

--- a/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_global__1.json
+++ b/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_global__1.json
@@ -205,7 +205,10 @@
       "defaultCarrierId": 1
     },
     "translations": {
-      "apple_tree": "Appelboom"
+      "apple_tree": "Appelboom",
+      "delivery_options": "Delivery options",
+      "delivery_options_morning": "Ochtend",
+      "some_delivery_options_broccoli": "Broccoli"
     }
   }
 }

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_delivery_options__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_delivery_options__1.json
@@ -13,33 +13,7 @@
       "apiBaseUrl": "https://api.myparcel.nl"
     },
     "strings": {
-      "addressNotFound": "delivery_options_address_not_found",
-      "cc": "delivery_options_cc",
-      "city": "delivery_options_city",
-      "closed": "delivery_options_closed",
-      "deliveryEveningTitle": "delivery_options_delivery_type_evening_title",
-      "deliveryMorningTitle": "delivery_options_delivery_type_morning_title",
-      "deliverySameDayTitle": "delivery_options_delivery_type_same_day_title",
-      "deliveryStandardTitle": "delivery_options_delivery_type_standard_title",
-      "deliveryTitle": "delivery_options_delivery_title",
-      "discount": "delivery_options_discount",
-      "free": "delivery_options_free",
-      "from": "delivery_options_from",
-      "loadMore": "delivery_options_load_more",
-      "mondayDeliveryTitle": "delivery_options_monday_delivery_title",
-      "number": "delivery_options_number",
-      "onlyRecipientTitle": "delivery_options_only_recipient_title",
-      "openingHours": "delivery_options_opening_hours",
-      "options": "delivery_options_options",
-      "packageTypeDigitalStamp": "delivery_options_package_type_digital_stamp",
-      "packageTypeMailbox": "delivery_options_package_type_mailbox",
-      "pickUpFrom": "delivery_options_pick_up_from",
-      "pickupLocationsListButton": "delivery_options_pickup_locations_list_button",
-      "pickupLocationsMapButton": "delivery_options_pickup_locations_map_button",
-      "pickupTitle": "delivery_options_pickup_title",
-      "postalCode": "delivery_options_postal_code",
-      "saturdayDeliveryTitle": "delivery_options_saturday_delivery_title",
-      "signatureTitle": "delivery_options_signature_title"
+      "morning": "Ochtend"
     },
     "settings": {
       "actions": {

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_init_script__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_init_script__1.json
@@ -205,7 +205,10 @@
       "defaultCarrierId": 1
     },
     "translations": {
-      "apple_tree": "Appelboom"
+      "apple_tree": "Appelboom",
+      "delivery_options": "Delivery options",
+      "delivery_options_morning": "Ochtend",
+      "some_delivery_options_broccoli": "Broccoli"
     }
   },
   "dynamic": {


### PR DESCRIPTION
Door [deze js-pdk commit](https://github.com/myparcelnl/js-pdk/commit/10a8a1fff644b5f6d411b9a6cbe1611fe15ce98d) worden er in de translations vanaf nu ook de delivery options vertalingen geincludeerd. Die worden hier vervolgens weer op de juiste plek in de context gestopt ✅ 