### PR TITLE
fix(settings): remove save address option when unavailable

### DIFF
--- a/src/Frontend/View/OrderSettingsView.php
+++ b/src/Frontend/View/OrderSettingsView.php
@@ -50,7 +50,7 @@ final class OrderSettingsView extends NewAbstractSettingsView
                 ->withOptions($orderStatusOptions, $orderStatusOptionsFlags),
 
             new ToggleInput(OrderSettings::SEND_RETURN_EMAIL),
-            new ToggleInput(OrderSettings::SAVE_CUSTOMER_ADDRESS),
+            (new ToggleInput(OrderSettings::SAVE_CUSTOMER_ADDRESS))->visibleWhen(OrderSettings::ORDER_MODE, false),
             new ToggleInput(OrderSettings::SHARE_CUSTOMER_INFORMATION),
 
             new SettingsDivider($this->label('status')),

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_plugin_settings__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_plugin_settings__1.json
@@ -87,6 +87,18 @@
         },
         {
           "name": "saveCustomerAddress",
+          "$builders": [
+            {
+              "$visibleWhen": {
+                "$if": [
+                  {
+                    "$target": "orderMode",
+                    "$eq": false
+                  }
+                ]
+              }
+            }
+          ],
           "$component": "ToggleInput",
           "label": "settings_order_save_customer_address",
           "description": "settings_order_save_customer_address_description"

--- a/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_order_settings__1.json
+++ b/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_order_settings__1.json
@@ -85,6 +85,18 @@
     },
     {
       "name": "saveCustomerAddress",
+      "$builders": [
+        {
+          "$visibleWhen": {
+            "$if": [
+              {
+                "$target": "orderMode",
+                "$eq": false
+              }
+            ]
+          }
+        }
+      ],
       "$component": "ToggleInput",
       "label": "settings_order_save_customer_address",
       "description": "settings_order_save_customer_address_description"


### PR DESCRIPTION
Saving the client address in the backoffice address book is not possible in order modus. The toggle being still present confused users obviously. Removed the toggle when the option is not available.

Reference: https://developer.myparcel.nl/api-reference/14.order-object-definitions.html

INT-902