### PR TITLE
fix(carriers): fix errors in another postnl carrier configuration

### DIFF
--- a/tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php
+++ b/tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php
@@ -188,6 +188,59 @@ it('maps carriers correctly with custom postnl contract', function () {
         ->pluck('externalIdentifier')
         ->all();
 
-    // If custom PostNL carrier is present, all other PostNL entries should be removed
+    // If multiple PostNL carriers are present, the custom contract should be used.
     expect($externalIdentifiers)->toBe(['postnl:23991']);
+});
+
+it('maps carriers correctly with multiple non-contract postnl entries', function () {
+    executeUpdateAccount(['apiKey' => 'test-api-key'], null, [
+        [
+            'id'         => 1,
+            'label'      => null,
+            'carrier_id' => 1,
+            'carrier'    => [
+                'id'   => 1,
+                'name' => 'postnl',
+            ],
+            'enabled'    => 1,
+            'optional'   => 1,
+            'primary'    => 1,
+            'type'       => 'main',
+        ],
+        [
+            'id'         => 1,
+            'label'      => 'postnl_package_small_nl',
+            'carrier_id' => 1,
+            'carrier'    => [
+                'id'   => 1,
+                'name' => 'postnl',
+            ],
+            'enabled'    => 1,
+            'optional'   => 0,
+            'primary'    => 1,
+            'type'       => 'main',
+        ],
+        [
+            'id'         => 1,
+            'label'      => 'postnl_flespakket_on_myparcel',
+            'carrier_id' => 1,
+            'carrier'    => [
+                'id'   => 1,
+                'name' => 'postnl',
+            ],
+            'enabled'    => 0,
+            'optional'   => 1,
+            'primary'    => 1,
+            'type'       => 'main',
+        ],
+    ]);
+
+    $firstShop = AccountSettings::getAccount()->shops->first();
+
+    $externalIdentifiers = $firstShop->carriers
+        ->pluck('externalIdentifier')
+        ->all();
+
+    // If multiple PostNL carriers are present, but no custom contract, only the first one should be kept.
+    expect($externalIdentifiers)->toBe(['postnl']);
 });

--- a/tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php
+++ b/tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php
@@ -233,6 +233,20 @@ it('maps carriers correctly with multiple non-contract postnl entries', function
             'primary'    => 1,
             'type'       => 'main',
         ],
+        // Add a dhl for you carrier to make sure it's not removed.
+        [
+            'id'          => 12424,
+            'carrier_id'  => 9,
+            'carrier'     => [
+                'id'   => 9,
+                'name' => 'dhlforyou',
+            ],
+            'enabled'     => 1,
+            'optional'    => 1,
+            'primary'     => 0,
+            'type'        => 'custom',
+            'contract_id' => 677,
+        ],
     ]);
 
     $firstShop = AccountSettings::getAccount()->shops->first();
@@ -242,5 +256,5 @@ it('maps carriers correctly with multiple non-contract postnl entries', function
         ->all();
 
     // If multiple PostNL carriers are present, but no custom contract, only the first one should be kept.
-    expect($externalIdentifiers)->toBe(['postnl']);
+    expect($externalIdentifiers)->toBe(['dhlforyou:12424', 'postnl']);
 });


### PR DESCRIPTION
- occurs when no custom postnl contract is present but there are still multiple enabled postnl carriers returned from the api
