### PR TITLE
fix: correctly list php 7.4 as the minimum required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The MyParcel PDK (Plugin Development Kit) is meant for developing entire plugins
 
 ## Requirements
 
-- PHP >=7.1
+- PHP >=7.4
 - Composer
 
 ## Documentation

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-zip": "*",
         "justinrainbow/json-schema": "^5.2",
         "myparcelnl/sdk": ">= 7",
-        "php": ">=7.1.0",
+        "php": ">=7.4.0",
         "php-di/php-di": ">= 6",
         "psr/log": "^1 || ^2 || ^3",
         "symfony/http-foundation": ">= 2 || >= 3 || >= 4 || >= 5"


### PR DESCRIPTION
Correctly lists php 7.4 as the minimum required version in the composer.json and README. This is not a breaking change because several dependencies already refused to install on PHP < 7.4 with the current version contraints and we have no test coverage for PHP < 7.4. This commit simply fixes the root-level version contraints to match.