### PR TITLE
feat(api): add SDK API infrastructure for generated API clients

### DIFF
--- a/src/Api/Service/AbstractApiService.php
+++ b/src/Api/Service/AbstractApiService.php
@@ -10,6 +10,7 @@ use MyParcelNL\Pdk\Api\Contract\ClientAdapterInterface;
 use MyParcelNL\Pdk\Api\Exception\ApiException;
 use MyParcelNL\Pdk\Api\Request\RequestInterface;
 use MyParcelNL\Pdk\Api\Response\ApiResponse;
+use MyParcelNL\Pdk\Base\Support\SensitiveDataScrubber;
 use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\Facade\Pdk;
 use RuntimeException;
@@ -74,10 +75,11 @@ abstract class AbstractApiService implements ApiServiceInterface
         /** @var \MyParcelNL\Pdk\Api\Contract\ApiResponseInterface $responseObject */
         $responseObject = new $responseClass($response);
         $body           = $responseObject->getBody();
+        $jsonBody       = is_string($body) ? json_decode($body, true) : null;
 
         $logContext['response'] = [
             'code' => $responseObject->getStatusCode(),
-            'body' => $body ? json_decode($body, true) : null,
+            'body' => !empty($jsonBody) ? SensitiveDataScrubber::scrubArray($jsonBody) : null,
         ];
 
         if ($responseObject->isErrorResponse()) {
@@ -105,13 +107,13 @@ abstract class AbstractApiService implements ApiServiceInterface
         try {
             $settingsRepository = Pdk::get(\MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface::class);
             $accountSettings = $settingsRepository->all()->account;
-            
+
             Logger::info('AbstractApiService - getBaseUrl environment check', [
                 'hasAccountSettings' => $accountSettings ? 'yes' : 'no',
                 'environment' => $accountSettings ? $accountSettings->environment : 'null',
                 'isAcceptance' => $accountSettings && $accountSettings->environment === \MyParcelNL\Pdk\Base\Config::ENVIRONMENT_ACCEPTANCE ? 'yes' : 'no'
             ]);
-            
+
             if ($accountSettings && $accountSettings->environment === \MyParcelNL\Pdk\Base\Config::ENVIRONMENT_ACCEPTANCE) {
                 Logger::info('AbstractApiService - Using acceptance API URL');
                 return \MyParcelNL\Pdk\Base\Config::API_URL_ACCEPTANCE;
@@ -174,21 +176,13 @@ abstract class AbstractApiService implements ApiServiceInterface
      */
     private function createLogContext(string $uri, string $method, array $options): array
     {
-        $headers = array_combine(array_map('strtolower', array_keys($options['headers'])), $options['headers']);
-
-        // Obfuscate sensitive headers
-        foreach (['authorization', 'x-api-key', 'api-key'] as $sensitiveHeader) {
-            if (isset($headers[$sensitiveHeader])) {
-                $headers[$sensitiveHeader] = '***';
-            }
-        }
-
+        $jsonBody = !empty($options['body']) ? json_decode($options['body'], true) : null;
         return [
             'request' => [
                 'uri'     => $uri,
                 'method'  => $method,
-                'headers' => $headers,
-                'body'    => $options['body'] ? json_decode($options['body'], true) : null,
+                'headers' => SensitiveDataScrubber::scrubHeaders($options['headers']),
+                'body'    => !empty($jsonBody) ? SensitiveDataScrubber::scrubArray($jsonBody) : null,
             ],
         ];
     }

--- a/src/Api/Service/MyParcelApiService.php
+++ b/src/Api/Service/MyParcelApiService.php
@@ -9,7 +9,9 @@ use MyParcelNL\Pdk\Facade\Settings;
 use MyParcelNL\Pdk\Settings\Model\AccountSettings;
 
 /**
- * This will replace the SDK one day...
+ * Service for making API calls to the MyParcel API.
+ *
+ * @deprecated use the generated SDK instead. Use specific services from the SdkApi namespace, such as those in the MyParcelNL\Pdk\SdkApi\Service\CoreApi namespace.
  */
 class MyParcelApiService extends AbstractApiService
 {

--- a/src/Base/Model/SdkBackedModel.php
+++ b/src/Base/Model/SdkBackedModel.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Base\Model;
+
+use MyParcelNL\Pdk\Base\Contract\Arrayable;
+use MyParcelNL\Pdk\Base\Support\SdkModelHelper;
+use MyParcelNL\Pdk\Base\Support\Utils;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ModelInterface;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\ObjectSerializer;
+
+/**
+ * Base class for PDK Models that are backed by a single SDK generated ModelInterface instance.
+ *
+ * SDK generated models (e.g. from OpenAPI codegen) implement ModelInterface and use a different internal structure
+ * ($container, static getters/setters/attributeMap) than PDK Models ($attributes, HasAttributes trait). This class
+ * bridges the two systems so all SDK model properties are accessible directly on the PDK model.
+ *
+ * Usage:
+ * 1. Extend this class instead of Model.
+ * 2. Declare `protected $sdkModelClass = SomeSdkModel::class;` pointing to the ModelInterface implementation.
+ *    This is the only requirement — the SDK model is discovered and initialised automatically.
+ * 3. Optionally declare native `$attributes` and `$casts` for PDK-only properties on top. Native PDK attributes always take precedence over SDK model properties.
+ */
+abstract class SdkBackedModel extends Model
+{
+    /**
+     * The SDK ModelInterface class this model is backed by.
+     * Subclasses must override this.
+     *
+     * @var string|null
+     */
+    protected $sdkModelClass = null;
+
+    /**
+     * The SDK model instance backing this model.
+     * Lazily initialised on the first write to an SDK property.
+     *
+     * @var object|null
+     */
+    private $sdkModel = null;
+
+    /**
+     * Getter map cached per class: ['camelCaseKey' => 'getterMethodName', ...]
+     *
+     * @var array<string, array<string, string>>
+     */
+    private static $sdkGetterMapCache = [];
+
+    /**
+     * Setter map cached per class: ['camelCaseKey' => 'setterMethodName', ...]
+     *
+     * @var array<string, array<string, string>>
+     */
+    private static $sdkSetterMapCache = [];
+
+    /**
+     * Return the underlying SDK model instance, or null if not yet initialised.
+     *
+     * @return object|null
+     */
+    public function getSdkModel(): ?object
+    {
+        return $this->sdkModel;
+    }
+
+    /**
+     * Pass non-native keys through setAttribute before handing native data to parent.
+     * All routing logic lives in setAttribute — this just ensures fill() sees SDK keys too.
+     *
+     * @param  array|null $data
+     */
+    public function __construct(?array $data = null)
+    {
+        if ($this->sdkModelClass !== null && $data !== null) {
+            $nativeKeys    = array_flip(array_keys($this->attributes));
+            $nonNativeData = array_diff_key($data, $nativeKeys);
+
+            foreach ($nonNativeData as $key => $value) {
+                $this->setAttribute($key, $value);
+            }
+
+            $data = array_intersect_key($data, $nativeKeys);
+        }
+
+        parent::__construct($data);
+    }
+
+    /**
+     * Override getAttribute to proxy unknown keys to the SDK model.
+     * Native PDK attributes take priority.
+     *
+     * @param  string $key
+     *
+     * @return mixed
+     */
+    public function getAttribute(string $key)
+    {
+        $key = Utils::changeCase($key);
+
+        $nativeValue = parent::getAttribute($key);
+
+        if (null !== $nativeValue || array_key_exists($key, $this->attributes)) {
+            return $nativeValue;
+        }
+
+        if ($this->sdkModel !== null) {
+            $getterMap = $this->getSdkGetterMap();
+
+            if (isset($getterMap[$key])) {
+                return $this->sdkModel->{$getterMap[$key]}();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Override setAttribute as the single routing point for all incoming data.
+     *
+     * Routing order:
+     * 1. Native PDK key  → parent::setAttribute
+     * 2. Direct SDK model instance → stored as the backing model
+     * 3. Known SDK setter key → lazy-init backing model if needed, then proxy to its setter
+     * 4. Anything else → parent::setAttribute (dynamic attribute)
+     *
+     * Because Model::fill() calls setAttribute() for every key in $data, no constructor
+     * override is needed — all routing happens here automatically.
+     *
+     * @param  string $key
+     * @param  mixed  $value
+     *
+     * @return self
+     */
+    public function setAttribute(string $key, $value): self
+    {
+        $key = Utils::changeCase($key);
+
+        if (array_key_exists($key, $this->attributes) || $this->isGuarded($key)) {
+            parent::setAttribute($key, $value);
+            return $this;
+        }
+
+        if ($this->sdkModelClass !== null && $value instanceof $this->sdkModelClass) {
+            $this->sdkModel = $value;
+
+            return $this;
+        }
+
+        if ($this->sdkModelClass !== null) {
+            $setterMap = $this->getSdkSetterMap();
+
+            if (isset($setterMap[$key])) {
+                if ($this->sdkModel === null) {
+                    $this->sdkModel = new $this->sdkModelClass();
+                }
+
+                $snakeKey     = SdkModelHelper::toSdkCase($key);
+                $openApiTypes = $this->sdkModelClass::openAPITypes();
+                $type         = $openApiTypes[$snakeKey] ?? null;
+
+                if ($type !== null && ! $this->isAlreadyHydrated($value, $type)) {
+                    $value = ObjectSerializer::deserialize($value, $type);
+                }
+
+                $this->sdkModel->{$setterMap[$key]}($value);
+
+                return $this;
+            }
+        }
+
+        parent::setAttribute($key, $value);
+        return $this;
+    }
+
+    /**
+     * Override attributesToArray to merge SDK model properties at root level.
+     * PDK native attributes take priority over SDK properties.
+     *
+     * @param  null|int $flags
+     *
+     * @return array
+     */
+    public function attributesToArray(?int $flags = null): array
+    {
+        $pdkAttributes = parent::attributesToArray($flags);
+
+        if ($this->sdkModel === null) {
+            return $pdkAttributes;
+        }
+
+        $sdkData = SdkModelHelper::toArray($this->sdkModel);
+
+        if ($flags & Arrayable::CASE_SNAKE || $flags & Arrayable::CASE_KEBAB || $flags & Arrayable::CASE_STUDLY) {
+            $sdkData = Utils::changeArrayKeysCase($sdkData, $flags);
+        }
+
+        return array_merge($sdkData, $pdkAttributes);
+    }
+
+    /**
+     * Get the getter map for $sdkModelClass, building and caching it on first access.
+     * Uses the class name directly — no instance required.
+     *
+     * @return array<string, string>
+     */
+    private function getSdkGetterMap(): array
+    {
+        if ($this->sdkModelClass === null) {
+            return [];
+        }
+
+        if (! isset(self::$sdkGetterMapCache[$this->sdkModelClass])) {
+            self::$sdkGetterMapCache[$this->sdkModelClass] = SdkModelHelper::buildGetterMap($this->sdkModelClass);
+        }
+
+        return self::$sdkGetterMapCache[$this->sdkModelClass];
+    }
+
+    /**
+     * Get the setter map for $sdkModelClass, building and caching it on first access.
+     * Uses the class name directly — no instance required.
+     *
+     * @return array<string, string>
+     */
+    private function getSdkSetterMap(): array
+    {
+        if ($this->sdkModelClass === null) {
+            return [];
+        }
+
+        if (! isset(self::$sdkSetterMapCache[$this->sdkModelClass])) {
+            self::$sdkSetterMapCache[$this->sdkModelClass] = SdkModelHelper::buildSetterMap($this->sdkModelClass);
+        }
+
+        return self::$sdkSetterMapCache[$this->sdkModelClass];
+    }
+
+    /**
+     * Returns true when $value is already a hydrated SDK model (or array of models) that should be passed
+     * through to the setter as-is. Passing already-hydrated ModelInterface instances to ObjectSerializer::deserialize
+     * would break them because the serializer accesses dynamic public properties, which SDK models don't expose.
+     *
+     * @param  mixed  $value
+     * @param  string $type  openAPI type string, e.g. '\Ns\SomeModel' or '\Ns\SomeModel[]'
+     *
+     * @return bool
+     */
+    private function isAlreadyHydrated($value, string $type): bool
+    {
+        // openAPI array types are suffixed with '[]', e.g. '\Ns\SomeModel[]'
+        if (strcasecmp(substr($type, -2), '[]') === 0) {
+            return is_array($value) && ! empty($value) && reset($value) instanceof ModelInterface;
+        }
+
+        return $value instanceof ModelInterface;
+    }
+}

--- a/src/Base/Model/SdkBackedModel.php
+++ b/src/Base/Model/SdkBackedModel.php
@@ -99,10 +99,8 @@ abstract class SdkBackedModel extends Model
     {
         $key = Utils::changeCase($key);
 
-        $nativeValue = parent::getAttribute($key);
-
-        if (null !== $nativeValue || array_key_exists($key, $this->attributes)) {
-            return $nativeValue;
+        if (array_key_exists($key, $this->attributes)) {
+            return parent::getAttribute($key);
         }
 
         if ($this->sdkModel !== null) {
@@ -156,9 +154,8 @@ abstract class SdkBackedModel extends Model
                     $this->sdkModel = new $this->sdkModelClass();
                 }
 
-                $snakeKey     = SdkModelHelper::toSdkCase($key);
                 $openApiTypes = $this->sdkModelClass::openAPITypes();
-                $type         = $openApiTypes[$snakeKey] ?? null;
+                $type         = $openApiTypes[SdkModelHelper::toOpenApiKey($key)] ?? null;
 
                 if ($type !== null && ! $this->isAlreadyHydrated($value, $type)) {
                     $value = ObjectSerializer::deserialize($value, $type);
@@ -250,7 +247,7 @@ abstract class SdkBackedModel extends Model
     private function isAlreadyHydrated($value, string $type): bool
     {
         // openAPI array types are suffixed with '[]', e.g. '\Ns\SomeModel[]'
-        if (strcasecmp(substr($type, -2), '[]') === 0) {
+        if ('[]' === substr($type, -2)) {
             return is_array($value) && ! empty($value) && reset($value) instanceof ModelInterface;
         }
 

--- a/src/Base/Support/SdkModelHelper.php
+++ b/src/Base/Support/SdkModelHelper.php
@@ -26,13 +26,13 @@ class SdkModelHelper
     }
 
     /**
-     * Convert a camelCase PDK attribute name to snake_case SDK property name.
+     * Convert a camelCase PDK attribute name to the key format used by SDK openAPITypes().
      *
      * @param  string $camelCaseKey
      *
      * @return string
      */
-    public static function toSdkCase(string $camelCaseKey): string
+    public static function toOpenApiKey(string $camelCaseKey): string
     {
         return Utils::changeCase($camelCaseKey, Arrayable::CASE_SNAKE);
     }

--- a/src/Base/Support/SdkModelHelper.php
+++ b/src/Base/Support/SdkModelHelper.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Base\Support;
+
+use MyParcelNL\Pdk\Base\Contract\Arrayable;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ModelInterface;
+
+/**
+ * Utility for interacting with auto-generated SDK model classes that implement the OpenAPI ModelInterface pattern.
+ * These models use a $container array with snake_case keys, and expose static getters()/setters()/attributeMap() methods.
+ */
+class SdkModelHelper
+{
+    /**
+     * Convert a snake_case SDK property name to camelCase PDK attribute name.
+     *
+     * @param  string $snakeCaseKey
+     *
+     * @return string
+     */
+    public static function toPdkCase(string $snakeCaseKey): string
+    {
+        return Utils::changeCase($snakeCaseKey);
+    }
+
+    /**
+     * Convert a camelCase PDK attribute name to snake_case SDK property name.
+     *
+     * @param  string $camelCaseKey
+     *
+     * @return string
+     */
+    public static function toSdkCase(string $camelCaseKey): string
+    {
+        return Utils::changeCase($camelCaseKey, Arrayable::CASE_SNAKE);
+    }
+
+    /**
+     * Build a map of camelCase PDK key => getter method name for an SDK model.
+     *
+     * @param  object|string $classOrInstance
+     *
+     * @return array<string, string> ['packageTypes' => 'getPackageTypes', ...]
+     */
+    public static function buildGetterMap($classOrInstance): array
+    {
+        $class   = is_object($classOrInstance) ? get_class($classOrInstance) : $classOrInstance;
+        $getters = $class::getters();
+        $map     = [];
+
+        foreach ($getters as $snakeKey => $getterMethod) {
+            $camelKey       = self::toPdkCase($snakeKey);
+            $map[$camelKey] = $getterMethod;
+        }
+
+        return $map;
+    }
+
+    /**
+     * Build a map of camelCase PDK key => setter method name for an SDK model.
+     *
+     * @param  object|string $classOrInstance
+     *
+     * @return array<string, string> ['packageTypes' => 'setPackageTypes', ...]
+     */
+    public static function buildSetterMap($classOrInstance): array
+    {
+        $class   = is_object($classOrInstance) ? get_class($classOrInstance) : $classOrInstance;
+        $setters = $class::setters();
+        $map     = [];
+
+        foreach ($setters as $snakeKey => $setterMethod) {
+            $camelKey       = self::toPdkCase($snakeKey);
+            $map[$camelKey] = $setterMethod;
+        }
+
+        return $map;
+    }
+
+    /**
+     * Serialize an SDK model instance to an associative array with camelCase keys.
+     *
+     * @param  object $sdkModel
+     *
+     * @return array
+     */
+    public static function toArray(object $sdkModel): array
+    {
+        $getterMap = self::buildGetterMap($sdkModel);
+        $result    = [];
+
+        foreach ($getterMap as $camelKey => $getterMethod) {
+            $value = $sdkModel->{$getterMethod}();
+
+            if (null !== $value) {
+                $result[$camelKey] = self::serializeValue($value);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Recursively serialize a value from an SDK model.
+     *
+     * @param  mixed $value
+     *
+     * @return mixed
+     */
+    private static function serializeValue($value)
+    {
+        if (is_object($value) && $value instanceof ModelInterface) {
+            return self::toArray($value);
+        }
+
+        if (is_array($value)) {
+            return array_map([self::class, 'serializeValue'], $value);
+        }
+
+        if ($value instanceof \JsonSerializable) {
+            return $value->jsonSerialize();
+        }
+
+        return $value;
+    }
+}

--- a/src/Base/Support/SensitiveDataScrubber.php
+++ b/src/Base/Support/SensitiveDataScrubber.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Base\Support;
+
+final class SensitiveDataScrubber
+{
+    const MASK = '***';
+
+    /**
+     * Exact lowercase matches for HTTP header names.
+     */
+    private const SENSITIVE_HEADERS = ['authorization', 'x-api-key', 'api-key'];
+
+    /**
+     * Substring patterns (lowercase) matched against query param and body keys.
+     * Using stripos() / strpos() after strtolower() catches variants like
+     * access_token, refresh_token, api_key, etc.
+     */
+    private const SENSITIVE_KEY_PATTERNS = [
+        'token',
+        'jwt',
+        'password',
+        'secret',
+        'credential',
+        'api_key',
+        'api-key',
+        'apikey',
+        'address',
+        'street',
+        'email',
+        'phone',
+        'zip',
+        'postal',
+        'postal_code',
+        'zip_code',
+        'lat',
+        'lng',
+        'name',
+        'last_name',
+        'lastName',
+        'first_name',
+        'firstName',
+        'company',
+        'customer',
+        'client',
+        'user',
+        'account',
+        'bsn'
+    ];
+
+    /**
+     * Normalise header keys to lowercase and mask sensitive values.
+     *
+     * Handles both plain-string header values (Guzzle request options) and
+     * PSR-7 array-of-strings header values (RequestInterface / ResponseInterface).
+     *
+     * @param array $headers
+     *
+     * @return array
+     */
+    public static function scrubHeaders(array $headers): array
+    {
+        $result = [];
+
+        foreach ($headers as $key => $value) {
+            $lower = strtolower((string) $key);
+
+            if (in_array($lower, self::SENSITIVE_HEADERS, true)) {
+                $value = is_array($value) ? [self::MASK] : self::MASK;
+            }
+
+            $result[$lower] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Mask values of sensitive query parameters in a URI string.
+     *
+     * @param string $uri
+     *
+     * @return string
+     */
+    public static function scrubUri(string $uri): string
+    {
+        $parts = parse_url($uri);
+
+        if (empty($parts['query'])) {
+            return $uri;
+        }
+
+        parse_str($parts['query'], $params);
+
+        foreach ($params as $key => $value) {
+            if (self::isSensitiveKey((string) $key)) {
+                $params[$key] = self::MASK;
+            }
+        }
+
+        $queryParts = [];
+
+        foreach ($params as $key => $value) {
+            // Keep the mask readable in logs; other values are percent-encoded normally.
+            $encodedValue = ($value === self::MASK) ? self::MASK : rawurlencode((string) $value);
+            $queryParts[] = rawurlencode((string) $key) . '=' . $encodedValue;
+        }
+
+        $parts['query'] = implode('&', $queryParts);
+
+        return self::buildUrl($parts);
+    }
+
+    /**
+     * Recursively scrub sensitive keys from a decoded array (e.g. a JSON body).
+     *
+     * @param array $data
+     *
+     * @return array
+     */
+    public static function scrubArray(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                // Recurse into nested arrays, e.g. for JSON bodies with multiple levels of nesting.
+                $data[$key] = self::scrubArray($value);
+            } elseif (self::isSensitiveKey((string) $key)) {
+                $data[$key] = self::MASK;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    private static function isSensitiveKey(string $key): bool
+    {
+        $lower = strtolower($key);
+
+        foreach (self::SENSITIVE_KEY_PATTERNS as $pattern) {
+            // @TODO PHP 8.0+: replace strpos() !== false with str_contains()
+            if (strpos($lower, $pattern) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Reconstruct a URL from the array returned by parse_url().
+     *
+     * @param array $parts
+     *
+     * @return string
+     */
+    private static function buildUrl(array $parts): string
+    {
+        $url = '';
+
+        if (isset($parts['scheme'])) {
+            $url .= $parts['scheme'] . '://';
+        }
+
+        if (isset($parts['host'])) {
+            $url .= $parts['host'];
+        }
+
+        if (isset($parts['port'])) {
+            $url .= ':' . $parts['port'];
+        }
+
+        if (isset($parts['path'])) {
+            $url .= $parts['path'];
+        }
+
+        if (isset($parts['query'])) {
+            $url .= '?' . $parts['query'];
+        }
+
+        if (isset($parts['fragment'])) {
+            $url .= '#' . $parts['fragment'];
+        }
+
+        return $url;
+    }
+}

--- a/src/Base/Support/SensitiveDataScrubber.php
+++ b/src/Base/Support/SensitiveDataScrubber.php
@@ -15,8 +15,7 @@ final class SensitiveDataScrubber
 
     /**
      * Substring patterns (lowercase) matched against query param and body keys.
-     * Using stripos() / strpos() after strtolower() catches variants like
-     * access_token, refresh_token, api_key, etc.
+     * Partial matches are made, so 'name' will also match 'first_name', 'lastName', etc.
      */
     private const SENSITIVE_KEY_PATTERNS = [
         'token',
@@ -33,15 +32,9 @@ final class SensitiveDataScrubber
         'phone',
         'zip',
         'postal',
-        'postal_code',
-        'zip_code',
         'lat',
         'lng',
         'name',
-        'last_name',
-        'lastName',
-        'first_name',
-        'firstName',
         'company',
         'customer',
         'client',

--- a/src/SdkApi/Middleware/LoggingMiddleware.php
+++ b/src/SdkApi/Middleware/LoggingMiddleware.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Middleware;
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\PromiseInterface;
+use MyParcelNL\Pdk\Base\Support\SensitiveDataScrubber;
+use MyParcelNL\Pdk\Facade\Logger;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+/**
+ * Guzzle middleware for logging API requests and responses.
+ *
+ * Intercepts all HTTP traffic at the transport layer to provide:
+ * - Debug logging of outgoing requests (method + URI)
+ * - Debug logging of successful responses (status code + decoded body)
+ * - Error logging of failed requests (error message, code, response body/headers)
+ *
+ * **Usage:**
+ * ```php
+ * $stack = HandlerStack::create();
+ * $stack->push(LoggingMiddleware::forApiRequests());
+ * $client = new Client(['handler' => $stack]);
+ * ```
+ */
+class LoggingMiddleware
+{
+    /**
+     * Create a Guzzle middleware callable that logs requests and responses.
+     *
+     * Follows the Guzzle double-callable middleware convention:
+     * the outer callable receives the next handler, the inner callable
+     * receives the request and options and returns a promise.
+     *
+     * @return callable(callable): callable
+     */
+    public static function forApiRequests(): callable
+    {
+        return static function (callable $handler): callable {
+            return static function (RequestInterface $request, array $options) use ($handler): PromiseInterface {
+                Logger::debug('Sending API request', [
+                    'method' => $request->getMethod(),
+                    'uri'    => SensitiveDataScrubber::scrubUri((string) $request->getUri()),
+                ]);
+
+
+                return $handler($request, $options)->then(
+                    static function (ResponseInterface $response): ResponseInterface {
+                        $body    = (string) $response->getBody();
+                        $decoded = $body ? json_decode($body, true) : null;
+
+                        Logger::debug('Received API response', [
+                            'status' => $response->getStatusCode(),
+                            'body'   => is_array($decoded) ? SensitiveDataScrubber::scrubArray($decoded) : null,
+                        ]);
+
+                        // Rewind so the SDK can still read the body after logging.
+                        $response->getBody()->rewind();
+
+                        return $response;
+                    },
+                    static function (Throwable $e): void {
+                        $context = [
+                            'error' => $e->getMessage(),
+                            'code'  => $e->getCode(),
+                        ];
+
+                        if ($e instanceof RequestException && $e->getResponse()) {
+                            $body    = (string) $e->getResponse()->getBody();
+                            $decoded = $body ? json_decode($body, true) : null;
+
+                            $context['responseBody']    = is_array($decoded) ? SensitiveDataScrubber::scrubArray($decoded) : $decoded;
+                            $context['responseHeaders'] = SensitiveDataScrubber::scrubHeaders($e->getResponse()->getHeaders());
+                        }
+
+                        Logger::error('API request failed', $context);
+
+                        throw $e;
+                    }
+                );
+            };
+        };
+    }
+}

--- a/src/SdkApi/Service/AbstractSdkApiService.php
+++ b/src/SdkApi/Service/AbstractSdkApiService.php
@@ -35,15 +35,15 @@ use Throwable;
  * Extend this class in namespace-specific abstracts (e.g., AbstractCoreApiService), then create
  * concrete service classes for specific business domains (e.g., ContractDefinitionsService).
  *
- * @see \MyParcelNL\Pdk\SdkApi\Service\CoreApi\CoreApiService
- * @see \MyParcelNL\Pdk\SdkApi\Service\CoreApi\Capabilities\ContractDefinitionsService
+ * @see \MyParcelNL\Pdk\SdkApi\Service\CoreApi\AbstractCoreApiService
+ * @see \MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService
  */
 abstract class AbstractSdkApiService
 {
     /**
-     * @return mixed a generated Configuration clas appropiate to the API you're using
+     * @return mixed A generated Configuration class appropriate to the API you're using
      */
-    abstract function getApiConfig();
+    abstract public function getApiConfig();
 
     /**
      * Get the API key from account settings.

--- a/src/SdkApi/Service/AbstractSdkApiService.php
+++ b/src/SdkApi/Service/AbstractSdkApiService.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use MyParcelNL\Pdk\Base\Config;
+use MyParcelNL\Pdk\Facade\Logger;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Facade\Settings;
+use MyParcelNL\Pdk\SdkApi\Middleware\LoggingMiddleware;
+use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
+use MyParcelNL\Pdk\Settings\Model\AccountSettings;
+use Throwable;
+
+/**
+ * Abstract base class for all OpenAPI SDK services.
+ *
+ * This class provides common functionality for interacting with MyParcel APIs via the OpenAPI-generated
+ * SDK client classes. It handles authentication, environment detection, user agent construction,
+ * error handling, and logging.
+ *
+ * This is the replacement for the legacy {@see \MyParcelNL\Pdk\Api\Service\AbstractApiService} pattern,
+ * which used ClientAdapterInterface and custom Request/Response objects.
+ *
+ * **Responsibilities:**
+ * - API key retrieval from settings
+ * - User agent string construction (platform + PDK version + PHP version)
+ * - Environment detection (production vs acceptance)
+ * - Guzzle client factory with logging middleware
+ *
+ * **Usage:**
+ * Extend this class in namespace-specific abstracts (e.g., AbstractCoreApiService), then create
+ * concrete service classes for specific business domains (e.g., ContractDefinitionsService).
+ *
+ * @see \MyParcelNL\Pdk\SdkApi\Service\CoreApi\CoreApiService
+ * @see \MyParcelNL\Pdk\SdkApi\Service\CoreApi\Capabilities\ContractDefinitionsService
+ */
+abstract class AbstractSdkApiService
+{
+    /**
+     * @return mixed a generated Configuration clas appropiate to the API you're using
+     */
+    abstract function getApiConfig();
+
+    /**
+     * Get the API key from account settings.
+     *
+     * @return null|string The unformatted API key, or null if not set
+     */
+    protected function getApiKey(): ?string
+    {
+        return Settings::get(AccountSettings::API_KEY, AccountSettings::ID);
+    }
+
+    /**
+     * Build a user agent string for API requests.
+     *
+     * Constructs a string in the format "Platform/Version Platform/Version ...",
+     * e.g., "MyParcelNL-PDK/1.0.0 php/8.0.0"
+     *
+     * @return string The user agent string
+     */
+    protected function getUserAgent(): string
+    {
+        $userAgentStrings = [];
+        /**
+         * @var array|null $definedUserAgents
+         */
+        $definedUserAgents = Pdk::get('userAgent');
+        $userAgents       = array_merge(
+            $definedUserAgents ?? [],
+            [
+                'MyParcelNL-PDK' => Pdk::get('pdkVersion'),
+                'php'            => PHP_VERSION,
+            ]
+        );
+
+        foreach ($userAgents as $platform => $version) {
+            $userAgentStrings[] = sprintf('%s/%s', $platform, $version);
+        }
+
+        return implode(' ', $userAgentStrings);
+    }
+
+    /**
+     * Check if the acceptance environment is active.
+     *
+     * Reads the environment setting from the settings repository. If set to acceptance,
+     * API services should use the acceptance API URL instead of production.
+     *
+     * @return bool True if acceptance environment is active, false otherwise
+     */
+    protected function isAcceptanceEnvironment(): bool
+    {
+        // Check if we're in acceptance mode via database
+        try {
+            /** @var PdkSettingsRepositoryInterface $settingsRepository */
+            $settingsRepository = Pdk::get(PdkSettingsRepositoryInterface::class);
+            $accountSettings = $settingsRepository->all()->account;
+
+            if ($accountSettings->environment === Config::ENVIRONMENT_ACCEPTANCE) {
+                Logger::debug('Using acceptance API URL');
+                return true;
+            }
+        } catch (Throwable $e) {
+            Logger::error('Error checking environment, assuming production', [
+                'error' => $e->getMessage()
+            ]);
+        }
+
+        return false;
+    }
+
+    /**
+     * Create a HandlerStack with middleware.
+     *
+     * This method can be overridden in child classes to add custom middleware
+     * to the Guzzle client handler stack. By default, it includes logging middleware.
+     *
+     * **Example override:**
+     * ```php
+     * protected function createGuzzleClientHandlerStack(): HandlerStack
+     * {
+     *     $stack = parent::createGuzzleClientHandlerStack();
+     *     $stack->push($myCustomMiddleware);
+     *     return $stack;
+     * }
+     * ```
+     *
+     * @return HandlerStack The configured handler stack
+     */
+    protected function createGuzzleClientHandlerStack(): HandlerStack
+    {
+        $stack = HandlerStack::create();
+        $stack->push(LoggingMiddleware::forApiRequests());
+
+        return $stack;
+    }
+
+    /**
+     * Create a Guzzle HTTP client pre-configured with middleware.
+     *
+     * All API classes that accept a `?ClientInterface` as their first constructor
+     * argument should receive the client produced here so that every request and
+     * response is automatically logged at the transport layer.
+     *
+     * Uses {@see createGuzzleClientHandlerStack()} to build the middleware stack, which can
+     * be overridden in child classes to add custom middleware.
+     *
+     * @return Client
+     */
+    protected function createGuzzleClient(): Client
+    {
+        return new Client(['handler' => $this->createGuzzleClientHandlerStack()]);
+    }
+}

--- a/src/SdkApi/Service/CoreApi/AbstractCoreApiService.php
+++ b/src/SdkApi/Service/CoreApi/AbstractCoreApiService.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service\CoreApi;
+
+use MyParcelNL\Pdk\Base\Config;
+use MyParcelNL\Pdk\SdkApi\Service\AbstractSdkApiService;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Configuration as CoreApiConfiguration;
+
+/**
+ * Abstract base class for CoreAPI-specific services.
+ *
+ * This class extends the generic SDK service base with CoreAPI-specific configuration,
+ * providing a ready-to-use Configuration object for OpenAPI CoreAPI client classes.
+ *
+ * The CoreAPI namespace contains endpoints for:
+ * - Shipments (create, retrieve, update, labels)
+ * - Capabilities (contract definitions, delivery options)
+ * - Notifications
+ * - Track & trace
+ *
+ * **Usage:**
+ * Extend this class to create services for specific business domains within the CoreAPI.
+ * Use {@see getApiConfig()} in your constructor when instantiating OpenAPI API classes.
+ *
+ * **Example:**
+ * ```php
+ * class ContractDefinitionsService extends AbstractCoreApiService
+ * {
+ *     protected ShipmentApi $shipmentApi;
+ *
+ *     public function __construct()
+ *     {
+ *         $this->shipmentApi = new ShipmentApi(null, $this->getApiConfig());
+ *     }
+ *
+ *     public function getContractDefinitions(string $carrier): array
+ *     {
+ *         return $this->executeOperationWithErrorHandling(
+ *             fn() => $this->shipmentApi->postCapabilitiesContractDefinitions(...),
+ *             'postContractDefinitions'
+ *         );
+ *     }
+ * }
+ * ```
+ *
+ * @see \MyParcelNL\Pdk\SdkApi\Service\AbstractSdkApiService
+ * @see \MyParcelNL\Sdk\Client\Generated\CoreApi\Configuration
+ */
+abstract class AbstractCoreApiService extends AbstractSdkApiService
+{
+    /**
+     * Get a configured CoreAPI configuration object.
+     *
+     * Builds a Configuration instance with:
+     * - Access token (base64-encoded API key)
+     * - User agent string (platform + PDK + PHP versions)
+     * - Host URL (conditional on environment: production or acceptance)
+     *
+     * @return CoreApiConfiguration The configured API configuration
+     */
+    public function getApiConfig(): CoreApiConfiguration
+    {
+        $config = new CoreApiConfiguration();
+        $apiKey = $this->getApiKey();
+        $config->setAccessToken($apiKey ? base64_encode($apiKey) : '');
+        $config->setUserAgent($this->getUserAgent());
+
+        // Set an alternate host for acceptance testing if the environment is set to acceptance,
+        // otherwise use the default host from the generated OpenAPI client.
+        if ($this->isAcceptanceEnvironment()) {
+            $config->setHost(Config::API_URL_ACCEPTANCE);
+        }
+
+        return $config;
+    }
+}

--- a/src/SdkApi/Service/CoreApi/Shipment/AbstractShipmentApiService.php
+++ b/src/SdkApi/Service/CoreApi/Shipment/AbstractShipmentApiService.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment;
+
+use MyParcelNL\Pdk\SdkApi\Service\CoreApi\AbstractCoreApiService;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
+
+/**
+ * Abstract base class for services using the ShipmentApi.
+ *
+ * This intermediate layer provides a shared ShipmentApi instance for all services
+ * that interact with shipment-related endpoints in the CoreAPI. The ShipmentApi class
+ * contains multiple endpoint groups including:
+ * - Capabilities (contract definitions, delivery options)
+ * - Shipments (create, retrieve, update, delete)
+ * - Labels (generate, retrieve)
+ * - Track & trace
+ *
+ * By centralizing the ShipmentApi instantiation here, we avoid duplication across
+ * multiple service classes that use the same API class.
+ *
+ * **Usage:**
+ * Extend this class for services that need to interact with ShipmentApi endpoints.
+ * Access the API instance via the protected `$shipmentApi` property.
+ *
+ * **Example:**
+ * ```php
+ * class ContractDefinitionsService extends AbstractShipmentApiService
+ * {
+ *     public function getContractDefinitions(string $carrier): array
+ *     {
+ *         return $this->executeOperationWithErrorHandling(
+ *             fn() => $this->shipmentApi->postCapabilitiesContractDefinitions(...),
+ *             'postContractDefinitions'
+ *         );
+ *     }
+ * }
+ * ```
+ *
+ * @see \MyParcelNL\Pdk\SdkApi\Service\CoreApi\AbstractCoreApiService
+ * @see \MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi
+ */
+abstract class AbstractShipmentApiService extends AbstractCoreApiService
+{
+    /**
+     * The ShipmentApi instance for making API calls.
+     *
+     * @var ShipmentApi
+     */
+    protected $shipmentApi;
+
+    /**
+     * Initialize the service with a configured ShipmentApi instance.
+     */
+    public function __construct()
+    {
+        $this->shipmentApi = new ShipmentApi($this->createGuzzleClient(), $this->getApiConfig());
+    }
+}

--- a/src/SdkApi/Service/CoreApi/Shipment/CapabilitiesService.php
+++ b/src/SdkApi/Service/CoreApi/Shipment/CapabilitiesService.php
@@ -28,7 +28,7 @@ use Psr\Http\Message\RequestInterface;
  * $capabilities = $service->getCapabilities([
  *     'carrier' => 'POSTNL',
  *     'recipient' => ['cc' => 'NL', 'postal_code' => '2132WT'],
- *     'package_type' => 'package',
+ *     'package_type' => 'PACKAGE',
  * ]);
  *
  * // Get contract definitions for a carrier

--- a/src/SdkApi/Service/CoreApi/Shipment/CapabilitiesService.php
+++ b/src/SdkApi/Service/CoreApi/Shipment/CapabilitiesService.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment;
+
+use GuzzleHttp\HandlerStack;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesPostCapabilitiesRequestV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesPostContractDefinitionsRequestV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesResponsesCapabilitiesV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesResponseCapabilityV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Service for retrieving capabilities information from the CoreAPI.
+ *
+ * This service provides access to two main capabilities endpoints:
+ * - Shipment capabilities: Calculate available delivery options, package types, and shipment options
+ *   based on specific shipment parameters (sender, recipient, carrier, etc.)
+ * - Contract definitions: Retrieve contract-specific configuration and available options for carriers
+ *
+ * **Usage Examples:**
+ * ```php
+ * $service = new CapabilitiesService();
+ *
+ * // Get dynamic capabilities for a specific shipment
+ * $capabilities = $service->getCapabilities([
+ *     'carrier' => 'POSTNL',
+ *     'recipient' => ['cc' => 'NL', 'postal_code' => '2132WT'],
+ *     'package_type' => 'package',
+ * ]);
+ *
+ * // Get contract definitions for a carrier
+ * $definitions = $service->getContractDefinitions('POSTNL');
+ * ```
+ *
+ * @see \MyParcelNL\Pdk\SdkApi\Service\CoreApi\AbstractShipmentApiService
+ * @see \MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi::postCapabilities()
+ * @see \MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi::postCapabilitiesContractDefinitions()
+ */
+class CapabilitiesService extends AbstractShipmentApiService
+{
+    /**
+     * Create a HandlerStack with custom middleware for capabilities endpoints.
+     *
+     * Adds middleware that enforces the Accept header to 'application/json;charset=utf-8;version=2'
+     * for all capabilities endpoints, ensuring consistent API version responses.
+     *
+     * @return HandlerStack The configured handler stack
+     */
+    protected function createGuzzleClientHandlerStack(): HandlerStack
+    {
+        $stack = parent::createGuzzleClientHandlerStack();
+
+        // Add middleware to enforce version 2 Accept header for capabilities endpoints
+        $stack->push(function (callable $handler) {
+            return function (RequestInterface $request, array $options) use ($handler) {
+                $path = $request->getUri()->getPath();
+
+                // Apply to both capabilities endpoints
+                if (strpos($path, '/shipments/capabilities') !== false) {
+                    $request = $request->withHeader('Accept', 'application/json;charset=utf-8;version=2');
+                }
+
+                return $handler($request, $options);
+            };
+        });
+
+        return $stack;
+    }
+
+    /**
+     * Get shipment capabilities based on specific parameters.
+     *
+     * Calculates and returns available delivery options, shipment options, and capabilities
+     * based on shipment details like sender, recipient, carrier, package type, etc.
+     * This is useful for building checkout flows with dynamic delivery options.
+     *
+     * @param array $parameters Array of shipment parameters including:
+     *                          - carrier: string (required) - Carrier identifier
+     *                          - recipient: array - Recipient address details (cc, postal_code, etc.)
+     *                          - sender: array - Sender address details
+     *                          - package_type: string - Package type (package, mailbox, letter, etc.)
+     *                          - physical_properties: array - Weight, dimensions
+     *                          - options: array - Requested shipment options
+     *                          - delivery_type: string - Delivery type (standard, morning, evening)
+     *                          - direction: string - Direction (outbound, inbound)
+     *                          - pickup: array - Pickup location details
+     *
+     * @return RefCapabilitiesResponseCapabilityV2[] The capabilities response with available options
+     * @throws \MyParcelNL\Sdk\Client\Generated\CoreApi\ApiException On API errors
+     * @throws \InvalidArgumentException If required parameters are missing
+     */
+    public function getCapabilities(array $parameters): array
+    {
+        /** @var CapabilitiesResponsesCapabilitiesV2 $response */
+        $response = $this->shipmentApi->postCapabilities(
+            $this->getUserAgent(),
+            new CapabilitiesPostCapabilitiesRequestV2($parameters)
+        );
+
+        return $response->getResults();
+    }
+
+    /**
+     * Get contract definitions for carriers.
+     *
+     * Retrieves contract-specific configuration including available package types, shipment options,
+     * and capabilities for specific carriers based on the user's contracts. This provides static
+     * configuration data rather than dynamic calculations.
+     *
+     * @param string|null $carrier The carrier identifier (e.g., 'POSTNL', 'DPD', 'DHL_FOR_YOU') to get a
+     *                             specific carrier's contract definitions, or null to retrieve all.
+     *
+     * @return RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2[] An array of contract definitions per carrier.
+     * @throws \MyParcelNL\Sdk\Client\Generated\CoreApi\ApiException On API errors
+     */
+    public function getContractDefinitions(?string $carrier): array
+    {
+        // Set carrier explicitly as it otherwise does not validate via the constructor.
+        $request = new CapabilitiesPostContractDefinitionsRequestV2();
+        if ($carrier) {
+            $request->setCarrier($carrier);
+        }
+
+        $response = $this->shipmentApi->postCapabilitiesContractDefinitions(
+            $this->getUserAgent(),
+            $request
+        );
+
+        return $response->getItems();
+    }
+}

--- a/tests/Mocks/MockSdkInheritingModel.php
+++ b/tests/Mocks/MockSdkInheritingModel.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Tests\Mocks;
+
+use MyParcelNL\Pdk\Base\Model\SdkBackedModel;
+
+/**
+ * A PDK Model that extends SdkBackedModel backed by a MockSdkModel instance.
+ *
+ * @property string|null $title      Native PDK attribute
+ * @property string|null $name       Native PDK attribute (overlaps with SDK model's 'name' property, PDK wins)
+ * @property string|null $firstName  Inherited from SDK model
+ * @property string|null $lastName   Inherited from SDK model
+ * @property int|null    $age        Inherited from SDK model
+ */
+class MockSdkInheritingModel extends SdkBackedModel
+{
+    protected $sdkModelClass = MockSdkModel::class;
+
+    protected $attributes = [
+        'title' => null,
+        'name'  => null,
+    ];
+
+    protected $casts = [
+        'title' => 'string',
+        'name'  => 'string',
+    ];
+}

--- a/tests/Mocks/MockSdkModel.php
+++ b/tests/Mocks/MockSdkModel.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Tests\Mocks;
+
+use ArrayAccess;
+use JsonSerializable;
+
+/**
+ * A mock that mimics the structure of OpenAPI-generated SDK models.
+ * Uses $container, static getters()/setters()/attributeMap() methods.
+ */
+class MockSdkModel implements ArrayAccess, JsonSerializable
+{
+    protected static $attributeMap = [
+        'first_name' => 'firstName',
+        'last_name'  => 'lastName',
+        'age'        => 'age',
+        'name'       => 'name',
+    ];
+
+    protected static $getters = [
+        'first_name' => 'getFirstName',
+        'last_name'  => 'getLastName',
+        'age'        => 'getAge',
+        'name'       => 'getName',
+    ];
+
+    protected static $setters = [
+        'first_name' => 'setFirstName',
+        'last_name'  => 'setLastName',
+        'age'        => 'setAge',
+        'name'       => 'setName',
+    ];
+
+    protected $container = [];
+
+    /**
+     * @param  null|array $data
+     */
+    public function __construct(?array $data = null)
+    {
+        $this->container['first_name'] = $data['first_name'] ?? null;
+        $this->container['last_name']  = $data['last_name'] ?? null;
+        $this->container['age']        = $data['age'] ?? null;
+        $this->container['name']       = $data['name'] ?? null;
+    }
+
+    public static function attributeMap(): array
+    {
+        return self::$attributeMap;
+    }
+
+    public static function getters(): array
+    {
+        return self::$getters;
+    }
+
+    public static function setters(): array
+    {
+        return self::$setters;
+    }
+
+    public static function openAPITypes(): array
+    {
+        return [];
+    }
+
+    public function getFirstName(): ?string
+    {
+        return $this->container['first_name'] ?? null;
+    }
+
+    public function setFirstName(?string $firstName): self
+    {
+        $this->container['first_name'] = $firstName;
+
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->container['last_name'] ?? null;
+    }
+
+    public function setLastName(?string $lastName): self
+    {
+        $this->container['last_name'] = $lastName;
+
+        return $this;
+    }
+
+    public function getAge(): ?int
+    {
+        return $this->container['age'] ?? null;
+    }
+
+    public function setAge(?int $age): self
+    {
+        $this->container['age'] = $age;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->container['name'] ?? null;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->container['name'] = $name;
+
+        return $this;
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->container[$offset]);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        return $this->container[$offset] ?? null;
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        $this->container[$offset] = $value;
+    }
+
+    public function offsetUnset($offset): void
+    {
+        unset($this->container[$offset]);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return $this->container;
+    }
+}

--- a/tests/SdkApi/MockSdkApiHandler.php
+++ b/tests/SdkApi/MockSdkApiHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Tests\SdkApi;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Centrally managed GuzzleHttp MockHandler for all SdkApi service mocks.
+ *
+ * Tests enqueue GuzzleHttp\Psr7\Response instances (or SdkJsonResponse subclasses)
+ * before executing code that triggers SdkApi calls:
+ *
+ *   MockSdkApiHandler::enqueue(new ExampleContractDefinitionsResponse());
+ *
+ * UsesSdkApiMock resets the handler before and after each test so unconsumed
+ * responses never bleed across tests.
+ */
+final class MockSdkApiHandler
+{
+    /**
+     * @var null|\GuzzleHttp\Handler\MockHandler
+     */
+    private static $handler = null;
+
+    /**
+     * Append one or more responses to the queue.
+     *
+     * @param  \GuzzleHttp\Psr7\Response ...$responses
+     *
+     * @return void
+     */
+    public static function enqueue(Response ...$responses): void
+    {
+        self::getHandler()->append(...$responses);
+    }
+
+    /**
+     * Clear the handler's response queue in-place.
+     * Called by UsesSdkApiMock before and after each test.
+     *
+     * Must clear the existing instance rather than replacing it, because
+     * MockCapabilitiesService captures the handler reference at construction
+     * time (via HandlerStack). Replacing the static would leave the Client
+     * pointing at a stale, empty handler.
+     *
+     * @return void
+     */
+    public static function reset(): void
+    {
+        self::getHandler()->reset();
+    }
+
+    /**
+     * Return the shared MockHandler, lazily initialising it on first access.
+     *
+     * @return \GuzzleHttp\Handler\MockHandler
+     */
+    public static function getHandler(): MockHandler
+    {
+        if (null === self::$handler) {
+            self::$handler = new MockHandler();
+        }
+
+        return self::$handler;
+    }
+}

--- a/tests/SdkApi/Response/ExampleContractDefinitionsResponse.php
+++ b/tests/SdkApi/Response/ExampleContractDefinitionsResponse.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Tests\SdkApi\Response;
+
+/**
+ * Mock response for CapabilitiesService::getContractDefinitions().
+ *
+ * Body shape: CapabilitiesResponsesContractDefinitionsV2 → {"items": [...]}
+ * Each item is a RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2.
+ *
+ * Field names use the JSON attribute names from the openapi spec
+ * (RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2::$attributeMap):
+ *   carrier           → 'carrier'
+ *   package_types     → 'packageTypes'
+ *   delivery_types    → 'deliveryTypes'
+ *   options           → 'options'
+ *   transaction_types → 'transactionTypes'
+ *   collo             → 'collo'
+ *
+ * Carrier names are values from CapabilitiesPostContractDefinitionsRequestV2::getCarrierAllowableValues().
+ * Package type strings are values from RefShipmentPackageTypeV2::getAllowableEnumValues().
+ * Delivery type strings are values from RefTypesDeliveryTypeV2::getAllowableEnumValues().
+ *
+ * Pass a custom $items array to the constructor to override defaults for a specific test:
+ *   new ExampleContractDefinitionsResponse([['carrier' => 'POSTNL', ...]]);
+ *
+ * @see \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesResponsesContractDefinitionsV2
+ * @see \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2
+ * @see \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesPostContractDefinitionsRequestV2
+ */
+class ExampleContractDefinitionsResponse extends SdkJsonResponse
+{
+    /**
+     * @return array
+     */
+    protected function getContent(): array
+    {
+        return [
+            'items' => $this->responseContent ?? $this->getDefaultItems(),
+        ];
+    }
+
+    /**
+     * Minimal realistic contract definitions for the carriers available via
+     * CapabilitiesPostContractDefinitionsRequestV2::getCarrierAllowableValues().
+     *
+     * Note: These are just theoretical examples for testing purposes, not necessarily the actual real-world values.
+     *
+     * @return array[]
+     */
+    protected function getDefaultItems(): array
+    {
+        return [
+            [
+                'carrier'          => 'POSTNL',
+                'packageTypes'     => ['PACKAGE', 'MAILBOX', 'UNFRANKED', 'DIGITAL_STAMP', 'SMALL_PACKAGE'],
+                'deliveryTypes'    => ['STANDARD_DELIVERY', 'MORNING_DELIVERY', 'EVENING_DELIVERY', 'PICKUP_DELIVERY'],
+                'transactionTypes' => ['B2C', 'B2B'],
+                'options'          => [
+                    'requiresAgeVerification'      => ['isSelectedByDefault' => false, 'isRequired' => false],
+                    'insurance'                    => [
+                        'isSelectedByDefault' => false,
+                        'isRequired'          => false,
+                        'insuredAmount'       => [
+                            'default' => ['amount' => 0,      'currency' => 'EUR'],
+                            'max'     => ['amount' => 500000, 'currency' => 'EUR'],
+                            'min'     => ['amount' => 0,      'currency' => 'EUR'],
+                        ],
+                    ],
+                    'oversizedPackage'             => ['isSelectedByDefault' => false, 'isRequired' => false],
+                    'recipientOnlyDelivery'        => ['isSelectedByDefault' => false, 'isRequired' => false],
+                    'printReturnLabelAtDropOff'    => ['isSelectedByDefault' => false, 'isRequired' => false],
+                    'priorityDelivery'             => ['isSelectedByDefault' => false, 'isRequired' => false],
+                    'requiresReceiptCode'          => ['isSelectedByDefault' => false, 'isRequired' => false],
+                    'returnOnFirstFailedDelivery'  => ['isSelectedByDefault' => false, 'isRequired' => false],
+                    'requiresSignature'            => ['isSelectedByDefault' => false, 'isRequired' => false],
+                    'noTracking'                   => ['isSelectedByDefault' => false, 'isRequired' => false],
+                    'tracked'                      => ['isSelectedByDefault' => false, 'isRequired' => false], // Tracked is deprecated but may still be included in the response
+                ],
+                'collo'            => ['max' => 10],
+            ],
+            [
+                'carrier'          => 'DHL_FOR_YOU',
+                'packageTypes'     => ['PACKAGE'],
+                'deliveryTypes'    => ['STANDARD_DELIVERY', 'PICKUP_DELIVERY'],
+                'options'          => null,
+                'transactionTypes' => null,
+                'collo'            => null,
+            ],
+            [
+                'carrier'          => 'DHL_PARCEL_CONNECT',
+                'packageTypes'     => ['PACKAGE'],
+                'deliveryTypes'    => ['STANDARD_DELIVERY'],
+                'options'          => null,
+                'transactionTypes' => null,
+                'collo'            => null,
+            ],
+            [
+                'carrier'          => 'DHL_EUROPLUS',
+                'packageTypes'     => ['PACKAGE'],
+                'deliveryTypes'    => ['STANDARD_DELIVERY'],
+                'options'          => null,
+                'transactionTypes' => null,
+                'collo'            => null,
+            ],
+            [
+                'carrier'          => 'DPD',
+                'packageTypes'     => ['PACKAGE'],
+                'deliveryTypes'    => ['STANDARD_DELIVERY'],
+                'options'          => null,
+                'transactionTypes' => null,
+                'collo'            => null,
+            ],
+            [
+                'carrier'          => 'BRT',
+                'packageTypes'     => ['PACKAGE'],
+                'deliveryTypes'    => ['STANDARD_DELIVERY'],
+                'options'          => null,
+                'transactionTypes' => null,
+                'collo'            => null,
+            ],
+            [
+                'carrier'          => 'INPOST',
+                'packageTypes'     => ['PACKAGE'],
+                'deliveryTypes'    => ['STANDARD_DELIVERY', 'PICKUP_DELIVERY'],
+                'options'          => null,
+                'transactionTypes' => null,
+                'collo'            => null,
+            ],
+        ];
+    }
+}

--- a/tests/SdkApi/Response/SdkJsonResponse.php
+++ b/tests/SdkApi/Response/SdkJsonResponse.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Tests\SdkApi\Response;
+
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+/**
+ * Base class for mocked responses returned to openapi-generator SDK clients.
+ *
+ * Unlike ExampleJsonResponse (legacy API), SDK client responses are plain JSON
+ * with no 'data.{property}' envelope — the response body is the direct JSON
+ * object the API returns and the ObjectSerializer deserialises.
+ *
+ * Subclasses implement getContent() to return the endpoint-specific payload.
+ */
+abstract class SdkJsonResponse extends Response
+{
+    /**
+     * @var null|array
+     */
+    protected $responseContent;
+
+    /**
+     * @param  null|array  $responseContent  Override the default response body
+     * @param  int         $status
+     * @param  array       $headers
+     * @param  null        $body
+     * @param  string      $version
+     * @param  string|null $reason
+     */
+    public function __construct(
+        ?array $responseContent = null,
+        int    $status = 200,
+        array  $headers = [],
+        $body = null,
+        string $version = '1.1',
+        string $reason = null
+    ) {
+        parent::__construct($status, $headers, $body, $version, $reason);
+        $this->responseContent = $responseContent;
+    }
+
+    /**
+     * @return \Psr\Http\Message\StreamInterface
+     */
+    public function getBody(): StreamInterface
+    {
+        return Utils::streamFor(json_encode($this->getContent()));
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getHeaders(): array
+    {
+        return ['Content-Type' => 'application/json'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode(): int
+    {
+        return SymfonyResponse::HTTP_OK;
+    }
+
+    /**
+     * Return the full JSON payload this response will serve.
+     * The shape must match what the corresponding openapi-generated model expects.
+     *
+     * @return array
+     */
+    abstract protected function getContent(): array;
+}

--- a/tests/SdkApi/Response/SdkJsonResponse.php
+++ b/tests/SdkApi/Response/SdkJsonResponse.php
@@ -7,7 +7,6 @@ namespace MyParcelNL\Pdk\Tests\SdkApi\Response;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
-use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 /**
  * Base class for mocked responses returned to openapi-generator SDK clients.
@@ -36,7 +35,7 @@ abstract class SdkJsonResponse extends Response
     public function __construct(
         ?array $responseContent = null,
         int    $status = 200,
-        array  $headers = [],
+        array  $headers = ['Content-Type' => 'application/json'],
         $body = null,
         string $version = '1.1',
         string $reason = null
@@ -51,22 +50,6 @@ abstract class SdkJsonResponse extends Response
     public function getBody(): StreamInterface
     {
         return Utils::streamFor(json_encode($this->getContent()));
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getHeaders(): array
-    {
-        return ['Content-Type' => 'application/json'];
-    }
-
-    /**
-     * @return int
-     */
-    public function getStatusCode(): int
-    {
-        return SymfonyResponse::HTTP_OK;
     }
 
     /**

--- a/tests/Unit/Base/Model/SdkBackedModelTest.php
+++ b/tests/Unit/Base/Model/SdkBackedModelTest.php
@@ -1,0 +1,284 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection,StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Base\Model;
+
+use MyParcelNL\Pdk\Carrier\Model\Carrier;
+use MyParcelNL\Pdk\Tests\Mocks\MockSdkInheritingModel;
+use MyParcelNL\Pdk\Tests\Mocks\MockSdkModel;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsInsuranceOptionV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesResponseCollo;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesSharedOptionsInsuranceBaseInsuranceV2InsuredAmount;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesMoney;
+use function expect;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+uses()->group('model', 'sdk');
+
+usesShared(new UsesMockPdkInstance());
+
+it('reads SDK model properties through the PDK model', function () {
+    $sdkModel = new MockSdkModel([
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+        'age'        => 30,
+        'name'       => 'sdk-name',
+    ]);
+
+    $model = new MockSdkInheritingModel([
+        'title'   => 'Mr.',
+        'sdkData' => $sdkModel,
+    ]);
+
+    // SDK properties accessible through camelCase
+    expect($model->firstName)->toBe('John')
+        ->and($model->lastName)->toBe('Doe')
+        ->and($model->age)->toBe(30);
+});
+
+it('can be constructed from a raw SDK property array', function () {
+    $model = new MockSdkInheritingModel([
+        'title'     => 'Ms.',
+        'firstName' => 'Jane',
+        'lastName'  => 'Doe',
+        'age'       => 25,
+    ]);
+
+    expect($model->firstName)->toBe('Jane')
+        ->and($model->lastName)->toBe('Doe')
+        ->and($model->age)->toBe(25)
+        ->and($model->title)->toBe('Ms.');
+});
+
+it('exposes the underlying SDK model via getSdkModel()', function () {
+    $sdkModel = new MockSdkModel(['first_name' => 'John']);
+    $model    = new MockSdkInheritingModel(['sdkModel' => $sdkModel]);
+
+    expect($model->getSdkModel())->toBe($sdkModel);
+});
+
+it('gives priority to native PDK attributes over SDK properties', function () {
+    $sdkModel = new MockSdkModel([
+        'first_name' => 'John',
+        'name'       => 'sdk-name-value',
+    ]);
+
+    $model = new MockSdkInheritingModel([
+        'title'   => 'Dr.',
+        'name'    => 'pdk-name-value',
+        'sdkData' => $sdkModel,
+    ]);
+
+    // Native PDK 'name' attribute takes priority over SDK model's 'name'
+    expect($model->name)->toBe('pdk-name-value')
+        ->and($model->firstName)->toBe('John');
+});
+
+it('writes SDK model properties through the PDK model', function () {
+    $sdkModel = new MockSdkModel([
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+    ]);
+
+    $model = new MockSdkInheritingModel([
+        'title'   => 'Mr.',
+        'sdkData' => $sdkModel,
+    ]);
+
+    $model->firstName = 'Jane';
+    $model->lastName  = 'Smith';
+
+    expect($model->firstName)->toBe('Jane')
+        ->and($model->lastName)->toBe('Smith')
+        // Verify it was written through to the SDK model
+        ->and($sdkModel->getFirstName())->toBe('Jane')
+        ->and($sdkModel->getLastName())->toBe('Smith');
+});
+
+it('merges SDK properties at root level in toArray()', function () {
+    $sdkModel = new MockSdkModel([
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+        'age'        => 30,
+        'name'       => 'sdk-name',
+    ]);
+
+    $model = new MockSdkInheritingModel([
+        'title'   => 'Mr.',
+        'name'    => 'pdk-name',
+        'sdkData' => $sdkModel,
+    ]);
+
+    $array = $model->toArray();
+
+    // SDK properties should be at root level
+    expect($array)->toHaveKey('firstName')
+        ->and($array)->toHaveKey('lastName')
+        ->and($array)->toHaveKey('age')
+        ->and($array['firstName'])->toBe('John')
+        ->and($array['lastName'])->toBe('Doe')
+        ->and($array['age'])->toBe(30);
+
+    // Native PDK 'name' should win over SDK 'name'
+    expect($array['name'])->toBe('pdk-name');
+
+    // The raw SDK model attribute key should be removed
+    expect($array)->not->toHaveKey('sdkData');
+});
+
+it('handles absent SDK model gracefully', function () {
+    $model = new MockSdkInheritingModel([
+        'title' => 'Mr.',
+        'name'  => 'test',
+        // No non-native keys → $sdkModel stays null
+    ]);
+
+    expect($model->firstName)->toBeNull()
+        ->and($model->getSdkModel())->toBeNull()
+        ->and($model->title)->toBe('Mr.')
+        ->and($model->toArray())->toHaveKey('title');
+});
+
+it('supports snake_case output in toArray with flags', function () {
+    $sdkModel = new MockSdkModel([
+        'first_name' => 'John',
+        'last_name'  => 'Doe',
+    ]);
+
+    $model = new MockSdkInheritingModel([
+        'title'   => 'Mr.',
+        'sdkData' => $sdkModel,
+    ]);
+
+    $array = $model->toSnakeCaseArray();
+
+    expect($array)->toHaveKey('first_name')
+        ->and($array)->toHaveKey('last_name')
+        ->and($array['first_name'])->toBe('John')
+        ->and($array['last_name'])->toBe('Doe');
+});
+
+it('only includes non-null SDK properties in toArray', function () {
+    $sdkModel = new MockSdkModel([
+        'first_name' => 'John',
+        'last_name'  => null,
+        'age'        => null,
+    ]);
+
+    $model = new MockSdkInheritingModel([
+        'title'   => 'Mr.',
+        'sdkData' => $sdkModel,
+    ]);
+
+    $array = $model->toArray();
+
+    expect($array)->toHaveKey('firstName')
+        ->and($array)->not->toHaveKey('lastName')
+        ->and($array)->not->toHaveKey('age');
+});
+
+it('can set native attributes without affecting SDK model', function () {
+    $sdkModel = new MockSdkModel([
+        'first_name' => 'John',
+    ]);
+
+    $model = new MockSdkInheritingModel([
+        'title'   => 'Mr.',
+        'sdkData' => $sdkModel,
+    ]);
+
+    $model->title = 'Dr.';
+
+    expect($model->title)->toBe('Dr.')
+        ->and($model->firstName)->toBe('John');
+});
+
+// ----- Typed-property hydration via openAPITypes (SdkBackedModel::setAttribute) -----
+
+it('hydrates a raw array into a ModelInterface for a typed SDK property', function () {
+    $carrier = new Carrier(['collo' => ['max' => 7]]);
+
+    expect($carrier->collo)
+        ->toBeInstanceOf(RefCapabilitiesResponseCollo::class)
+        ->and($carrier->collo->getMax())->toBe(7);
+});
+
+it('hydrates nested models recursively when the outer model is also an array', function () {
+    $carrier = new Carrier([
+        'options' => [
+            // attributeMap for requiresSignature uses camelCase JSON key 'requiresSignature'
+            'requiresSignature' => ['isSelectedByDefault' => true, 'isRequired' => false],
+        ],
+    ]);
+
+    expect($carrier->options)
+        ->toBeInstanceOf(RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::class)
+        ->and($carrier->options->getRequiresSignature())
+        ->toBeInstanceOf(RefCapabilitiesContractDefinitionsResponseOptionsOptionV2::class)
+        ->and($carrier->options->getRequiresSignature()->getIsSelectedByDefault())->toBeTrue()
+        ->and($carrier->options->getRequiresSignature()->getIsRequired())->toBeFalse();
+});
+
+it('passes an already-hydrated ModelInterface instance through without re-hydrating', function () {
+    $collo = new RefCapabilitiesResponseCollo(['max' => 3]);
+
+    $carrier = new Carrier(['collo' => $collo]);
+
+    expect($carrier->collo)->toBe($collo);
+});
+
+it('passes an already-hydrated ModelInterface through when set via setAttribute', function () {
+    $collo   = new RefCapabilitiesResponseCollo(['max' => 9]);
+    $carrier = new Carrier();
+
+    $carrier->collo = $collo;
+
+    expect($carrier->collo)->toBe($collo);
+});
+
+it('round-trips a carrier through toArray and back without corrupting typed properties', function () {
+    $original = new Carrier(['collo' => ['max' => 4]]);
+
+    $array  = $original->toArray();
+    $reload = new Carrier($array);
+
+    expect($reload->collo)
+        ->toBeInstanceOf(RefCapabilitiesResponseCollo::class)
+        ->and($reload->collo->getMax())->toBe(4);
+});
+
+it('hydrates insurance option with nested insuredAmount from plain arrays', function () {
+    $carrier = new Carrier([
+        'options' => [
+            'insurance' => [
+                'insuredAmount' => [
+                    'default' => ['currency' => 'EUR', 'amount' => 0],
+                    'min'     => ['currency' => 'EUR', 'amount' => 0],
+                    'max'     => ['currency' => 'EUR', 'amount' => 500000],
+                ],
+            ],
+        ],
+    ]);
+
+    $options = $carrier->options;
+    expect($options)->toBeInstanceOf(RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::class);
+
+    $insurance = $options->getInsurance();
+    expect($insurance)->toBeInstanceOf(RefCapabilitiesContractDefinitionsResponseOptionsInsuranceOptionV2::class);
+
+    $insuredAmount = $insurance->getInsuredAmount();
+    expect($insuredAmount)->toBeInstanceOf(RefCapabilitiesSharedOptionsInsuranceBaseInsuranceV2InsuredAmount::class);
+
+    expect($insuredAmount->getMax())->toBeInstanceOf(RefTypesMoney::class)
+        ->and($insuredAmount->getMax()->getAmount())->toBe(500000)
+        ->and($insuredAmount->getMin())->toBeInstanceOf(RefTypesMoney::class)
+        ->and($insuredAmount->getMin()->getAmount())->toBe(0)
+        ->and($insuredAmount->getDefault())->toBeInstanceOf(RefTypesMoney::class)
+        ->and($insuredAmount->getDefault()->getAmount())->toBe(0);
+});

--- a/tests/Unit/Base/Support/SdkModelHelperTest.php
+++ b/tests/Unit/Base/Support/SdkModelHelperTest.php
@@ -14,8 +14,8 @@ uses()->group('model', 'sdk');
 it('converts keys between PDK and SDK case', function () {
     expect(SdkModelHelper::toPdkCase('first_name'))->toBe('firstName')
         ->and(SdkModelHelper::toPdkCase('package_types'))->toBe('packageTypes')
-        ->and(SdkModelHelper::toSdkCase('firstName'))->toBe('first_name')
-        ->and(SdkModelHelper::toSdkCase('packageTypes'))->toBe('package_types');
+        ->and(SdkModelHelper::toOpenApiKey('firstName'))->toBe('first_name')
+        ->and(SdkModelHelper::toOpenApiKey('packageTypes'))->toBe('package_types');
 });
 
 it('builds getter map with camelCase keys', function () {

--- a/tests/Unit/Base/Support/SdkModelHelperTest.php
+++ b/tests/Unit/Base/Support/SdkModelHelperTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection,StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Base\Support;
+
+use MyParcelNL\Pdk\Tests\Mocks\MockSdkModel;
+use function expect;
+
+uses()->group('model', 'sdk');
+
+it('converts keys between PDK and SDK case', function () {
+    expect(SdkModelHelper::toPdkCase('first_name'))->toBe('firstName')
+        ->and(SdkModelHelper::toPdkCase('package_types'))->toBe('packageTypes')
+        ->and(SdkModelHelper::toSdkCase('firstName'))->toBe('first_name')
+        ->and(SdkModelHelper::toSdkCase('packageTypes'))->toBe('package_types');
+});
+
+it('builds getter map with camelCase keys', function () {
+    $map = SdkModelHelper::buildGetterMap(MockSdkModel::class);
+
+    expect($map)->toBe([
+        'firstName' => 'getFirstName',
+        'lastName'  => 'getLastName',
+        'age'       => 'getAge',
+        'name'      => 'getName',
+    ]);
+});
+
+it('builds setter map with camelCase keys', function () {
+    $map = SdkModelHelper::buildSetterMap(MockSdkModel::class);
+
+    expect($map)->toBe([
+        'firstName' => 'setFirstName',
+        'lastName'  => 'setLastName',
+        'age'       => 'setAge',
+        'name'      => 'setName',
+    ]);
+});
+
+it('serializes SDK model to camelCase array', function () {
+    $sdkModel = new MockSdkModel([
+        'first_name' => 'Jane',
+        'last_name'  => 'Smith',
+        'age'        => 25,
+        'name'       => 'test',
+    ]);
+
+    $array = SdkModelHelper::toArray($sdkModel);
+
+    expect($array)->toBe([
+        'firstName' => 'Jane',
+        'lastName'  => 'Smith',
+        'age'       => 25,
+        'name'      => 'test',
+    ]);
+});
+
+it('excludes null values from serialized array', function () {
+    $sdkModel = new MockSdkModel([
+        'first_name' => 'Jane',
+    ]);
+
+    $array = SdkModelHelper::toArray($sdkModel);
+
+    expect($array)->toHaveKey('firstName')
+        ->and($array)->not->toHaveKey('lastName')
+        ->and($array)->not->toHaveKey('age');
+});

--- a/tests/Unit/SdkApi/Middleware/LoggingMiddlewareTest.php
+++ b/tests/Unit/SdkApi/Middleware/LoggingMiddlewareTest.php
@@ -1,0 +1,268 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection,PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Middleware;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Logger\Contract\PdkLoggerInterface;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use Psr\Log\LogLevel;
+
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPdkInstance());
+
+/**
+ * Build a Guzzle Client that uses a MockHandler and LoggingMiddleware,
+ * returning the mock so tests can enqueue responses.
+ */
+function makeLoggingClient(): array
+{
+    $mock  = new MockHandler();
+    $stack = HandlerStack::create($mock);
+    $stack->push(LoggingMiddleware::forApiRequests());
+
+    return [new Client(['handler' => $stack]), $mock];
+}
+
+// forApiRequests() returns a callable
+it('forApiRequests returns a callable', function () {
+    expect(LoggingMiddleware::forApiRequests())->toBeCallable();
+});
+
+// Request logging
+it('logs debug message with method and uri before sending request', function () {
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    [$client, $mock] = makeLoggingClient();
+    $mock->append(new Response(200, [], '{}'));
+
+    $client->get('http://example.com/api/test');
+
+    $debugLogs = $logger->getLogs(LogLevel::DEBUG);
+    $requestLog = array_values(array_filter($debugLogs, fn($l) => $l['message'] === '[PDK]: Sending API request'));
+
+    expect($requestLog)->toHaveCount(1)
+        ->and($requestLog[0]['context']['method'])->toBe('GET')
+        ->and($requestLog[0]['context']['uri'])->toBe('http://example.com/api/test');
+});
+
+// Successful response logging
+it('logs debug message with status and decoded body on successful response', function () {
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    [$client, $mock] = makeLoggingClient();
+    $mock->append(new Response(200, [], json_encode(['foo' => 'bar'])));
+
+    $client->get('http://example.com/api/test');
+
+    $debugLogs   = $logger->getLogs(LogLevel::DEBUG);
+    $responseLog = array_values(array_filter($debugLogs, fn($l) => $l['message'] === '[PDK]: Received API response'));
+
+    expect($responseLog)->toHaveCount(1)
+        ->and($responseLog[0]['context']['status'])->toBe(200)
+        ->and($responseLog[0]['context']['body'])->toBe(['foo' => 'bar']);
+});
+
+it('logs null body when response body is empty', function () {
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    [$client, $mock] = makeLoggingClient();
+    $mock->append(new Response(204, [], ''));
+
+    $client->get('http://example.com/api/test');
+
+    $debugLogs   = $logger->getLogs(LogLevel::DEBUG);
+    $responseLog = array_values(array_filter($debugLogs, fn($l) => $l['message'] === '[PDK]: Received API response'));
+
+    expect($responseLog)->toHaveCount(1)
+        ->and($responseLog[0]['context']['body'])->toBeNull();
+});
+
+it('rewinds the response body after logging so the SDK can still read it', function () {
+    [$client, $mock] = makeLoggingClient();
+    $mock->append(new Response(200, [], json_encode(['result' => 42])));
+
+    // The SDK reads the body via the response object; if the body was not rewound
+    // after logging, getBody()->getContents() would return an empty string.
+    $response = $client->get('http://example.com/api/test');
+
+    expect((string) $response->getBody())->toBe(json_encode(['result' => 42]));
+});
+
+// Error logging
+it('logs error message with error details on request exception', function () {
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    [$client, $mock] = makeLoggingClient();
+    $errorResponse   = new Response(500, ['X-Req' => 'id-123'], json_encode(['message' => 'Server Error']));
+    $mock->append(new RequestException('Server Error', new Request('POST', 'http://example.com/fail'), $errorResponse));
+
+    try {
+        $client->post('http://example.com/fail');
+    } catch (\Throwable $e) {
+        // Expected
+    }
+
+    $errorLogs = $logger->getLogs(LogLevel::ERROR);
+
+    expect($errorLogs)->toHaveCount(1)
+        ->and($errorLogs[0]['message'])->toBe('[PDK]: API request failed')
+        ->and($errorLogs[0]['context']['error'])->toContain('Server Error')
+        ->and($errorLogs[0]['context']['responseBody'])->toBe(['message' => 'Server Error'])
+        ->and($errorLogs[0]['context']['responseHeaders'])->toHaveKey('x-req');
+});
+
+it('logs error without responseBody and responseHeaders when exception has no response', function () {
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    [$client, $mock] = makeLoggingClient();
+    $mock->append(new RequestException('Connection refused', new Request('GET', 'http://example.com/no-response')));
+
+    try {
+        $client->get('http://example.com/no-response');
+    } catch (\Throwable $e) {
+        // Expected
+    }
+
+    $errorLogs = $logger->getLogs(LogLevel::ERROR);
+
+    expect($errorLogs)->toHaveCount(1)
+        ->and($errorLogs[0]['context'])->not->toHaveKey('responseBody')
+        ->and($errorLogs[0]['context'])->not->toHaveKey('responseHeaders');
+});
+
+it('re-throws the exception after logging', function () {
+    [$client, $mock] = makeLoggingClient();
+    $mock->append(new RequestException('Fail', new Request('GET', 'http://example.com/rethrow')));
+
+    expect(fn() => $client->get('http://example.com/rethrow'))
+        ->toThrow(RequestException::class);
+});
+
+// Sensitive data redaction
+
+it('masks sensitive query parameters in the logged request URI', function () {
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    [$client, $mock] = makeLoggingClient();
+    $mock->append(new Response(200, [], '{}'));
+
+    $client->get('http://example.com/api?api_key=supersecret123&page=2');
+
+    $debugLogs  = $logger->getLogs(LogLevel::DEBUG);
+    $requestLog = array_values(array_filter($debugLogs, fn($l) => $l['message'] === '[PDK]: Sending API request'));
+
+    expect($requestLog)->toHaveCount(1)
+        ->and($requestLog[0]['context']['uri'])->not->toContain('supersecret123')
+        ->and($requestLog[0]['context']['uri'])->toContain('api_key=***');
+});
+
+it('preserves non-sensitive query parameters in the logged request URI', function () {
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    [$client, $mock] = makeLoggingClient();
+    $mock->append(new Response(200, [], '{}'));
+
+    $client->get('http://example.com/api?page=2&limit=10');
+
+    $debugLogs  = $logger->getLogs(LogLevel::DEBUG);
+    $requestLog = array_values(array_filter($debugLogs, fn($l) => $l['message'] === '[PDK]: Sending API request'));
+
+    expect($requestLog)->toHaveCount(1)
+        ->and($requestLog[0]['context']['uri'])->toContain('page=2')
+        ->and($requestLog[0]['context']['uri'])->toContain('limit=10');
+});
+
+it('masks sensitive headers in error response', function () {
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    [$client, $mock] = makeLoggingClient();
+    $errorResponse   = new Response(500, ['Authorization' => 'Bearer token123', 'X-Request-Id' => 'req-abc'], '{}');
+    $mock->append(new RequestException('Server Error', new Request('GET', 'http://example.com/fail'), $errorResponse));
+
+    try {
+        $client->get('http://example.com/fail');
+    } catch (\Throwable $e) {
+        // Expected
+    }
+
+    $errorLogs = $logger->getLogs(LogLevel::ERROR);
+
+    expect($errorLogs)->toHaveCount(1)
+        ->and($errorLogs[0]['context']['responseHeaders'])->toHaveKey('authorization')
+        ->and($errorLogs[0]['context']['responseHeaders']['authorization'])->toBe(['***'])
+        ->and($errorLogs[0]['context']['responseHeaders'])->not->toHaveKey('Authorization');
+});
+
+it('preserves non-sensitive headers in error response', function () {
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    [$client, $mock] = makeLoggingClient();
+    $errorResponse   = new Response(500, ['Content-Type' => 'application/json', 'X-Request-Id' => 'req-abc'], '{}');
+    $mock->append(new RequestException('Server Error', new Request('GET', 'http://example.com/fail'), $errorResponse));
+
+    try {
+        $client->get('http://example.com/fail');
+    } catch (\Throwable $e) {
+        // Expected
+    }
+
+    $errorLogs = $logger->getLogs(LogLevel::ERROR);
+
+    expect($errorLogs)->toHaveCount(1)
+        ->and($errorLogs[0]['context']['responseHeaders'])->toHaveKey('content-type')
+        ->and($errorLogs[0]['context']['responseHeaders']['content-type'])->toBe(['application/json'])
+        ->and($errorLogs[0]['context']['responseHeaders'])->toHaveKey('x-request-id')
+        ->and($errorLogs[0]['context']['responseHeaders']['x-request-id'])->toBe(['req-abc']);
+});
+
+it('recursively scrubs sensitive keys from error response body', function () {
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    [$client, $mock] = makeLoggingClient();
+    $body            = json_encode(['user' => ['access_token' => 'abc123', 'name' => 'John']]);
+    $errorResponse   = new Response(500, [], $body);
+    $mock->append(new RequestException('Server Error', new Request('GET', 'http://example.com/fail'), $errorResponse));
+
+    try {
+        $client->get('http://example.com/fail');
+    } catch (\Throwable $e) {
+        // Expected
+    }
+
+    $errorLogs = $logger->getLogs(LogLevel::ERROR);
+
+    expect($errorLogs)->toHaveCount(1)
+        ->and($errorLogs[0]['context']['responseBody']['user']['access_token'])->toBe('***')
+        ->and($errorLogs[0]['context']['responseBody']['user']['name'])->toBe('***');
+});

--- a/tests/Unit/SdkApi/Middleware/LoggingMiddlewareTest.php
+++ b/tests/Unit/SdkApi/Middleware/LoggingMiddlewareTest.php
@@ -34,7 +34,6 @@ function makeLoggingClient(): array
     return [new Client(['handler' => $stack]), $mock];
 }
 
-// forApiRequests() returns a callable
 it('forApiRequests returns a callable', function () {
     expect(LoggingMiddleware::forApiRequests())->toBeCallable();
 });

--- a/tests/Unit/SdkApi/Service/AbstractSdkApiServiceTest.php
+++ b/tests/Unit/SdkApi/Service/AbstractSdkApiServiceTest.php
@@ -1,0 +1,184 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection,PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use MyParcelNL\Pdk\Base\Config;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Logger\Contract\PdkLoggerInterface;
+use MyParcelNL\Pdk\Settings\Model\AccountSettings;
+use MyParcelNL\Pdk\Tests\Bootstrap\MockPdkFactory;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use Psr\Log\LogLevel;
+
+use function DI\value;
+use function MyParcelNL\Pdk\Tests\factory;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPdkInstance());
+
+// Create a concrete test implementation for testing abstract methods
+class ConcreteSdkApiServiceForTest extends AbstractSdkApiService
+{
+    public function getApiConfig()
+    {
+        return null; // Dummy implementation
+    }
+
+    // Expose protected methods for testing
+    public function publicGetApiKey(): ?string
+    {
+        return $this->getApiKey();
+    }
+
+    public function publicGetUserAgent(): string
+    {
+        return $this->getUserAgent();
+    }
+
+    public function publicIsAcceptanceEnvironment(): bool
+    {
+        return $this->isAcceptanceEnvironment();
+    }
+
+    public function publicCreateGuzzleClientHandlerStack(): HandlerStack
+    {
+        return $this->createGuzzleClientHandlerStack();
+    }
+
+    public function publicCreateGuzzleClient(): Client
+    {
+        return $this->createGuzzleClient();
+    }
+}
+
+// Tests for getApiKey()
+it('returns null when API key is not set', function () {
+    $service = new ConcreteSdkApiServiceForTest();
+
+    expect($service->publicGetApiKey())->toBeNull();
+});
+
+it('returns API key when set in settings', function () {
+    TestBootstrapper::hasApiKey('test-api-key-12345');
+
+    $service = new ConcreteSdkApiServiceForTest();
+
+    expect($service->publicGetApiKey())->toBe('test-api-key-12345');
+});
+
+// Tests for getUserAgent()
+it('builds user agent with PDK defaults', function () {
+    $service = new ConcreteSdkApiServiceForTest();
+    $userAgent = $service->publicGetUserAgent();
+    $pdkVersion = Pdk::get('pdkVersion');
+
+    expect($userAgent)
+        ->toBeString()
+        ->toContain('MyParcelNL-PDK/' . $pdkVersion)
+        ->toContain('php/' . PHP_VERSION);
+});
+
+it('includes custom user agents from config', function () {
+    $pdk = MockPdkFactory::create([
+        'userAgent' => value([
+            'MyPlatform' => '2.0.0',
+            'CustomApp'  => '1.5.3',
+        ]),
+    ]);
+
+    $service = new ConcreteSdkApiServiceForTest();
+    $userAgent = $service->publicGetUserAgent();
+
+    expect($userAgent)
+        ->toContain('MyPlatform/2.0.0')
+        ->toContain('CustomApp/1.5.3')
+        ->toContain('MyParcelNL-PDK/')
+        ->toContain('php/');
+});
+
+it('user agent format follows Platform/Version pattern', function () {
+    $service = new ConcreteSdkApiServiceForTest();
+    $userAgent = $service->publicGetUserAgent();
+
+    // Should match: "Platform1/1.0.0 Platform2/2.0.0"
+    expect($userAgent)->toMatch('/^[\w-]+\/[\d.]+(?: [\w-]+\/[\d.]+)*$/');
+});
+
+// Tests for isAcceptanceEnvironment()
+it('returns false when environment is production', function () {
+    TestBootstrapper::hasAccount();
+
+    factory(AccountSettings::class)
+        ->withEnvironment(Config::ENVIRONMENT_PRODUCTION)
+        ->store();
+
+    $service = new ConcreteSdkApiServiceForTest();
+
+    expect($service->publicIsAcceptanceEnvironment())->toBeFalse();
+});
+
+it('returns true when environment is acceptance', function () {
+    TestBootstrapper::hasAccount();
+
+    factory(AccountSettings::class)
+        ->withEnvironment(Config::ENVIRONMENT_ACCEPTANCE)
+        ->store();
+
+    $service = new ConcreteSdkApiServiceForTest();
+
+    expect($service->publicIsAcceptanceEnvironment())->toBeTrue();
+});
+
+it('logs debug message when using acceptance environment', function () {
+    TestBootstrapper::hasAccount();
+
+    factory(AccountSettings::class)
+        ->withEnvironment(Config::ENVIRONMENT_ACCEPTANCE)
+        ->store();
+
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    $service = new ConcreteSdkApiServiceForTest();
+    $service->publicIsAcceptanceEnvironment();
+
+    $logs = $logger->getLogs(LogLevel::DEBUG);
+
+    expect($logs)
+        ->toHaveCount(1)
+        ->and($logs[0]['message'])
+        ->toContain('Using acceptance API URL');
+});
+
+it('returns false when environment is not set', function () {
+    factory(AccountSettings::class)
+        ->store();
+
+    $service = new ConcreteSdkApiServiceForTest();
+    $result  = $service->publicIsAcceptanceEnvironment();
+
+    expect($result)->toBeFalse();
+});
+
+// Tests for createGuzzleClientHandlerStack() and createGuzzleClient()
+it('createGuzzleClientHandlerStack returns a HandlerStack', function () {
+    $service = new ConcreteSdkApiServiceForTest();
+    $stack   = $service->publicCreateGuzzleClientHandlerStack();
+
+    expect($stack)->toBeInstanceOf(HandlerStack::class);
+});
+
+it('createGuzzleClient returns a Guzzle Client', function () {
+    $service = new ConcreteSdkApiServiceForTest();
+    $client  = $service->publicCreateGuzzleClient();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});

--- a/tests/Unit/SdkApi/Service/AbstractSdkApiServiceTest.php
+++ b/tests/Unit/SdkApi/Service/AbstractSdkApiServiceTest.php
@@ -86,7 +86,7 @@ it('builds user agent with PDK defaults', function () {
 });
 
 it('includes custom user agents from config', function () {
-    $pdk = MockPdkFactory::create([
+    MockPdkFactory::create([
         'userAgent' => value([
             'MyPlatform' => '2.0.0',
             'CustomApp'  => '1.5.3',

--- a/tests/Unit/SdkApi/Service/CoreApi/AbstractCoreApiServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApi/AbstractCoreApiServiceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection,PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service\CoreApi;
+
+use MyParcelNL\Pdk\Base\Config;
+use MyParcelNL\Pdk\Settings\Model\AccountSettings;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Configuration as CoreApiConfiguration;
+
+use function MyParcelNL\Pdk\Tests\factory;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPdkInstance());
+
+// Concrete implementation for testing
+class ConcreteCoreApiServiceForTest extends AbstractCoreApiService
+{
+    public function publicGetApiConfig(): CoreApiConfiguration
+    {
+        return $this->getApiConfig();
+    }
+}
+
+// Tests for getApiConfig()
+it('returns Configuration instance based on generated CoreApi Config class', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $service = new ConcreteCoreApiServiceForTest();
+    $config  = $service->publicGetApiConfig();
+
+    expect($config)->toBeInstanceOf(CoreApiConfiguration::class);
+});
+
+it('sets base64-encoded access token from API key', function () {
+    TestBootstrapper::hasApiKey('my-secret-key');
+
+    $service = new ConcreteCoreApiServiceForTest();
+    $config  = $service->publicGetApiConfig();
+
+    expect($config->getAccessToken())->toBe(base64_encode('my-secret-key'));
+});
+
+it('populates user agent in the config with platform info', function () {
+    TestBootstrapper::hasApiKey();
+
+    $service   = new ConcreteCoreApiServiceForTest();
+    $config    = $service->publicGetApiConfig();
+    $userAgent = $config->getUserAgent();
+    $pdkVersion = \MyParcelNL\Pdk\Facade\Pdk::get('pdkVersion');
+
+    expect($userAgent)
+        ->toContain('MyParcelNL-PDK/' . $pdkVersion)
+        ->toContain('php/' . PHP_VERSION);
+});
+
+it('config uses default host when environment is production', function () {
+    TestBootstrapper::hasAccount();
+
+    factory(AccountSettings::class)
+        ->withEnvironment(Config::ENVIRONMENT_PRODUCTION)
+        ->store();
+
+    $service = new ConcreteCoreApiServiceForTest();
+    $config  = $service->publicGetApiConfig();
+
+    // Default from OpenAPI spec should be used (not explicitly set)
+    $defaultConfig = new CoreApiConfiguration();
+    expect($config->getHost())->toBe($defaultConfig->getHost());
+});
+
+it('sets acceptance host in config when environment is acceptance', function () {
+    TestBootstrapper::hasAccount();
+
+    factory(AccountSettings::class)
+        ->withEnvironment(Config::ENVIRONMENT_ACCEPTANCE)
+        ->store();
+
+    $service = new ConcreteCoreApiServiceForTest();
+    $config  = $service->publicGetApiConfig();
+
+    expect($config->getHost())->toBe(Config::API_URL_ACCEPTANCE);
+});
+
+it('handles null API key gracefully', function () {
+    // No API key set
+    $service = new ConcreteCoreApiServiceForTest();
+    $config  = $service->publicGetApiConfig();
+
+    // Should still return a config, with base64 of null (empty string essentially)
+    expect($config)->toBeInstanceOf(CoreApiConfiguration::class);
+    expect($config->getAccessToken())->toBe('');
+});

--- a/tests/Unit/SdkApi/Service/CoreApi/Shipment/AbstractShipmentApiServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApi/Shipment/AbstractShipmentApiServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection,PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment;
+
+use MyParcelNL\Pdk\Base\Config;
+use MyParcelNL\Pdk\Settings\Model\AccountSettings;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
+
+use function MyParcelNL\Pdk\Tests\factory;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPdkInstance());
+
+// Concrete implementation for testing
+class ConcreteShipmentApiServiceForTest extends AbstractShipmentApiService
+{
+    public function getShipmentApiInstance(): ShipmentApi
+    {
+        return $this->shipmentApi;
+    }
+}
+
+// Tests for constructor
+it('instantiates ShipmentApi', function () {
+    $service     = new ConcreteShipmentApiServiceForTest();
+    $shipmentApi = $service->getShipmentApiInstance();
+
+    expect($shipmentApi)->toBeInstanceOf(ShipmentApi::class);
+});
+
+it('instantiated ShipmentApi uses configuration from parent', function () {
+    TestBootstrapper::hasApiKey('configured-key');
+
+    factory(AccountSettings::class)
+        ->withEnvironment(Config::ENVIRONMENT_ACCEPTANCE)
+        ->store();
+
+    $service     = new ConcreteShipmentApiServiceForTest();
+    $shipmentApi = $service->getShipmentApiInstance();
+
+    // Verify it was constructed (can't directly introspect private Guzzle config)
+    expect($shipmentApi)->toBeInstanceOf(ShipmentApi::class);
+    expect($shipmentApi->getConfig())->toBeInstanceOf(\MyParcelNL\Sdk\Client\Generated\CoreApi\Configuration::class);
+    expect($shipmentApi->getConfig()->getHost())->toBe(Config::API_URL_ACCEPTANCE);
+});

--- a/tests/Unit/SdkApi/Service/CoreApi/Shipment/CapabilitiesServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApi/Shipment/CapabilitiesServiceTest.php
@@ -223,11 +223,12 @@ it('response body is logged as decoded JSON array via middleware', function () {
 });
 
 // Tests for Accept-header middleware in CapabilitiesService
-it('sets version-2 Accept header for capabilities endpoint requests', function () {
+it('sets version-2 Accept header for all capabilities endpoints', function () {
     TestBootstrapper::hasApiKey('test-key');
 
     $service = new MockableCapabilitiesService();
     $service->mockHandler->append(new Response(200, [], json_encode(['results' => []])));
+    $service->mockHandler->append(new Response(200, [], json_encode(['items' => []])));
 
     $service->getCapabilities([
         'carrier'      => 'POSTNL',
@@ -235,28 +236,11 @@ it('sets version-2 Accept header for capabilities endpoint requests', function (
         'package_type' => 'PACKAGE',
     ]);
 
-    expect($service->capturedRequests)->toHaveCount(1);
-
-    $request = $service->capturedRequests[0];
-    expect($request->getHeaderLine('Accept'))->toBe('application/json;charset=utf-8;version=2');
-});
-
-it('does not override Accept header for non-capabilities endpoints', function () {
-    // Build the handler stack directly to send a request to a non-capabilities path
-    TestBootstrapper::hasApiKey('test-key');
-
-    $service = new MockableCapabilitiesService();
-
-    // Append a dummy response for the mock
-    $service->mockHandler->append(new Response(200, [], json_encode(['items' => []])));
-
-    // getContractDefinitions goes to /shipments/capabilities/contract-definitions,
-    // which matches the middleware pattern, so let's verify it also gets the header.
     $service->getContractDefinitions(null);
 
-    expect($service->capturedRequests)->toHaveCount(1);
+    expect($service->capturedRequests)->toHaveCount(2);
 
-    $request = $service->capturedRequests[0];
-    // Contract definitions path also contains /shipments/capabilities
-    expect($request->getHeaderLine('Accept'))->toBe('application/json;charset=utf-8;version=2');
+    foreach ($service->capturedRequests as $request) {
+        expect($request->getHeaderLine('Accept'))->toBe('application/json;charset=utf-8;version=2');
+    }
 });

--- a/tests/Unit/SdkApi/Service/CoreApi/Shipment/CapabilitiesServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApi/Shipment/CapabilitiesServiceTest.php
@@ -1,0 +1,262 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection,PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment;
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Psr7\Response;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Logger\Contract\PdkLoggerInterface;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesPostContractDefinitionsRequestV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesSharedCarrierV2;
+use Psr\Http\Message\RequestInterface;
+use Psr\Log\LogLevel;
+
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPdkInstance());
+
+/**
+ * Test subclass that replaces only the real Guzzle transport with a MockHandler.
+ *
+ * Overrides createGuzzleClient() rather than createGuzzleClientHandlerStack(), so
+ * the full real middleware chain from CapabilitiesService (Accept-header override)
+ * and AbstractSdkApiService (LoggingMiddleware) is preserved without duplication.
+ */
+class MockableCapabilitiesService extends CapabilitiesService
+{
+    /** @var MockHandler */
+    public $mockHandler;
+
+    /** @var RequestInterface[] */
+    public $capturedRequests = [];
+
+    public function __construct()
+    {
+        $this->mockHandler = new MockHandler();
+        parent::__construct();
+    }
+
+    protected function createGuzzleClient(): \GuzzleHttp\Client
+    {
+        $capturedRequests = &$this->capturedRequests;
+
+        // Build the real middleware stack (LoggingMiddleware + Accept-header override)
+        // then swap the transport for the MockHandler — no duplication of middleware logic.
+        $stack = $this->createGuzzleClientHandlerStack();
+        $stack->setHandler($this->mockHandler);
+
+        // Capture each outgoing request after all middleware has run
+        $stack->push(function (callable $handler) use (&$capturedRequests) {
+            return function (RequestInterface $request, array $options) use ($handler, &$capturedRequests) {
+                $capturedRequests[] = $request;
+
+                return $handler($request, $options);
+            };
+        });
+
+        return new \GuzzleHttp\Client(['handler' => $stack]);
+    }
+}
+
+// Tests for getCapabilities()
+it('can be instantiated', function () {
+    TestBootstrapper::hasApiKey('valid-key');
+
+    expect(new CapabilitiesService())->toBeInstanceOf(CapabilitiesService::class);
+});
+
+it('getCapabilities returns array of results from API response', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $service = new MockableCapabilitiesService();
+    $service->mockHandler->append(new Response(200, [], json_encode(['results' => []])));
+
+    $result = $service->getCapabilities([
+        'carrier'      => 'POSTNL',
+        'recipient'    => ['cc' => 'NL', 'postal_code' => '2132WT'],
+        'package_type' => 'PACKAGE',
+    ]);
+
+    expect($result)->toBeArray();
+});
+
+it('getCapabilities rejects incorrect parameter types before making a request', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $service = new CapabilitiesService();
+
+    $allowedValuesString = implode("', '", RefCapabilitiesSharedCarrierV2::getAllowableEnumValues());
+
+    // The OpenAPI SDK validates parameters when building the request object,
+    // so no HTTP request is made and no mock handler is needed.
+    expect(fn() => $service->getCapabilities([
+        'carrier'      => 2, // Invalid: must be a string enum value
+        'recipient'    => ['cc' => 'NL', 'postal_code' => '2132WT'],
+        'package_type' => 'PACKAGE',
+    ]))->toThrow(
+        \InvalidArgumentException::class,
+        "Invalid value for enum '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesSharedCarrierV2', must be one of: '$allowedValuesString'"
+    );
+});
+
+// Tests for getContractDefinitions()
+it('getContractDefinitions returns array of items from API response', function () {
+    TestBootstrapper::hasApiKey('valid-key');
+
+    $service = new MockableCapabilitiesService();
+    $service->mockHandler->append(new Response(200, [], json_encode(['items' => []])));
+
+    expect($service->getContractDefinitions('POSTNL'))->toBeArray();
+});
+
+it('getContractDefinitions accepts null carrier to retrieve all definitions', function () {
+    TestBootstrapper::hasApiKey('valid-key');
+
+    $service = new MockableCapabilitiesService();
+    $service->mockHandler->append(new Response(200, [], json_encode(['items' => []])));
+
+    expect($service->getContractDefinitions(null))->toBeArray();
+});
+
+it('getContractDefinitions rejects unknown carrier names before making a request', function () {
+    TestBootstrapper::hasApiKey('valid-key');
+
+    $service = new CapabilitiesService();
+    $allowedValuesString = implode("', '", (new CapabilitiesPostContractDefinitionsRequestV2())->getCarrierAllowableValues());
+
+    expect(fn() => $service->getContractDefinitions('unknown_carrier'))
+        ->toThrow(\InvalidArgumentException::class, "Invalid value 'unknown_carrier' for 'carrier', must be one of '$allowedValuesString'");
+});
+
+// Tests for LoggingMiddleware integration
+it('logs a debug message for outgoing request via middleware', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    $service = new MockableCapabilitiesService();
+    $service->mockHandler->append(new Response(200, [], json_encode(['items' => []])));
+
+    $service->getContractDefinitions(null);
+
+    $debugLogs = $logger->getLogs(LogLevel::DEBUG);
+
+    $requestLog = array_values(array_filter($debugLogs, fn($l) => $l['message'] === '[PDK]: Sending API request'));
+    expect($requestLog)->toHaveCount(1)
+        ->and($requestLog[0]['context'])->toHaveKeys(['method', 'uri'])
+        ->and($requestLog[0]['context']['method'])->toBe('POST');
+});
+
+it('logs a debug message for received response via middleware', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    $service = new MockableCapabilitiesService();
+    $service->mockHandler->append(new Response(200, [], json_encode(['items' => []])));
+
+    $service->getContractDefinitions(null);
+
+    $debugLogs = $logger->getLogs(LogLevel::DEBUG);
+
+    $responseLog = array_values(array_filter($debugLogs, fn($l) => $l['message'] === '[PDK]: Received API response'));
+    expect($responseLog)->toHaveCount(1)
+        ->and($responseLog[0]['context']['status'])->toBe(200);
+});
+
+it('logs an error message when a transport-level exception occurs', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    $service = new MockableCapabilitiesService();
+    // Use a RequestException to simulate a transport-level failure (e.g., connection refused).
+    // An HTTP 500 response is returned by MockHandler as a normal response; the SDK then throws
+    // an ApiException itself after the middleware chain, so it would not hit the error callback.
+    $service->mockHandler->append(
+        new RequestException('Connection timed out', new GuzzleRequest('POST', 'http://api.myparcel.nl'))
+    );
+
+    try {
+        $service->getContractDefinitions(null);
+    } catch (\Throwable $e) {
+        // Expected
+    }
+
+    $errorLogs = $logger->getLogs(LogLevel::ERROR);
+
+    expect($errorLogs)->toHaveCount(1)
+        ->and($errorLogs[0]['message'])->toBe('[PDK]: API request failed')
+        ->and($errorLogs[0]['context'])->toHaveKeys(['error', 'code']);
+});
+
+it('response body is logged as decoded JSON array via middleware', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(PdkLoggerInterface::class);
+    $logger->clear();
+
+    $service = new MockableCapabilitiesService();
+    $service->mockHandler->append(new Response(200, [], json_encode(['items' => []])));
+
+    $service->getContractDefinitions(null);
+
+    $debugLogs = $logger->getLogs(LogLevel::DEBUG);
+
+    $responseLog = array_values(array_filter($debugLogs, fn($l) => $l['message'] === '[PDK]: Received API response'));
+    expect($responseLog[0]['context']['body'])->toBe(['items' => []]);
+});
+
+// Tests for Accept-header middleware in CapabilitiesService
+it('sets version-2 Accept header for capabilities endpoint requests', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $service = new MockableCapabilitiesService();
+    $service->mockHandler->append(new Response(200, [], json_encode(['results' => []])));
+
+    $service->getCapabilities([
+        'carrier'      => 'POSTNL',
+        'recipient'    => ['cc' => 'NL', 'postal_code' => '2132WT'],
+        'package_type' => 'PACKAGE',
+    ]);
+
+    expect($service->capturedRequests)->toHaveCount(1);
+
+    $request = $service->capturedRequests[0];
+    expect($request->getHeaderLine('Accept'))->toBe('application/json;charset=utf-8;version=2');
+});
+
+it('does not override Accept header for non-capabilities endpoints', function () {
+    // Build the handler stack directly to send a request to a non-capabilities path
+    TestBootstrapper::hasApiKey('test-key');
+
+    $service = new MockableCapabilitiesService();
+
+    // Append a dummy response for the mock
+    $service->mockHandler->append(new Response(200, [], json_encode(['items' => []])));
+
+    // getContractDefinitions goes to /shipments/capabilities/contract-definitions,
+    // which matches the middleware pattern, so let's verify it also gets the header.
+    $service->getContractDefinitions(null);
+
+    expect($service->capturedRequests)->toHaveCount(1);
+
+    $request = $service->capturedRequests[0];
+    // Contract definitions path also contains /shipments/capabilities
+    expect($request->getHeaderLine('Accept'))->toBe('application/json;charset=utf-8;version=2');
+});

--- a/tests/Uses/UsesSdkApiMock.php
+++ b/tests/Uses/UsesSdkApiMock.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Tests\Uses;
+
+use MyParcelNL\Pdk\Tests\SdkApi\MockSdkApiHandler;
+
+/**
+ * Pest hook that resets the SdkApi MockHandler around each test.
+ *
+ * Add to usesShared() in any test file that exercises code going through
+ * a SdkApi service (e.g. CapabilitiesService via CarrierCapabilitiesRepository):
+ *
+ *   usesShared(new UsesMockPdkInstance(), new UsesApiMock(), new UsesSdkApiMock());
+ */
+class UsesSdkApiMock implements BaseMock
+{
+    public function beforeEach(): void
+    {
+        MockSdkApiHandler::reset();
+    }
+
+    public function afterEach(): void
+    {
+        MockSdkApiHandler::reset();
+    }
+}


### PR DESCRIPTION
Depends on: #438

Introduce the SdkApi module for calling SDK-generated API clients, replacing
hand-written request/response classes. Includes logging middleware with
sensitive data scrubbing, a SdkBackedModel base class for wrapping SDK types
in PDK-compatible models, and a CapabilitiesService for fetching contract
capability definitions.

- Add SdkApi/ module (AbstractSdkApiService, LoggingMiddleware, CoreApi hierarchy)
- Add CapabilitiesService for fetching contract capability definitions
- Add SdkBackedModel base class and SdkModelHelper utilities
- Add SensitiveDataScrubber for sanitizing log data
- Add test infrastructure (MockSdkApiHandler, UsesSdkApiMock, etc.)
- Fix accept headers in MyParcelApiService

Refs: INT-1261