### PR TITLE
fix: update order status on webhook

### DIFF
--- a/src/App/Action/Backend/Order/UpdateOrderStatusAction.php
+++ b/src/App/Action/Backend/Order/UpdateOrderStatusAction.php
@@ -36,6 +36,8 @@ class UpdateOrderStatusAction extends AbstractOrderAction
      * @param  \Symfony\Component\HttpFoundation\Request $request
      *
      * @return \Symfony\Component\HttpFoundation\Response
+     *                                                   
+     * @todo INT-944 this allows an array of orderIds in the request, but the action only works with one orderId
      */
     public function handle(Request $request): Response
     {

--- a/src/App/Action/Backend/Shipment/UpdateShipmentsAction.php
+++ b/src/App/Action/Backend/Shipment/UpdateShipmentsAction.php
@@ -116,13 +116,12 @@ class UpdateShipmentsAction extends AbstractOrderAction
 
     private function updateOrderStatus(ShipmentCollection $shipments): void
     {
-        $orderIds = $shipments->map(function($s) { return $s->orderId; });
-
-        if (count($orderIds)) {
-            Actions::execute(PdkBackendActions::UPDATE_ORDER_STATUS, [
-                'orderIds' => $orderIds,
-                'setting'  => OrderSettings::STATUS_ON_LABEL_CREATE,
-            ]);
-        }
+        $shipments
+            ->each(function (Shipment $shipment) {
+                Actions::execute(PdkBackendActions::UPDATE_ORDER_STATUS, [
+                    'orderIds' => [$shipment->orderId],
+                    'setting'  => OrderSettings::STATUS_ON_LABEL_CREATE,
+                ]);
+            });
     }
 }

--- a/src/App/Action/Backend/Shipment/UpdateShipmentsAction.php
+++ b/src/App/Action/Backend/Shipment/UpdateShipmentsAction.php
@@ -116,12 +116,13 @@ class UpdateShipmentsAction extends AbstractOrderAction
 
     private function updateOrderStatus(ShipmentCollection $shipments): void
     {
-        $shipments
-            ->each(function (Shipment $shipment) {
-                Actions::execute(PdkBackendActions::UPDATE_ORDER_STATUS, [
-                    'orderIds' => [$shipment->orderId],
-                    'setting'  => OrderSettings::STATUS_ON_LABEL_CREATE,
-                ]);
-            });
+        $orderIds = $shipments->map(function($s) { return $s->orderId; });
+
+        if (count($orderIds)) {
+            Actions::execute(PdkBackendActions::UPDATE_ORDER_STATUS, [
+                'orderIds' => $orderIds,
+                'setting'  => OrderSettings::STATUS_ON_LABEL_CREATE,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
INT-885

Since the shipment status change webhook is used for label creation from the backoffice, and the barcode is put in the order notes at that point, which is working solidly, we can safely update the order status there as well.