### PR TITLE
fix(language): return fallback translations even if language argument is specifically provided, and language is not supported

### DIFF
--- a/src/Language/Contract/LanguageServiceInterface.php
+++ b/src/Language/Contract/LanguageServiceInterface.php
@@ -16,6 +16,13 @@ interface LanguageServiceInterface
     public function getIso2(?string $language = null): string;
 
     /**
+     * Given an ISO-639-1 language code, returns the language code back if supported or a fallback language if not.
+     * @param string $isoCode
+     * @return string
+     */
+    public function getLanguageWithFallback(string $isoCode): string;
+
+    /**
      * Returns the IETF language tag of the current language.
      *
      * @example en-US

--- a/src/Language/Service/AbstractLanguageService.php
+++ b/src/Language/Service/AbstractLanguageService.php
@@ -40,7 +40,7 @@ abstract class AbstractLanguageService implements LanguageServiceInterface
     abstract protected function getFilePath(?string $language = null): string;
 
     /**
-     * @param  null|string $language
+     * @param  null|string $language The language code in IETF format (eg. en, en-US)
      *
      * @return string
      */
@@ -50,9 +50,19 @@ abstract class AbstractLanguageService implements LanguageServiceInterface
             return $this->getIsoFromIetf($language);
         }
 
-        $iso = $this->getIsoFromIetf($this->getLanguage());
+        return $this->getLanguageWithFallback(
+            $this->getIsoFromIetf($this->getLanguage())
+        );
 
-        return in_array($iso, Pdk::get('availableLanguages'), true) ? $iso : Pdk::get('defaultLanguage');
+    }
+
+    /**
+     * @param string $isoCode
+     * @return string
+     */
+    public function getLanguageWithFallback(string $isoCode): string
+    {
+        return in_array($isoCode, Pdk::get('availableLanguages'), true) ? $isoCode : Pdk::get('defaultLanguage');
     }
 
     /**
@@ -60,10 +70,10 @@ abstract class AbstractLanguageService implements LanguageServiceInterface
      */
     public function getTranslations(?string $language = null): array
     {
-        $iso2 = $this->getIso2($language);
+        $lang = $this->getLanguageWithFallback($this->getIso2($language));
 
-        return $this->repository->getTranslations($iso2, function () use ($iso2) {
-            return json_decode($this->fileSystem->get($this->getFilePath($iso2)), true);
+        return $this->repository->getTranslations($lang, function () use ($lang) {
+            return json_decode($this->fileSystem->get($this->getFilePath($lang)), true);
         });
     }
 

--- a/tests/Bootstrap/MockLanguageService.php
+++ b/tests/Bootstrap/MockLanguageService.php
@@ -44,6 +44,15 @@ class MockLanguageService implements LanguageServiceInterface, ResetInterface
     }
 
     /**
+     * @param string $isoCode
+     * @return string
+     */
+    public function getLanguageWithFallback(string $isoCode): string
+    {
+        return $isoCode;
+    }
+
+    /**
      * @return string
      */
     public function getLanguage(): string

--- a/tests/Unit/Language/Service/AbstractLanguageServiceTest.php
+++ b/tests/Unit/Language/Service/AbstractLanguageServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection PhpUndefinedMethodInspection,PhpUnhandledExceptionInspection,StaticClosureCanBeUsedInspection */
 
 declare(strict_types=1);
@@ -10,6 +11,7 @@ use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Language\Contract\LanguageServiceInterface;
 use MyParcelNL\Pdk\Tests\Bootstrap\MockAbstractLanguageService;
 use MyParcelNL\Pdk\Tests\Uses\UsesEachMockPdkInstance;
+
 use function DI\get;
 use function MyParcelNL\Pdk\Tests\usesShared;
 
@@ -33,6 +35,12 @@ it('gets current language', function () {
 it('loads translations from file', function (?string $language) {
     expect(Language::getTranslations($language))->toBeArray();
 })->with('languages');
+
+
+it('loads fallback translations from file if language is not supported', function () {
+    expect(Language::getTranslations('tr-TR'))->toBeArray(['send_help' => 'Send help']);
+});
+
 
 it('translates strings in current language', function (?string $language, string $translation) {
     if ($language) {


### PR DESCRIPTION
fixes INT-875, [#1252](https://github.com/myparcelnl/woocommerce/issues/1252)