### PR TITLE
feat: add pickup locations display configuration

### DIFF
--- a/config/platform/belgie.php
+++ b/config/platform/belgie.php
@@ -19,6 +19,7 @@ return [
     'defaultSettings' => [
         CheckoutSettings::ID => [
             CheckoutSettings::PICKUP_LOCATIONS_DEFAULT_VIEW => CheckoutSettings::PICKUP_LOCATIONS_VIEW_MAP,
+            CheckoutSettings::PICKUP_LOCATIONS_STYLE        => CheckoutSettings::PICKUP_LOCATIONS_STYLE_DEFAULT,
         ],
     ],
 

--- a/config/platform/myparcel.php
+++ b/config/platform/myparcel.php
@@ -20,6 +20,7 @@ return [
     'defaultSettings' => [
         CheckoutSettings::ID => [
             CheckoutSettings::PICKUP_LOCATIONS_DEFAULT_VIEW => CheckoutSettings::PICKUP_LOCATIONS_VIEW_LIST,
+            CheckoutSettings::PICKUP_LOCATIONS_STYLE        => CheckoutSettings::PICKUP_LOCATIONS_STYLE_DEFAULT,
         ],
     ],
 

--- a/src/Context/Model/DeliveryOptionsConfig.php
+++ b/src/Context/Model/DeliveryOptionsConfig.php
@@ -22,6 +22,7 @@ use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
  * @property string $locale
  * @property string $packageType
  * @property string $pickupLocationsDefaultView
+ * @property string $pickupLocationsStyle
  * @property string $platform
  * @property int    $priceStandardDelivery
  * @property bool   $showPriceSurcharge
@@ -36,6 +37,7 @@ class DeliveryOptionsConfig extends Model
         'locale'                     => null,
         'packageType'                => DeliveryOptions::DEFAULT_PACKAGE_TYPE_NAME,
         'pickupLocationsDefaultView' => null,
+        'pickupLocationsStyle'       => null,
         'platform'                   => null,
         'priceStandardDelivery'      => 0,
         'showPriceSurcharge'         => false,
@@ -49,6 +51,7 @@ class DeliveryOptionsConfig extends Model
         'locale'                     => 'string',
         'packageType'                => 'string',
         'pickupLocationsDefaultView' => 'string',
+        'pickupLocationsStyle'       => 'string',
         'platform'                   => 'string',
         'priceStandardDelivery'      => 'float',
         'showPriceSurcharge'         => 'boolean',
@@ -68,6 +71,10 @@ class DeliveryOptionsConfig extends Model
         $this->showPriceSurcharge         = CheckoutSettings::PRICE_TYPE_EXCLUDED === $priceType;
         $this->pickupLocationsDefaultView = Settings::get(
             CheckoutSettings::PICKUP_LOCATIONS_DEFAULT_VIEW,
+            CheckoutSettings::ID
+        );
+        $this->pickupLocationsStyle       = Settings::get(
+            CheckoutSettings::PICKUP_LOCATIONS_STYLE,
             CheckoutSettings::ID
         );
 

--- a/src/Frontend/View/CheckoutSettingsView.php
+++ b/src/Frontend/View/CheckoutSettingsView.php
@@ -78,17 +78,37 @@ class CheckoutSettingsView extends AbstractSettingsView
                 new InteractiveElement(CheckoutSettings::DELIVERY_OPTIONS_HEADER, Components::INPUT_TEXT),
                 new InteractiveElement(CheckoutSettings::DELIVERY_OPTIONS_CUSTOM_CSS, Components::INPUT_CODE_EDITOR),
                 new InteractiveElement(
-                    CheckoutSettings::PICKUP_LOCATIONS_DEFAULT_VIEW,
+                    CheckoutSettings::PICKUP_LOCATIONS_STYLE,
                     Components::INPUT_SELECT,
                     [
                         'options' => $this->createSelectOptions(
-                            CheckoutSettings::PICKUP_LOCATIONS_DEFAULT_VIEW,
+                            CheckoutSettings::PICKUP_LOCATIONS_STYLE,
                             [
-                                CheckoutSettings::PICKUP_LOCATIONS_VIEW_LIST,
-                                CheckoutSettings::PICKUP_LOCATIONS_VIEW_MAP,
+                                CheckoutSettings::PICKUP_LOCATIONS_STYLE_DEFAULT,
+                                CheckoutSettings::PICKUP_LOCATIONS_STYLE_MAP,
+                                CheckoutSettings::PICKUP_LOCATIONS_STYLE_LIST,
                             ]
                         ),
+                        'helpText' => $this->getSettingKey('pickup_locations_style_help'),
                     ]
+                ),
+                $this->withOperation(
+                    function (FormOperationBuilder $builder) {
+                        $builder->visibleWhen(CheckoutSettings::PICKUP_LOCATIONS_STYLE, CheckoutSettings::PICKUP_LOCATIONS_STYLE_DEFAULT);
+                    },
+                    new InteractiveElement(
+                        CheckoutSettings::PICKUP_LOCATIONS_DEFAULT_VIEW,
+                        Components::INPUT_SELECT,
+                        [
+                            'options' => $this->createSelectOptions(
+                                CheckoutSettings::PICKUP_LOCATIONS_DEFAULT_VIEW,
+                                [
+                                    CheckoutSettings::PICKUP_LOCATIONS_VIEW_LIST,
+                                    CheckoutSettings::PICKUP_LOCATIONS_VIEW_MAP,
+                                ]
+                            ),
+                        ]
+                    )
                 ),
                 new InteractiveElement(CheckoutSettings::SHOW_TAX_FIELDS, Components::INPUT_TOGGLE)
             ),

--- a/src/Settings/Model/CheckoutSettings.php
+++ b/src/Settings/Model/CheckoutSettings.php
@@ -12,6 +12,7 @@ use MyParcelNL\Pdk\Base\Support\Collection;
  * @property string                                  $deliveryOptionsHeader
  * @property string                                  $deliveryOptionsPosition
  * @property string                                  $pickupLocationsDefaultView
+ * @property string                                  $pickupLocationsStyle
  * @property string                                  $priceType
  * @property bool                                    $showDeliveryDay
  * @property bool                                    $useSeparateAddressFields
@@ -31,6 +32,7 @@ class CheckoutSettings extends AbstractSettingsModel
     public const DELIVERY_OPTIONS_HEADER                   = 'deliveryOptionsHeader';
     public const DELIVERY_OPTIONS_POSITION                 = 'deliveryOptionsPosition';
     public const PICKUP_LOCATIONS_DEFAULT_VIEW             = 'pickupLocationsDefaultView';
+    public const PICKUP_LOCATIONS_STYLE                    = 'pickupLocationsStyle';
     public const PRICE_TYPE                                = 'priceType';
     public const ENABLE_DELIVERY_OPTIONS                   = 'enableDeliveryOptions';
     public const ENABLE_DELIVERY_OPTIONS_WHEN_NOT_IN_STOCK = 'enableDeliveryOptionsWhenNotInStock';
@@ -38,6 +40,10 @@ class CheckoutSettings extends AbstractSettingsModel
     /** Pickup location views */
     public const PICKUP_LOCATIONS_VIEW_LIST = 'list';
     public const PICKUP_LOCATIONS_VIEW_MAP  = 'map';
+    /** Pickup location styles */
+    public const PICKUP_LOCATIONS_STYLE_DEFAULT = 'default';
+    public const PICKUP_LOCATIONS_STYLE_MAP     = 'map';
+    public const PICKUP_LOCATIONS_STYLE_LIST    = 'list';
     /** Price types */
     public const DEFAULT_PRICE_TYPE  = self::PRICE_TYPE_INCLUDED;
     public const PRICE_TYPE_EXCLUDED = 'excluded';
@@ -54,6 +60,7 @@ class CheckoutSettings extends AbstractSettingsModel
         self::DELIVERY_OPTIONS_HEADER                   => null,
         self::DELIVERY_OPTIONS_POSITION                 => null,
         self::PICKUP_LOCATIONS_DEFAULT_VIEW             => null,
+        self::PICKUP_LOCATIONS_STYLE                    => self::PICKUP_LOCATIONS_STYLE_DEFAULT,
         self::PRICE_TYPE                                => self::DEFAULT_PRICE_TYPE,
         self::ENABLE_DELIVERY_OPTIONS                   => true,
         self::ENABLE_DELIVERY_OPTIONS_WHEN_NOT_IN_STOCK => true,
@@ -68,6 +75,7 @@ class CheckoutSettings extends AbstractSettingsModel
         self::DELIVERY_OPTIONS_HEADER                   => 'string',
         self::DELIVERY_OPTIONS_POSITION                 => 'string',
         self::PICKUP_LOCATIONS_DEFAULT_VIEW             => 'string',
+        self::PICKUP_LOCATIONS_STYLE                    => 'string',
         self::PRICE_TYPE                                => 'string',
         self::ENABLE_DELIVERY_OPTIONS                   => 'bool',
         self::ENABLE_DELIVERY_OPTIONS_WHEN_NOT_IN_STOCK => 'bool',

--- a/tests/Unit/App/Context/Model/DeliveryOptionsConfigTest.php
+++ b/tests/Unit/App/Context/Model/DeliveryOptionsConfigTest.php
@@ -33,6 +33,10 @@ it('can be instantiated', function () {
         CheckoutSettings::PICKUP_LOCATIONS_DEFAULT_VIEW,
         CheckoutSettings::ID
     );
+    $pickupLocationsStyle = Settings::get(
+        CheckoutSettings::PICKUP_LOCATIONS_STYLE,
+        CheckoutSettings::ID
+    );
 
     expect($config)
         ->toBeInstanceOf(DeliveryOptionsConfig::class)
@@ -46,6 +50,7 @@ it('can be instantiated', function () {
             'locale'                     => 'nl-NL',
             'packageType'                => 'package',
             'pickupLocationsDefaultView' => $pickupLocationsDefaultView,
+            'pickupLocationsStyle'       => $pickupLocationsStyle,
             'platform'                   => 'myparcel',
             'showPriceSurcharge'         => false,
             'priceStandardDelivery'      => 0,


### PR DESCRIPTION
Add PickupLocationsStyle configuration option to control how pickup locations are displayed in delivery options. Supports Default, Map, and List display modes.

Closes #INT-1103