### PR TITLE
feat(address): add pdk settings for the address widget

### DIFF
--- a/config/pdk-fields.php
+++ b/config/pdk-fields.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use MyParcelNL\Pdk\Base\Service\CountryCodes;
 use MyParcelNL\Pdk\Facade\Pdk as PdkFacade;
+
 use function DI\factory;
 use function DI\value;
 
@@ -14,7 +15,6 @@ return [
     /**
      * Default fields
      */
-
     'fieldAddress1'   => value('address_1'),
     'fieldAddress2'   => value('address_2'),
     'fieldCity'       => value('city'),
@@ -30,7 +30,6 @@ return [
     /**
      * Custom fields for separate address fields.
      */
-
     'fieldNumber'       => value('number'),
     'fieldNumberSuffix' => value('number_suffix'),
     'fieldStreet'       => value('street'),
@@ -38,7 +37,6 @@ return [
     /**
      * Custom fields for tax fields
      */
-
     'fieldEoriNumber' => value('eori_number'),
     'fieldVatNumber'  => value('vat_number'),
 
@@ -57,6 +55,19 @@ return [
     ]),
 
     'separateAddressFields' => value([
+        'fieldNumber',
+        'fieldNumberSuffix',
+        'fieldStreet',
+    ]),
+
+    // Replacable fields for the address widget
+    'addressFields' => value([
+        'fieldAddress1',
+        'fieldAddress2',
+        'fieldCity',
+        // 'fieldCountry', currently disabled - address widget is NL-only and country selection is not happening within it.
+        'fieldPostalCode',
+        'fieldState',
         'fieldNumber',
         'fieldNumberSuffix',
         'fieldStreet',
@@ -89,7 +100,6 @@ return [
     /**
      * Carriers that need tax fields.
      */
-
     'carriersWithTaxFields' => value([
         'dhleuroplus',
     ]),
@@ -97,7 +107,6 @@ return [
     /**
      * Countries that support separate address fields.
      */
-
     'countriesWithSeparateAddressFields' => value([
         CountryCodes::CC_NL,
         CountryCodes::CC_BE,
@@ -105,9 +114,16 @@ return [
 
     /**
      * The name of the hidden input in the checkout where delivery options are stored.
+     * TODO: Rename to "deliveryOptionsHiddenInputName" in the next major.
      */
-
     'checkoutHiddenInputName' => factory(function () {
         return sprintf('%s_checkout_data', PdkFacade::getAppInfo()->name);
+    }),
+
+    /**
+     * The name of the hidden input in the checkout where address data is stored.
+     */
+    'checkoutAddressHiddenInputName' => factory(function () {
+        return sprintf('%s_checkout_address', PdkFacade::getAppInfo()->name);
     }),
 ];

--- a/src/Context/Model/CheckoutContext.php
+++ b/src/Context/Model/CheckoutContext.php
@@ -23,7 +23,7 @@ use MyParcelNL\Sdk\src\Support\Str;
  */
 class CheckoutContext extends Model
 {
-    public    $attributes = [
+    public $attributes = [
         'config'    => null,
         'strings'   => [],
         'settings'  => [],
@@ -93,6 +93,7 @@ class CheckoutContext extends Model
                 CheckoutSettings::ID
             ),
             'hiddenInputName'                    => Pdk::get('checkoutHiddenInputName'),
+            'checkoutAddressHiddenInputName'     => Pdk::get('checkoutAddressHiddenInputName'),
 
             /** Separate address fields */
             'countriesWithSeparateAddressFields' => Pdk::get('countriesWithSeparateAddressFields'),

--- a/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_delivery_options_config__1.json
+++ b/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_delivery_options_config__1.json
@@ -34,6 +34,7 @@
       "allowedShippingMethods": [],
       "hasDeliveryOptions": true,
       "hiddenInputName": "pest_checkout_data",
+      "checkoutAddressHiddenInputName": "pest_checkout_address",
       "countriesWithSeparateAddressFields": ["NL", "BE"],
       "carriersWithTaxFields": []
     },

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_delivery_options__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_delivery_options__1.json
@@ -46,6 +46,7 @@
       "allowedShippingMethods": [],
       "hasDeliveryOptions": true,
       "hiddenInputName": "pest_checkout_data",
+      "checkoutAddressHiddenInputName": "pest_checkout_address",
       "countriesWithSeparateAddressFields": ["NL", "BE"],
       "carriersWithTaxFields": []
     },


### PR DESCRIPTION
adds settings to the PDK checkout context to support functionality for the address widget vue package