### PR TITLE
fix: print more than one label on first a4 in bulk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,9 @@ name: 'Publish new version 🚀'
 on:
   workflow_dispatch:
 
-  schedule:
-    # every day at 16:00
-    - cron: '0 16 * * *'
+#  schedule:
+#    # every day at 16:00
+#    - cron: '0 16 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,9 @@ name: 'Publish new version 🚀'
 on:
   workflow_dispatch:
 
-#  schedule:
-#    # every day at 16:00
-#    - cron: '0 16 * * *'
+  schedule:
+    # every day at 16:00
+    - cron: '0 16 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/src/App/Action/Backend/Shipment/PrintShipmentsAction.php
+++ b/src/App/Action/Backend/Shipment/PrintShipmentsAction.php
@@ -9,7 +9,6 @@ use MyParcelNL\Pdk\Api\Response\JsonResponse;
 use MyParcelNL\Pdk\App\Action\Backend\Order\AbstractOrderAction;
 use MyParcelNL\Pdk\App\Api\Backend\PdkBackendActions;
 use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
-use MyParcelNL\Pdk\Base\Support\Utils;
 use MyParcelNL\Pdk\Facade\Actions;
 use MyParcelNL\Pdk\Facade\Settings;
 use MyParcelNL\Pdk\Settings\Model\LabelSettings;
@@ -45,9 +44,11 @@ class PrintShipmentsAction extends AbstractOrderAction
     {
         $format    = strtoupper($this->getLabelOption($request, LabelSettings::FORMAT, LabelSettings::DEFAULT_FORMAT));
         $output    = $this->getLabelOption($request, LabelSettings::OUTPUT, LabelSettings::DEFAULT_OUTPUT);
-        $positions = Utils::toArray(
-            $this->getLabelOption($request, LabelSettings::POSITION, LabelSettings::DEFAULT_POSITION)
-        );
+        // todo INT-768, until the frontend bulk export works we ignore the request for now
+//        $positions = Utils::toArray(
+//            $this->getLabelOption($request, LabelSettings::POSITION, LabelSettings::DEFAULT_POSITION)
+//        );
+        $positions = Settings::get(LabelSettings::POSITION, LabelSettings::ID, LabelSettings::DEFAULT_POSITION);
 
         $orderIds    = $this->getOrderIds($request);
         $orders      = $this->pdkOrderRepository->getMany($orderIds);

--- a/src/App/Action/Backend/Shipment/PrintShipmentsAction.php
+++ b/src/App/Action/Backend/Shipment/PrintShipmentsAction.php
@@ -9,6 +9,7 @@ use MyParcelNL\Pdk\Api\Response\JsonResponse;
 use MyParcelNL\Pdk\App\Action\Backend\Order\AbstractOrderAction;
 use MyParcelNL\Pdk\App\Api\Backend\PdkBackendActions;
 use MyParcelNL\Pdk\App\Order\Contract\PdkOrderRepositoryInterface;
+use MyParcelNL\Pdk\Base\Support\Utils;
 use MyParcelNL\Pdk\Facade\Actions;
 use MyParcelNL\Pdk\Facade\Settings;
 use MyParcelNL\Pdk\Settings\Model\LabelSettings;
@@ -44,11 +45,13 @@ class PrintShipmentsAction extends AbstractOrderAction
     {
         $format    = strtoupper($this->getLabelOption($request, LabelSettings::FORMAT, LabelSettings::DEFAULT_FORMAT));
         $output    = $this->getLabelOption($request, LabelSettings::OUTPUT, LabelSettings::DEFAULT_OUTPUT);
-        // todo INT-768, until the frontend bulk export works we ignore the request for now
-//        $positions = Utils::toArray(
-//            $this->getLabelOption($request, LabelSettings::POSITION, LabelSettings::DEFAULT_POSITION)
-//        );
-        $positions = Settings::get(LabelSettings::POSITION, LabelSettings::ID, LabelSettings::DEFAULT_POSITION);
+        $positions = Utils::toArray(
+            $this->getLabelOption($request, LabelSettings::POSITION, LabelSettings::DEFAULT_POSITION)
+        );
+        // todo INT-768, until the frontend bulk export works we fix the info we got from the request
+        if (1 === count($positions) && is_string($positions[0])) {
+            $positions = explode(',', $positions[0]);
+        }
 
         $orderIds    = $this->getOrderIds($request);
         $orders      = $this->pdkOrderRepository->getMany($orderIds);

--- a/tests/Unit/App/Order/Calculator/General/LabelDescriptionCalculatorTest.php
+++ b/tests/Unit/App/Order/Calculator/General/LabelDescriptionCalculatorTest.php
@@ -27,7 +27,7 @@ function createOrder($labelDescription): PdkOrder
     return factory(PdkOrder::class)
         ->withReferenceIdentifier('123')
         ->withDeliveryOptions([
-            'date'            => new DateTimeImmutable('2025-09-27'),
+            'date'            => new DateTimeImmutable('2070-09-27'),
             'shipmentOptions' => ['labelDescription' => $labelDescription],
         ])
         ->withLines([
@@ -102,7 +102,7 @@ it('formats label description from order', function ($labelDescription, $output)
         ],
         'label description DELIVERY_DATE'         => [
             'input'  => 'DELIVERY_DATE: [DELIVERY_DATE]',
-            'output' => 'DELIVERY_DATE: 2025-09-27',
+            'output' => 'DELIVERY_DATE: 2070-09-27',
         ],
         'multiple label description placeholders' => [
             'input'  => '[CUSTOMER_NOTE] | [ORDER_ID] | [PRODUCT_ID] | [PRODUCT_NAME] | [PRODUCT_SKU] | [PRODUCT_EAN] | [PRODUCT_QTY]',


### PR DESCRIPTION
INT-1155

This PR also updates the labeldescriptiontest to a date far in the future, to have it keep working (dates in the past are not displayed).