### PR TITLE
fix: fix unreachable settings page when order status is NULL

### DIFF
--- a/src/Frontend/Form/Element/Concern/HasOptions.php
+++ b/src/Frontend/Form/Element/Concern/HasOptions.php
@@ -89,9 +89,12 @@ trait HasOptions
     {
         $associativeArray = Arr::isAssoc($array) ? $array : array_combine($array, $array);
 
-        $options = array_map(function (string $key, $value) use ($flags) {
+        $options = array_map(function (?string $key, $value) use ($flags) {
             $usePlainLabel = $flags & ElementBuilderWithOptionsInterface::USE_PLAIN_LABEL;
             $labelKey      = $usePlainLabel ? 'plainLabel' : 'label';
+
+            // Cast key to string to prevent issues with non-string array keys
+            $key = (string) $key;
 
             return [
                 $labelKey => $usePlainLabel ? $key : $this->createOptionLabel($key),


### PR DESCRIPTION
Fix crash when order status key is null due to incomplete creation in PrestaShop.

Some plugins using the PDK crashed because array_keys() returned null as a key, which caused a type error in the callback expecting a string.

This commit allows the key to be nullable and safely casts it to a string.

INT-973
