### PR TITLE
build(phpstan): pin phpstan to v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "nette/robot-loader": ">= 3",
         "pestphp/pest": ">= 1",
         "phpdocumentor/reflection-docblock": "^5",
-        "phpstan/phpstan": ">= 1",
+        "phpstan/phpstan": "^1",
         "rector/rector": ">= 1",
         "spatie/pest-plugin-snapshots": ">= 1",
         "symfony/console": "*"


### PR DESCRIPTION
pin phpstan to v1 as v2 is not compatible with our repo yet. should fix failing checks in CI since PHPStan v2 release.

fixes INT-774