### PR TITLE
feat(options)!: move all order (shipment) option definitions to `OptionDefinition`

### DIFF
--- a/.claude/skills/add-shipment-option.md
+++ b/.claude/skills/add-shipment-option.md
@@ -1,0 +1,98 @@
+---
+name: add-shipment-option
+description: Guide step-by-step through adding a new shipment option to the PDK
+---
+
+# Add Shipment Option
+
+Use this skill when adding a new shipment option to the PDK.
+
+## Information Gathering
+
+Ask the user the following questions one at a time:
+
+### 1. SDK Keys
+
+Ask: "What is the snake_case key from `RefShipmentShipmentOptions::attributeMap()`? (e.g. `my_new_option`)"
+
+Then: "What is the snake_case key from `RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()`? (e.g. `my_new_option`)"
+
+If the option is not in the SDK types, suggest regenerating the OpenAPI generated types and/or updating the SDK first. New shipment options should be defined in the API spec and reflected in the SDK before being added to the PDK. Only use plain string values as a last resort for options that are PDK-internal and not part of the API (e.g. `excludeParcelLockers`).
+
+### 2. Allow Setting
+
+Ask: "Should consumers be able to toggle this option at checkout in the delivery options widget? (allow setting)"
+
+Explain: The `allow*` setting controls whether the consumer can choose this option at checkout. Only use for options where consumer choice is appropriate (e.g. signature, pickup). Options that should always be applied by the merchant via the export setting and should not be (de)selectable by the consumer (e.g. age check for alcohol, insurance, hide sender) should NOT have an allow setting.
+
+If yes: the default `getAllowSettingsKey()` will produce `allow{OptionName}`.
+If no: override `getAllowSettingsKey()` to return `null`.
+
+### 3. Price Setting
+
+Ask: "Should there be a price surcharge setting for this option? (price setting)"
+
+Explain: The `price*` setting represents a monetary surcharge added to the shipping cost when the option is active. This is typically used together with an allow setting so the consumer can see the surcharge at checkout, but can also be used for merchant-applied options where the cost is passed on.
+
+If yes: the default `getPriceSettingsKey()` will produce `price{OptionName}`.
+If no: override `getPriceSettingsKey()` to return `null`.
+
+### 4. Value Type
+
+Ask: "Is this a standard boolean/tri-state option, or does it have a numeric value (like insurance amount)?"
+
+If tri-state: no override needed (default `getShipmentOptionsCast()` returns `TriStateService::TYPE_STRICT`).
+If numeric: override `getShipmentOptionsCast()` to return `'int'`.
+
+### 5. Carrier/Product Settings
+
+Ask: "Should this option have carrier-level and product-level export settings?"
+
+Most options have both. Some (like same day delivery) have neither — they are controlled purely by capabilities. Override `getCarrierSettingsKey()` and/or `getProductSettingsKey()` to return `null` to opt out.
+
+## Implementation Steps
+
+After gathering the information:
+
+### 1. Create the Definition Class
+
+Create `src/App/Options/Definition/{OptionName}Definition.php` extending `AbstractOrderOptionDefinition`.
+
+Required methods:
+
+- `getShipmentOptionsKey()` — return `Str::camel(RefShipmentShipmentOptions::attributeMap()['sdk_key'])`
+- `getCapabilitiesOptionsKey()` — return `RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['capabilities_key']`
+
+Add null overrides for any settings the user opted out of.
+
+### 2. Register the Definition
+
+Add the new definition to the `orderOptionDefinitions` array in `config/pdk-business-logic.php`. Add the import at the top of the file.
+
+### 3. Add Deprecated Constant to ShipmentOptions
+
+Add a `@deprecated` constant to `src/Shipment/Model/ShipmentOptions.php` for backwards compatibility with platform integrations. Do NOT use this constant anywhere in PDK code — use the definition's `getShipmentOptionsKey()` instead.
+
+### 4. Run IDE Helper
+
+```bash
+docker compose run php composer console generate:ide-helper
+```
+
+### 5. Run Tests
+
+```bash
+yarn run test:unit
+```
+
+The consistency tests will verify everything is wired up correctly. Update snapshots if needed:
+
+```bash
+yarn test:unit:snapshot
+```
+
+## Notes
+
+- The `Carrier` model filters serialized options to only include those with registered definitions. Adding a definition automatically makes the option visible to the frontend.
+- `CarrierSettings`, `ProductSettings`, `ShipmentOptions`, and `Fulfilment\ShipmentOptions` all build their option attributes dynamically from definitions — no manual attribute registration needed.
+- `CarrierSchema::canHaveShipmentOption()` checks capabilities for the option automatically via the definition's capabilities key.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,34 @@ docker compose build
 docker compose run php composer test
 ```
 
+#### Updating snapshots
+
+To update test snapshots and format them consistently:
+
+```shell
+yarn test:unit:snapshot
+```
+
+This runs the Pest snapshot update inside Docker, then applies Prettier formatting on the host. Use this instead of running `composer test:unit:snapshot` directly inside Docker, as PHP's `json_encode` outputs 4-space indented JSON while the project standard (enforced by Prettier) is 2-space.
+
+### Adding a shipment option
+
+Shipment options are managed through the `OrderOptionDefinitionInterface` system. Each option is a single Definition class that declares all its keys (shipment, capabilities, carrier settings, product settings, allow, price). All models, views, and services build their attributes and form elements dynamically from these definitions.
+
+To add a new option:
+
+1. **Create a Definition class** in `src/App/Options/Definition/` extending `AbstractOrderOptionDefinition`. Only two methods are required:
+   - `getShipmentOptionsKey()` — the PDK-internal key, derived from `Str::camel(RefShipmentShipmentOptions::attributeMap()['sdk_key'])`
+   - `getCapabilitiesOptionsKey()` — the V2 capabilities key, from `RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['capabilities_key']`
+2. **Register it** in the `orderOptionDefinitions` array in `config/pdk-business-logic.php`.
+3. **Optionally**, add a deprecated constant to `ShipmentOptions` if platform integrations reference the key directly.
+
+Everything else (carrier settings, product settings, allow/price toggles, validation, frontend form fields, API export/import) is derived automatically. Run `yarn test:unit` to verify the consistency tests pass.
+
+If the option is not yet in the SDK types, update the SDK or regenerate the OpenAPI types first.
+
+> **Using Claude Code?** Run `/add-shipment-option` for a guided step-by-step walkthrough that asks the right questions and generates the code.
+
 ### Linting
 
 We use Prettier to format .json, .yml, .md and .html files.

--- a/config/pdk-business-logic.php
+++ b/config/pdk-business-logic.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use MyParcelNL\Pdk\App\Options\Definition\AgeCheckDefinition;
 use MyParcelNL\Pdk\App\Options\Definition\CollectDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\CooledDeliveryDefinition;
 use MyParcelNL\Pdk\App\Options\Definition\DirectReturnDefinition;
 use MyParcelNL\Pdk\App\Options\Definition\ExcludeParcelLockersDefinition;
 use MyParcelNL\Pdk\App\Options\Definition\FreshFoodDefinition;
@@ -90,6 +91,7 @@ return [
             new ExcludeParcelLockersDefinition(),
             new FreshFoodDefinition(),
             new FrozenDefinition(),
+            new CooledDeliveryDefinition(),
         ];
     }),
 

--- a/config/pdk-default.php
+++ b/config/pdk-default.php
@@ -3,12 +3,9 @@
 declare(strict_types=1);
 
 use MyParcelNL\Pdk\Base\Support\Arr;
-use MyParcelNL\Pdk\Base\Support\Collection;
 use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
-use MyParcelNL\Pdk\Facade\Config;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Facade\Pdk as PdkFacade;
-use MyParcelNL\Pdk\Facade\Platform;
 use MyParcelNL\Pdk\Facade\Settings;
 use MyParcelNL\Pdk\Proposition\Service\PropositionService;
 use MyParcelNL\Pdk\Settings\Model\OrderSettings;
@@ -37,6 +34,7 @@ return [
     /**
      * Url to the API.
      */
+    //@deprecated, use the apiUrl from the OpenAPI spec instead.
     'apiUrl'                 => env('PDK_API_URL', 'https://api.myparcel.nl'),
     'printingApiUrl'         => env('PDK_PRINTING_API_URL', 'https://printing.api.myparcel.nl'),
     'addressesServiceUrl'    => env('PDK_ADDRESSES_SERVICE_URL', 'https://address.api.myparcel.nl'),
@@ -125,24 +123,6 @@ return [
      * Allowed positions for the delivery options in the checkout.
      */
     'deliveryOptionsPositions' => value([]),
-
-    /**
-     * All carriers available in the proposition.
-     * @deprecated use PropositionService::getCarriers() instead.
-     * @see \MyParcelNL\Pdk\Proposition\Service\PropositionService::getCarriers();
-     */
-    'allCarriers' => factory(function (): CarrierCollection {
-        return Pdk::get(PropositionService::class)->getCarriers();
-    }),
-
-    /**
-     * All carriers available in the proposition that support available delivery types.
-     * @deprecated use PropositionService::getCarriers(true) instead.
-     * @see \MyParcelNL\Pdk\Proposition\Service\PropositionService::getCarriers();
-     */
-    'carriers' => factory(function (): CarrierCollection {
-        return Pdk::get(PropositionService::class)->getCarriers(true);
-    }),
 
     /**
      * Language to default to when no language is set.

--- a/config/pdk-settings.php
+++ b/config/pdk-settings.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use MyParcelNL\Pdk\Facade\Pdk as PdkFacade;
 use MyParcelNL\Pdk\Facade\Pdk;
-use MyParcelNL\Pdk\Facade\Platform;
 use MyParcelNL\Pdk\Proposition\Service\PropositionService;
 use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
 use MyParcelNL\Pdk\Settings\Model\CustomsSettings;
@@ -74,14 +73,14 @@ return [
                     CarrierSettings::EXPORT_SIGNATURE                        => false,
                     CarrierSettings::EXPORT_FROZEN                           => false,
                     CarrierSettings::EXPORT_FRESH_FOOD                       => false,
-                    CarrierSettings::PRICE_DELIVERY_TYPE_EVENING             => 0,
-                    CarrierSettings::PRICE_DELIVERY_TYPE_EXPRESS             => 0,
-                    CarrierSettings::PRICE_DELIVERY_TYPE_MONDAY              => 0,
-                    CarrierSettings::PRICE_DELIVERY_TYPE_MORNING             => 0,
+                    CarrierSettings::PRICE_DELIVERY_TYPE_EVENING_DELIVERY             => 0,
+                    CarrierSettings::PRICE_DELIVERY_TYPE_EXPRESS_DELIVERY             => 0,
+                    CarrierSettings::PRICE_DELIVERY_TYPE_MONDAY_DELIVERY              => 0,
+                    CarrierSettings::PRICE_DELIVERY_TYPE_MORNING_DELIVERY             => 0,
                     CarrierSettings::PRICE_DELIVERY_TYPE_PICKUP              => 0,
-                    CarrierSettings::PRICE_DELIVERY_TYPE_SAME_DAY            => 0,
-                    CarrierSettings::PRICE_DELIVERY_TYPE_SATURDAY            => 0,
-                    CarrierSettings::PRICE_DELIVERY_TYPE_STANDARD            => 0,
+                    CarrierSettings::PRICE_DELIVERY_TYPE_SAME_DAY_DELIVERY            => 0,
+                    CarrierSettings::PRICE_DELIVERY_TYPE_SATURDAY_DELIVERY            => 0,
+                    CarrierSettings::PRICE_DELIVERY_TYPE_STANDARD_DELIVERY            => 0,
                     CarrierSettings::PRICE_ONLY_RECIPIENT                    => 0,
                     CarrierSettings::PRICE_PACKAGE_TYPE_DIGITAL_STAMP        => 0,
                     CarrierSettings::PRICE_PACKAGE_TYPE_MAILBOX              => 0,

--- a/src/App/DeliveryOptions/Service/DeliveryOptionsFeesService.php
+++ b/src/App/DeliveryOptions/Service/DeliveryOptionsFeesService.php
@@ -7,20 +7,28 @@ namespace MyParcelNL\Pdk\App\DeliveryOptions\Service;
 use MyParcelNL\Pdk\App\Cart\Collection\PdkCartFeeCollection;
 use MyParcelNL\Pdk\App\Cart\Model\PdkCartFee;
 use MyParcelNL\Pdk\App\DeliveryOptions\Contract\DeliveryOptionsFeesServiceInterface;
+use MyParcelNL\Pdk\App\Options\Definition\OnlyRecipientDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\PriorityDeliveryDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\SignatureDefinition;
 use MyParcelNL\Pdk\Facade\Settings;
 use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
 use MyParcelNL\Pdk\Types\Service\TriStateService;
 use MyParcelNL\Sdk\Support\Str;
 
 class DeliveryOptionsFeesService implements DeliveryOptionsFeesServiceInterface
 {
-    private const FRONTEND_SHIPMENT_OPTIONS = [
-        ShipmentOptions::ONLY_RECIPIENT,
-        ShipmentOptions::PRIORITY_DELIVERY,
-        ShipmentOptions::SIGNATURE,
-    ];
+    /**
+     * @return string[]
+     */
+    private static function getFrontendShipmentOptionKeys(): array
+    {
+        return [
+            (new OnlyRecipientDefinition())->getShipmentOptionsKey(),
+            (new PriorityDeliveryDefinition())->getShipmentOptionsKey(),
+            (new SignatureDefinition())->getShipmentOptionsKey(),
+        ];
+    }
 
     /**
      * @param  string                                         $identifier
@@ -82,7 +90,7 @@ class DeliveryOptionsFeesService implements DeliveryOptionsFeesServiceInterface
         $fees = [];
 
         foreach ($deliveryOptions->shipmentOptions->toArrayWithoutNull() as $key => $option) {
-            if (! in_array($key, self::FRONTEND_SHIPMENT_OPTIONS, true)) {
+            if (! in_array($key, self::getFrontendShipmentOptionKeys(), true)) {
                 continue;
             }
 

--- a/src/App/DeliveryOptions/Service/DeliveryOptionsService.php
+++ b/src/App/DeliveryOptions/Service/DeliveryOptionsService.php
@@ -32,32 +32,28 @@ use MyParcelNL\Sdk\Support\Str;
 
 class DeliveryOptionsService implements DeliveryOptionsServiceInterface
 {
-    private const CONFIG_CARRIER_SETTINGS_MAP = [
+    /**
+     * Settings map for non-shipment-option entries (delivery types, package types, etc.)
+     * that are not covered by OrderOptionDefinitions. Shipment option allow/price keys
+     * are built dynamically from definitions in getCarrierSettingsMap().
+     */
+    private const NON_DEFINITION_CARRIER_SETTINGS_MAP = [
         'allowDeliveryOptions'         => CarrierSettings::ALLOW_DELIVERY_OPTIONS,
         'allowStandardDelivery'        => CarrierSettings::ALLOW_STANDARD_DELIVERY,
         'allowEveningDelivery'         => CarrierSettings::ALLOW_EVENING_DELIVERY,
         'allowMondayDelivery'          => CarrierSettings::ALLOW_MONDAY_DELIVERY,
         'allowMorningDelivery'         => CarrierSettings::ALLOW_MORNING_DELIVERY,
-        'allowOnlyRecipient'           => CarrierSettings::ALLOW_ONLY_RECIPIENT,
         'allowPickupLocations'         => CarrierSettings::ALLOW_PICKUP_DELIVERY,
-        'allowPriorityDelivery'        => CarrierSettings::ALLOW_PRIORITY_DELIVERY,
-        'allowSameDayDelivery'         => CarrierSettings::ALLOW_SAME_DAY_DELIVERY,
-        'allowSaturdayDelivery'        => CarrierSettings::ALLOW_SATURDAY_DELIVERY,
-        'allowSignature'               => CarrierSettings::ALLOW_SIGNATURE,
         'allowExpressDelivery'         => CarrierSettings::ALLOW_DELIVERY_TYPE_EXPRESS,
-        'priceEveningDelivery'         => CarrierSettings::PRICE_DELIVERY_TYPE_EVENING,
-        'priceMorningDelivery'         => CarrierSettings::PRICE_DELIVERY_TYPE_MORNING,
-        'priceOnlyRecipient'           => CarrierSettings::PRICE_ONLY_RECIPIENT,
-        'pricePriorityDelivery'        => CarrierSettings::PRICE_PRIORITY_DELIVERY,
+        'priceEveningDelivery'         => CarrierSettings::PRICE_DELIVERY_TYPE_EVENING_DELIVERY,
+        'priceMorningDelivery'         => CarrierSettings::PRICE_DELIVERY_TYPE_MORNING_DELIVERY,
         'pricePackageTypeDigitalStamp' => CarrierSettings::PRICE_PACKAGE_TYPE_DIGITAL_STAMP,
         'pricePackageTypeMailbox'      => CarrierSettings::PRICE_PACKAGE_TYPE_MAILBOX,
         'pricePackageTypePackageSmall' => CarrierSettings::PRICE_PACKAGE_TYPE_PACKAGE_SMALL,
         'pricePickup'                  => CarrierSettings::PRICE_DELIVERY_TYPE_PICKUP,
-        'priceSameDayDelivery'         => CarrierSettings::PRICE_DELIVERY_TYPE_SAME_DAY,
-        'priceSignature'               => CarrierSettings::PRICE_SIGNATURE,
-        'priceStandardDelivery'        => CarrierSettings::PRICE_DELIVERY_TYPE_STANDARD,
-        'priceCollect'                 => CarrierSettings::PRICE_COLLECT,
-        'priceExpressDelivery'         => CarrierSettings::PRICE_DELIVERY_TYPE_EXPRESS,
+        'priceSameDayDelivery'         => CarrierSettings::PRICE_DELIVERY_TYPE_SAME_DAY_DELIVERY,
+        'priceStandardDelivery'        => CarrierSettings::PRICE_DELIVERY_TYPE_STANDARD_DELIVERY,
+        'priceExpressDelivery'         => CarrierSettings::PRICE_DELIVERY_TYPE_EXPRESS_DELIVERY,
         'excludeParcelLockers'         => CheckoutSettings::EXCLUDE_PARCEL_LOCKERS,
     ];
 
@@ -234,7 +230,8 @@ class DeliveryOptionsService implements DeliveryOptionsServiceInterface
         $cc = $cart->shippingMethod->shippingAddress->cc ?? null;
         if (
             $cc
-            && $this->shouldUseInternationalMailboxPrice($packageType, $cc)) {
+            && $this->shouldUseInternationalMailboxPrice($packageType, $cc)
+        ) {
             $carrierSettings->pricePackageTypeMailbox = $carrierSettings->priceInternationalMailbox;
         }
 
@@ -284,7 +281,7 @@ class DeliveryOptionsService implements DeliveryOptionsServiceInterface
             }
 
             return $value;
-        }, self::CONFIG_CARRIER_SETTINGS_MAP);
+        }, self::getCarrierSettingsMap());
     }
 
     /**
@@ -365,6 +362,35 @@ class DeliveryOptionsService implements DeliveryOptionsServiceInterface
         }
 
         return [DeliveryOptions::DEFAULT_PACKAGE_TYPE_NAME, $allCarriers];
+    }
+
+    /**
+     * Build the full carrier settings map by merging definition-derived allow/price keys
+     * with the static non-definition entries.
+     *
+     * @return array<string, string>
+     */
+    private static function getCarrierSettingsMap(): array
+    {
+        /** @var \MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface[] $definitions */
+        $definitions = Pdk::get('orderOptionDefinitions');
+        $map         = [];
+
+        foreach ($definitions as $definition) {
+            $allowKey = $definition->getAllowSettingsKey();
+
+            if ($allowKey) {
+                $map[$allowKey] = $allowKey;
+            }
+
+            $priceKey = $definition->getPriceSettingsKey();
+
+            if ($priceKey) {
+                $map[$priceKey] = $priceKey;
+            }
+        }
+
+        return array_merge($map, self::NON_DEFINITION_CARRIER_SETTINGS_MAP);
     }
 
     /**

--- a/src/App/Endpoint/Resource/DeliveryOptionsV1Resource.php
+++ b/src/App/Endpoint/Resource/DeliveryOptionsV1Resource.php
@@ -7,11 +7,21 @@ namespace MyParcelNL\Pdk\App\Endpoint\Resource;
 use Alcohol\ISO4217;
 use ArrayObject;
 use MyParcelNL\Pdk\App\Endpoint\Contract\AbstractVersionedResource;
+use MyParcelNL\Pdk\App\Options\Definition\AgeCheckDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\CollectDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\DirectReturnDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\HideSenderDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\InsuranceDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\LargeFormatDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\OnlyRecipientDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\PriorityDeliveryDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\ReceiptCodeDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\SameDayDeliveryDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\SaturdayDeliveryDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\SignatureDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\TrackedDefinition;
 use MyParcelNL\Pdk\Carrier\Model\Carrier;
 use MyParcelNL\Pdk\Facade\Logger;
-use MyParcelNL\Pdk\Facade\Pdk;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Proposition\Service\PropositionService;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Pdk\Shipment\Model\RetailLocation;
 use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
@@ -79,32 +89,37 @@ final class DeliveryOptionsV1Resource extends AbstractVersionedResource
          * New tracking implementation: When tracked option is not present or explicitly enabled we do nothing (tracking is enabled by default in the order service)
          * Only when tracking is explicitly disabled we include the "noTracking" option with an ADR-0013 compliant empty object as value
          */
-        if ($shipmentOptions->tracked === TriStateService::DISABLED) {
+        $trackedKey = (new TrackedDefinition())->getShipmentOptionsKey();
+
+        if ($shipmentOptions->{$trackedKey} === TriStateService::DISABLED) {
             $formattedOptions[$orderApiShipmentOptions['no_tracking']] = new ArrayObject();
         }
 
+        $insuranceKey        = (new InsuranceDefinition())->getShipmentOptionsKey();
+        $labelDescriptionKey = ShipmentOptions::LABEL_DESCRIPTION;
+
         $optionMap = [
-            ShipmentOptions::AGE_CHECK => $orderApiShipmentOptions['requires_age_verification'],
-            ShipmentOptions::SIGNATURE => $orderApiShipmentOptions['requires_signature'],
-            ShipmentOptions::ONLY_RECIPIENT => $orderApiShipmentOptions['recipient_only_delivery'],
-            ShipmentOptions::LARGE_FORMAT => $orderApiShipmentOptions['oversized_package'],
-            ShipmentOptions::DIRECT_RETURN => $orderApiShipmentOptions['print_return_label_at_drop_off'],
-            ShipmentOptions::HIDE_SENDER => $orderApiShipmentOptions['hide_sender'],
-            ShipmentOptions::LABEL_DESCRIPTION => $orderApiShipmentOptions['custom_label_text'],
-            ShipmentOptions::PRIORITY_DELIVERY => $orderApiShipmentOptions['priority_delivery'],
-            ShipmentOptions::RECEIPT_CODE => $orderApiShipmentOptions['requires_receipt_code'],
-            ShipmentOptions::SAME_DAY_DELIVERY => $orderApiShipmentOptions['same_day_delivery'],
-            ShipmentOptions::SATURDAY_DELIVERY => $orderApiShipmentOptions['saturday_delivery'],
-            ShipmentOptions::COLLECT => $orderApiShipmentOptions['scheduled_collection'],
+            (new AgeCheckDefinition())->getShipmentOptionsKey()         => $orderApiShipmentOptions['requires_age_verification'],
+            (new SignatureDefinition())->getShipmentOptionsKey()        => $orderApiShipmentOptions['requires_signature'],
+            (new OnlyRecipientDefinition())->getShipmentOptionsKey()    => $orderApiShipmentOptions['recipient_only_delivery'],
+            (new LargeFormatDefinition())->getShipmentOptionsKey()      => $orderApiShipmentOptions['oversized_package'],
+            (new DirectReturnDefinition())->getShipmentOptionsKey()     => $orderApiShipmentOptions['print_return_label_at_drop_off'],
+            (new HideSenderDefinition())->getShipmentOptionsKey()       => $orderApiShipmentOptions['hide_sender'],
+            $labelDescriptionKey                                        => $orderApiShipmentOptions['custom_label_text'],
+            (new PriorityDeliveryDefinition())->getShipmentOptionsKey() => $orderApiShipmentOptions['priority_delivery'],
+            (new ReceiptCodeDefinition())->getShipmentOptionsKey()      => $orderApiShipmentOptions['requires_receipt_code'],
+            (new SameDayDeliveryDefinition())->getShipmentOptionsKey()  => $orderApiShipmentOptions['same_day_delivery'],
+            (new SaturdayDeliveryDefinition())->getShipmentOptionsKey() => $orderApiShipmentOptions['saturday_delivery'],
+            (new CollectDefinition())->getShipmentOptionsKey()          => $orderApiShipmentOptions['scheduled_collection'],
         ];
 
         foreach ($filteredOptions as $key => $value) {
-            if ($key === ShipmentOptions::INSURANCE) {
+            if ($key === $insuranceKey) {
                 // Insurance amount converted to integer micro as per ADR-0014
                 $amount = ((int)$value) * 1_000_000;
                 $currency = (new ISO4217())->getByAlpha3('EUR'); // Assuming EUR, adjust in the future as needed
                 $formattedOptions[$orderApiShipmentOptions['insurance']] = ['amount' => $amount, 'currency' => $currency['alpha3']];
-            } elseif ($key === ShipmentOptions::LABEL_DESCRIPTION) {
+            } elseif ($key === $labelDescriptionKey) {
                 // Custom label text option needs to be formatted as an object with a "text" property
                 $formattedOptions[$orderApiShipmentOptions['custom_label_text']] = ['text' => (string) $value];
             } else {

--- a/src/App/Options/Contract/OrderOptionDefinitionInterface.php
+++ b/src/App/Options/Contract/OrderOptionDefinitionInterface.php
@@ -30,11 +30,40 @@ interface OrderOptionDefinitionInterface
     public function getShipmentOptionsKey(): ?string;
 
     /**
-     * Get the key that represents the option in the proposition.
+     * Get the camelCase property key that represents this option in the capabilities options object
+     * (RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2).
      *
      * @return null|string
      */
-    public function getPropositionKey(): ?string;
+    public function getCapabilitiesOptionsKey(): ?string;
+
+    /**
+     * Get the delivery options "allow" toggle key (e.g. 'allowSignature').
+     *
+     * @return null|string
+     */
+    public function getAllowSettingsKey(): ?string;
+
+    /**
+     * Get the price surcharge key (e.g. 'priceSignature').
+     *
+     * @return null|string
+     */
+    public function getPriceSettingsKey(): ?string;
+
+    /**
+     * Get the cast type for this option on the ShipmentOptions model.
+     *
+     * @return string
+     */
+    public function getShipmentOptionsCast(): string;
+
+    /**
+     * Get the default value for this option on the ShipmentOptions model.
+     *
+     * @return mixed
+     */
+    public function getShipmentOptionsDefault();
 
     /**
      * Validates if the option is allowed for the current carrier.

--- a/src/App/Options/Definition/AbstractOrderOptionDefinition.php
+++ b/src/App/Options/Definition/AbstractOrderOptionDefinition.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\App\Options\Definition;
+
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
+use MyParcelNL\Pdk\Types\Service\TriStateService;
+use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+
+abstract class AbstractOrderOptionDefinition implements OrderOptionDefinitionInterface
+{
+    /**
+     * The internal PDK key used on the ShipmentOptions model (e.g. 'signature', 'ageCheck').
+     * This is the root key from which carrier/product/allow/price settings keys are derived.
+     * These keys correspond to the legacy API naming used by the shipment-, order v1,
+     * delivery-options and other legacy API endpoints.
+     *
+     * By default, derived from the SDK's RefShipmentShipmentOptions::attributeMap() via
+     * Str::camel(). Override with a string if the PDK key differs from the SDK key's
+     * camelCase equivalent, or return null if this definition does not represent a shipment
+     * option (e.g. product-only settings like CountryOfOrigin).
+     *
+     * When null, all derived settings keys also return null automatically, and the option
+     * will not appear on the ShipmentOptions model.
+     */
+    abstract public function getShipmentOptionsKey(): ?string;
+
+    /**
+     * The SDK capabilities key (e.g. 'requiresSignature', 'oversizedPackage').
+     * This is the explicit bridge between PDK option names and SDK-generated type names.
+     * These keys correspond to the V2 naming used by the capabilities API and
+     * microservices (e.g. order v2).
+     *
+     * Return null if this option has no corresponding capabilities entry (e.g.
+     * ExcludeParcelLockers). When null, the option cannot be validated against carrier
+     * capabilities, and no default value will be resolved from the capabilities response.
+     */
+    abstract public function getCapabilitiesOptionsKey(): ?string;
+
+    /**
+     * The carrier-level settings key (e.g. 'exportSignature').
+     * Derived by default: 'export' + ucfirst(shipmentOptionsKey).
+     *
+     * Return null to opt out of carrier-level settings. When null, no attribute will be
+     * registered on CarrierSettings and the option cannot be configured at the carrier level.
+     */
+    public function getCarrierSettingsKey(): ?string
+    {
+        $key = $this->getShipmentOptionsKey();
+
+        return $key ? 'export' . ucfirst($key) : null;
+    }
+
+    /**
+     * The product-level settings key (e.g. 'exportSignature').
+     * Derived by default: same as carrier settings key.
+     *
+     * Return null to opt out of product-level settings. When null, no attribute will be
+     * registered on ProductSettings and the option cannot be overridden per product.
+     */
+    public function getProductSettingsKey(): ?string
+    {
+        return $this->getCarrierSettingsKey();
+    }
+
+    /**
+     * The delivery options "allow" toggle key (e.g. 'allowSignature').
+     * Derived by default: 'allow' + ucfirst(shipmentOptionsKey).
+     *
+     * This controls whether the consumer can choose this option at checkout in the
+     * delivery options widget. Only use for options where consumer choice is appropriate
+     * (e.g. signature, pickup). Return null for options that should always be applied by
+     * the merchant via the export setting and should not be (de)selectable by the consumer
+     * (e.g. age check, insurance, hide sender).
+     *
+     * When null, no allow attribute will be registered on CarrierSettings and the option
+     * will not appear as a toggleable choice in the delivery options frontend widget.
+     */
+    public function getAllowSettingsKey(): ?string
+    {
+        $key = $this->getShipmentOptionsKey();
+
+        return $key ? 'allow' . ucfirst($key) : null;
+    }
+
+    /**
+     * The price surcharge key (e.g. 'priceSignature').
+     * Derived by default: 'price' + ucfirst(shipmentOptionsKey).
+     *
+     * Return null to opt out of the price surcharge. When null, no price attribute will be
+     * registered on CarrierSettings and no surcharge will be shown in the delivery options
+     * frontend widget for this option.
+     */
+    public function getPriceSettingsKey(): ?string
+    {
+        $key = $this->getShipmentOptionsKey();
+
+        return $key ? 'price' . ucfirst($key) : null;
+    }
+
+    /**
+     * The cast type for this option on the ShipmentOptions model.
+     * Default: TriStateService::TYPE_STRICT (tri-state: -1/0/1).
+     *
+     * Override for options with different value types (e.g. InsuranceDefinition returns 'int').
+     * Fulfilment models derive their cast from this: TYPE_STRICT becomes 'bool', others are kept as-is.
+     */
+    public function getShipmentOptionsCast(): string
+    {
+        return TriStateService::TYPE_STRICT;
+    }
+
+    /**
+     * The default value for this option on the ShipmentOptions model.
+     * Default: TriStateService::INHERIT (-1).
+     *
+     * Override for options with different default values.
+     * Fulfilment models use null as default regardless of this value.
+     *
+     * @return mixed
+     */
+    public function getShipmentOptionsDefault()
+    {
+        return TriStateService::INHERIT;
+    }
+
+    /**
+     * Validates whether this option is available for the given carrier.
+     * Default: checks if the capabilities key exists in the carrier's options.
+     *
+     * Override to provide custom validation logic, or to always return true for options
+     * that are universally available regardless of carrier capabilities.
+     */
+    public function validate(CarrierSchema $carrierSchema): bool
+    {
+        return $carrierSchema->canHaveShipmentOption($this);
+    }
+}

--- a/src/App/Options/Definition/AgeCheckDefinition.php
+++ b/src/App/Options/Definition/AgeCheckDefinition.php
@@ -4,37 +4,29 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class AgeCheckDefinition implements OrderOptionDefinitionInterface
+final class AgeCheckDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
-    {
-        return CarrierSettings::EXPORT_AGE_CHECK;
-    }
-
-    public function getProductSettingsKey(): ?string
-    {
-        return ProductSettings::EXPORT_AGE_CHECK;
-    }
-
     public function getShipmentOptionsKey(): ?string
     {
-        return ShipmentOptions::AGE_CHECK;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['age_check']);
     }
 
-    public function getPropositionKey(): ?string
+    public function getCapabilitiesOptionsKey(): ?string
     {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_AGE_CHECK_NAME;
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['requires_age_verification'];
     }
 
-    public function validate(CarrierSchema $carrierSchema): bool
+    public function getAllowSettingsKey(): ?string
     {
-        return $carrierSchema->canHaveAgeCheck();
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
+    {
+        return null;
     }
 }

--- a/src/App/Options/Definition/CollectDefinition.php
+++ b/src/App/Options/Definition/CollectDefinition.php
@@ -4,48 +4,34 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-class CollectDefinition implements OrderOptionDefinitionInterface
+final class CollectDefinition extends AbstractOrderOptionDefinition
 {
-    /**
-     * @inheritDoc
-     */
-    public function getCarrierSettingsKey(): ?string
+    public function getShipmentOptionsKey(): ?string
     {
-        return CarrierSettings::EXPORT_COLLECT;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['collect']);
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
+    {
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['scheduled_collection'];
     }
 
     /**
-     * @inheritDoc
+     * @TODO: Collect has a priceCollect setting but no allowCollect toggle. The price is sent
+     *        to the delivery options frontend but the consumer cannot toggle collect on/off.
+     *        Consider adding allowCollect or removing priceCollect.
      */
-    public function getProductSettingsKey(): ?string
+    public function getAllowSettingsKey(): ?string
     {
         return null;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function getShipmentOptionsKey(): ?string
+    public function getProductSettingsKey(): ?string
     {
-        return ShipmentOptions::COLLECT;
-    }
-
-    public function getPropositionKey(): ?string
-    {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_COLLECT_NAME;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function validate(CarrierSchema $carrierSchema): bool
-    {
-        return $carrierSchema->canHaveCollect();
+        return null;
     }
 }

--- a/src/App/Options/Definition/CooledDeliveryDefinition.php
+++ b/src/App/Options/Definition/CooledDeliveryDefinition.php
@@ -8,16 +8,16 @@ use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinit
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
 use MyParcelNL\Sdk\Support\Str;
 
-final class FrozenDefinition extends AbstractOrderOptionDefinition
+final class CooledDeliveryDefinition extends AbstractOrderOptionDefinition
 {
     public function getShipmentOptionsKey(): ?string
     {
-        return Str::camel(RefShipmentShipmentOptions::attributeMap()['frozen']);
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['cooled_delivery']);
     }
 
     public function getCapabilitiesOptionsKey(): ?string
     {
-        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['frozen'];
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['cooled_delivery'];
     }
 
     public function getAllowSettingsKey(): ?string

--- a/src/App/Options/Definition/CountryOfOriginDefinition.php
+++ b/src/App/Options/Definition/CountryOfOriginDefinition.php
@@ -4,28 +4,31 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
 use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
 
-final class CountryOfOriginDefinition implements OrderOptionDefinitionInterface
+final class CountryOfOriginDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
+    public function getShipmentOptionsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
     {
         return null;
     }
 
     public function getProductSettingsKey(): ?string
     {
-        return ProductSettings::COUNTRY_OF_ORIGIN;
+        return 'countryOfOrigin';
     }
 
-    public function getShipmentOptionsKey(): ?string
+    public function getAllowSettingsKey(): ?string
     {
         return null;
     }
 
-    public function getPropositionKey(): ?string
+    public function getPriceSettingsKey(): ?string
     {
         return null;
     }

--- a/src/App/Options/Definition/CustomsCodeDefinition.php
+++ b/src/App/Options/Definition/CustomsCodeDefinition.php
@@ -4,28 +4,31 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
 use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
 
-final class CustomsCodeDefinition implements OrderOptionDefinitionInterface
+final class CustomsCodeDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
+    public function getShipmentOptionsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
     {
         return null;
     }
 
     public function getProductSettingsKey(): ?string
     {
-        return ProductSettings::CUSTOMS_CODE;
+        return 'customsCode';
     }
 
-    public function getShipmentOptionsKey(): ?string
+    public function getAllowSettingsKey(): ?string
     {
         return null;
     }
 
-    public function getPropositionKey(): ?string
+    public function getPriceSettingsKey(): ?string
     {
         return null;
     }

--- a/src/App/Options/Definition/DirectReturnDefinition.php
+++ b/src/App/Options/Definition/DirectReturnDefinition.php
@@ -4,37 +4,29 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class DirectReturnDefinition implements OrderOptionDefinitionInterface
+final class DirectReturnDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
-    {
-        return CarrierSettings::EXPORT_RETURN;
-    }
-
-    public function getProductSettingsKey(): ?string
-    {
-        return ProductSettings::EXPORT_RETURN;
-    }
-
     public function getShipmentOptionsKey(): ?string
     {
-        return ShipmentOptions::DIRECT_RETURN;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['return']);
     }
 
-    public function getPropositionKey(): ?string
+    public function getCapabilitiesOptionsKey(): ?string
     {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_DIRECT_RETURN_NAME;
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['return_on_first_failed_delivery'];
     }
 
-    public function validate(CarrierSchema $carrierSchema): bool
+    public function getAllowSettingsKey(): ?string
     {
-        return $carrierSchema->canHaveDirectReturn();
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
+    {
+        return null;
     }
 }

--- a/src/App/Options/Definition/DisableDeliveryOptionsDefinition.php
+++ b/src/App/Options/Definition/DisableDeliveryOptionsDefinition.php
@@ -4,28 +4,31 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
 use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
 
-final class DisableDeliveryOptionsDefinition implements OrderOptionDefinitionInterface
+final class DisableDeliveryOptionsDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
+    public function getShipmentOptionsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
     {
         return null;
     }
 
     public function getProductSettingsKey(): ?string
     {
-        return ProductSettings::DISABLE_DELIVERY_OPTIONS;
+        return 'disableDeliveryOptions';
     }
 
-    public function getShipmentOptionsKey(): ?string
+    public function getAllowSettingsKey(): ?string
     {
         return null;
     }
 
-    public function getPropositionKey(): ?string
+    public function getPriceSettingsKey(): ?string
     {
         return null;
     }

--- a/src/App/Options/Definition/ExcludeParcelLockersDefinition.php
+++ b/src/App/Options/Definition/ExcludeParcelLockersDefinition.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
 use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
 
-final class ExcludeParcelLockersDefinition implements OrderOptionDefinitionInterface
+final class ExcludeParcelLockersDefinition extends AbstractOrderOptionDefinition
 {
-    public function getPropositionKey(): ?string
+    public function getShipmentOptionsKey(): ?string
+    {
+        return 'excludeParcelLockers';
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
     {
         return null;
     }
@@ -23,12 +25,17 @@ final class ExcludeParcelLockersDefinition implements OrderOptionDefinitionInter
 
     public function getProductSettingsKey(): ?string
     {
-        return ProductSettings::EXCLUDE_PARCEL_LOCKERS;
+        return 'excludeParcelLockers';
     }
 
-    public function getShipmentOptionsKey(): ?string
+    public function getAllowSettingsKey(): ?string
     {
-        return ShipmentOptions::EXCLUDE_PARCEL_LOCKERS;
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
+    {
+        return null;
     }
 
     public function validate(CarrierSchema $carrierSchema): bool

--- a/src/App/Options/Definition/FitInDigitalStampDefinition.php
+++ b/src/App/Options/Definition/FitInDigitalStampDefinition.php
@@ -4,28 +4,31 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
 use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
 
-final class FitInDigitalStampDefinition implements OrderOptionDefinitionInterface
+final class FitInDigitalStampDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
+    public function getShipmentOptionsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
     {
         return null;
     }
 
     public function getProductSettingsKey(): ?string
     {
-        return ProductSettings::FIT_IN_DIGITAL_STAMP;
+        return 'fitInDigitalStamp';
     }
 
-    public function getShipmentOptionsKey(): ?string
+    public function getAllowSettingsKey(): ?string
     {
         return null;
     }
 
-    public function getPropositionKey(): ?string
+    public function getPriceSettingsKey(): ?string
     {
         return null;
     }

--- a/src/App/Options/Definition/FitInMailboxDefinition.php
+++ b/src/App/Options/Definition/FitInMailboxDefinition.php
@@ -4,28 +4,31 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
 use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
 
-final class FitInMailboxDefinition implements OrderOptionDefinitionInterface
+final class FitInMailboxDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
+    public function getShipmentOptionsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
     {
         return null;
     }
 
     public function getProductSettingsKey(): ?string
     {
-        return ProductSettings::FIT_IN_MAILBOX;
+        return 'fitInMailbox';
     }
 
-    public function getShipmentOptionsKey(): ?string
+    public function getAllowSettingsKey(): ?string
     {
         return null;
     }
 
-    public function getPropositionKey(): ?string
+    public function getPriceSettingsKey(): ?string
     {
         return null;
     }

--- a/src/App/Options/Definition/FreshFoodDefinition.php
+++ b/src/App/Options/Definition/FreshFoodDefinition.php
@@ -4,36 +4,29 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class FreshFoodDefinition implements OrderOptionDefinitionInterface
+final class FreshFoodDefinition extends AbstractOrderOptionDefinition
 {
-    public function getPropositionKey(): ?string
-    {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_FRESH_FOOD_NAME;
-    }
-    public function getCarrierSettingsKey(): ?string
-    {
-        return CarrierSettings::EXPORT_FRESH_FOOD;
-    }
-
-    public function getProductSettingsKey(): ?string
-    {
-        return ProductSettings::EXPORT_FRESH_FOOD;
-    }
-
     public function getShipmentOptionsKey(): ?string
     {
-        return ShipmentOptions::FRESH_FOOD;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['fresh_food']);
     }
 
-    public function validate(CarrierSchema $carrierSchema): bool
+    public function getCapabilitiesOptionsKey(): ?string
     {
-        return $carrierSchema->canHaveFreshFood();
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['fresh_food'];
+    }
+
+    public function getAllowSettingsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
+    {
+        return null;
     }
 }

--- a/src/App/Options/Definition/HideSenderDefinition.php
+++ b/src/App/Options/Definition/HideSenderDefinition.php
@@ -4,37 +4,29 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class HideSenderDefinition implements OrderOptionDefinitionInterface
+final class HideSenderDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
-    {
-        return CarrierSettings::EXPORT_HIDE_SENDER;
-    }
-
-    public function getProductSettingsKey(): ?string
-    {
-        return ProductSettings::EXPORT_HIDE_SENDER;
-    }
-
     public function getShipmentOptionsKey(): ?string
     {
-        return ShipmentOptions::HIDE_SENDER;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['hide_sender']);
     }
 
-    public function getPropositionKey(): ?string
+    public function getCapabilitiesOptionsKey(): ?string
     {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_HIDE_SENDER_NAME;
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['hide_sender'];
     }
 
-    public function validate(CarrierSchema $carrierSchema): bool
+    public function getAllowSettingsKey(): ?string
     {
-        return $carrierSchema->canHaveHideSender();
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
+    {
+        return null;
     }
 }

--- a/src/App/Options/Definition/InsuranceDefinition.php
+++ b/src/App/Options/Definition/InsuranceDefinition.php
@@ -4,37 +4,34 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class InsuranceDefinition implements OrderOptionDefinitionInterface
+final class InsuranceDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
-    {
-        return CarrierSettings::EXPORT_INSURANCE;
-    }
-
-    public function getProductSettingsKey(): ?string
-    {
-        return ProductSettings::EXPORT_INSURANCE;
-    }
-
     public function getShipmentOptionsKey(): ?string
     {
-        return ShipmentOptions::INSURANCE;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['insurance']);
     }
 
-    public function getPropositionKey(): ?string
+    public function getCapabilitiesOptionsKey(): ?string
     {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_INSURANCE_NAME;
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['insurance'];
     }
 
-    public function validate(CarrierSchema $carrierSchema): bool
+    public function getAllowSettingsKey(): ?string
     {
-        return $carrierSchema->canHaveInsurance();
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getShipmentOptionsCast(): string
+    {
+        return 'int';
     }
 }

--- a/src/App/Options/Definition/LargeFormatDefinition.php
+++ b/src/App/Options/Definition/LargeFormatDefinition.php
@@ -4,37 +4,29 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class LargeFormatDefinition implements OrderOptionDefinitionInterface
+final class LargeFormatDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
-    {
-        return CarrierSettings::EXPORT_LARGE_FORMAT;
-    }
-
-    public function getProductSettingsKey(): ?string
-    {
-        return ProductSettings::EXPORT_LARGE_FORMAT;
-    }
-
     public function getShipmentOptionsKey(): ?string
     {
-        return ShipmentOptions::LARGE_FORMAT;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['large_format']);
     }
 
-    public function getPropositionKey(): ?string
+    public function getCapabilitiesOptionsKey(): ?string
     {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_LARGE_FORMAT_NAME;
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['oversized_package'];
     }
 
-    public function validate(CarrierSchema $carrierSchema): bool
+    public function getAllowSettingsKey(): ?string
     {
-        return $carrierSchema->canHaveLargeFormat();
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
+    {
+        return null;
     }
 }

--- a/src/App/Options/Definition/OnlyRecipientDefinition.php
+++ b/src/App/Options/Definition/OnlyRecipientDefinition.php
@@ -4,37 +4,19 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class OnlyRecipientDefinition implements OrderOptionDefinitionInterface
+final class OnlyRecipientDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
-    {
-        return CarrierSettings::EXPORT_ONLY_RECIPIENT;
-    }
-
-    public function getProductSettingsKey(): ?string
-    {
-        return ProductSettings::EXPORT_ONLY_RECIPIENT;
-    }
-
     public function getShipmentOptionsKey(): ?string
     {
-        return ShipmentOptions::ONLY_RECIPIENT;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['only_recipient']);
     }
 
-    public function getPropositionKey(): ?string
+    public function getCapabilitiesOptionsKey(): ?string
     {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_ONLY_RECIPIENT_NAME;
-    }
-
-    public function validate(CarrierSchema $carrierSchema): bool
-    {
-        return $carrierSchema->canHaveOnlyRecipient();
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['recipient_only_delivery'];
     }
 }

--- a/src/App/Options/Definition/PackageTypeDefinition.php
+++ b/src/App/Options/Definition/PackageTypeDefinition.php
@@ -4,28 +4,31 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
 use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
 
-final class PackageTypeDefinition implements OrderOptionDefinitionInterface
+final class PackageTypeDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
+    public function getShipmentOptionsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
     {
         return null;
     }
 
     public function getProductSettingsKey(): ?string
     {
-        return ProductSettings::PACKAGE_TYPE;
+        return 'packageType';
     }
 
-    public function getShipmentOptionsKey(): ?string
+    public function getAllowSettingsKey(): ?string
     {
         return null;
     }
 
-    public function getPropositionKey(): ?string
+    public function getPriceSettingsKey(): ?string
     {
         return null;
     }

--- a/src/App/Options/Definition/PriorityDeliveryDefinition.php
+++ b/src/App/Options/Definition/PriorityDeliveryDefinition.php
@@ -4,38 +4,29 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class PriorityDeliveryDefinition implements OrderOptionDefinitionInterface
+final class PriorityDeliveryDefinition extends AbstractOrderOptionDefinition
 {
+    public function getShipmentOptionsKey(): ?string
+    {
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['priority_delivery']);
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
+    {
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['priority_delivery'];
+    }
+
     public function getCarrierSettingsKey(): ?string
     {
-        return CarrierSettings::ALLOW_PRIORITY_DELIVERY;
+        return 'allowPriorityDelivery';
     }
 
     public function getProductSettingsKey(): ?string
     {
         return null;
-    }
-
-    public function getShipmentOptionsKey(): ?string
-    {
-        return ShipmentOptions::PRIORITY_DELIVERY;
-    }
-
-    public function getPropositionKey(): ?string
-    {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_PRIORITY_DELIVERY_NAME;
-    }
-
-    public function validate(CarrierSchema $carrierSchema): bool
-    {
-        return $carrierSchema->hasShipmentOptionName(
-            PropositionCarrierFeatures::SHIPMENT_OPTION_PRIORITY_DELIVERY_NAME
-        );
     }
 }

--- a/src/App/Options/Definition/PriorityDeliveryDefinition.php
+++ b/src/App/Options/Definition/PriorityDeliveryDefinition.php
@@ -19,14 +19,4 @@ final class PriorityDeliveryDefinition extends AbstractOrderOptionDefinition
     {
         return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['priority_delivery'];
     }
-
-    public function getCarrierSettingsKey(): ?string
-    {
-        return 'allowPriorityDelivery';
-    }
-
-    public function getProductSettingsKey(): ?string
-    {
-        return null;
-    }
 }

--- a/src/App/Options/Definition/ReceiptCodeDefinition.php
+++ b/src/App/Options/Definition/ReceiptCodeDefinition.php
@@ -4,37 +4,34 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class ReceiptCodeDefinition implements OrderOptionDefinitionInterface
+final class ReceiptCodeDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
+    public function getShipmentOptionsKey(): ?string
     {
-        return CarrierSettings::EXPORT_RECEIPT_CODE;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['receipt_code']);
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
+    {
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['requires_receipt_code'];
+    }
+
+    public function getAllowSettingsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
+    {
+        return null;
     }
 
     public function getProductSettingsKey(): ?string
     {
         return null;
-    }
-
-    public function getShipmentOptionsKey(): ?string
-    {
-        return ShipmentOptions::RECEIPT_CODE;
-    }
-
-    public function getPropositionKey(): ?string
-    {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_RECEIPT_CODE_NAME;
-    }
-
-    public function validate(CarrierSchema $carrierSchema): bool
-    {
-        return $carrierSchema->canHaveReceiptCode();
     }
 }

--- a/src/App/Options/Definition/SameDayDeliveryDefinition.php
+++ b/src/App/Options/Definition/SameDayDeliveryDefinition.php
@@ -4,14 +4,28 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class SameDayDeliveryDefinition implements OrderOptionDefinitionInterface
+final class SameDayDeliveryDefinition extends AbstractOrderOptionDefinition
 {
+    public function getShipmentOptionsKey(): ?string
+    {
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['same_day_delivery']);
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
+    {
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['same_day_delivery'];
+    }
+
     public function getCarrierSettingsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
     {
         return null;
     }
@@ -19,20 +33,5 @@ final class SameDayDeliveryDefinition implements OrderOptionDefinitionInterface
     public function getProductSettingsKey(): ?string
     {
         return null;
-    }
-
-    public function getShipmentOptionsKey(): ?string
-    {
-        return ShipmentOptions::SAME_DAY_DELIVERY;
-    }
-
-    public function getPropositionKey(): ?string
-    {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_SAME_DAY_DELIVERY_NAME;
-    }
-
-    public function validate(CarrierSchema $carrierSchema): bool
-    {
-        return $carrierSchema->canHaveSameDayDelivery();
     }
 }

--- a/src/App/Options/Definition/SaturdayDeliveryDefinition.php
+++ b/src/App/Options/Definition/SaturdayDeliveryDefinition.php
@@ -4,14 +4,28 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class SaturdayDeliveryDefinition implements OrderOptionDefinitionInterface
+final class SaturdayDeliveryDefinition extends AbstractOrderOptionDefinition
 {
+    public function getShipmentOptionsKey(): ?string
+    {
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['saturday_delivery']);
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
+    {
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['saturday_delivery'];
+    }
+
     public function getCarrierSettingsKey(): ?string
+    {
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
     {
         return null;
     }
@@ -19,20 +33,5 @@ final class SaturdayDeliveryDefinition implements OrderOptionDefinitionInterface
     public function getProductSettingsKey(): ?string
     {
         return null;
-    }
-
-    public function getShipmentOptionsKey(): ?string
-    {
-        return ShipmentOptions::SATURDAY_DELIVERY;
-    }
-
-    public function getPropositionKey(): ?string
-    {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_SATURDAY_DELIVERY_NAME;
-    }
-
-    public function validate(CarrierSchema $carrierSchema): bool
-    {
-        return $carrierSchema->canHaveSaturdayDelivery();
     }
 }

--- a/src/App/Options/Definition/SignatureDefinition.php
+++ b/src/App/Options/Definition/SignatureDefinition.php
@@ -4,37 +4,19 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class SignatureDefinition implements OrderOptionDefinitionInterface
+final class SignatureDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
-    {
-        return CarrierSettings::EXPORT_SIGNATURE;
-    }
-
-    public function getProductSettingsKey(): ?string
-    {
-        return ProductSettings::EXPORT_SIGNATURE;
-    }
-
     public function getShipmentOptionsKey(): ?string
     {
-        return ShipmentOptions::SIGNATURE;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['signature']);
     }
 
-    public function getPropositionKey(): ?string
+    public function getCapabilitiesOptionsKey(): ?string
     {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_SIGNATURE_NAME;
-    }
-
-    public function validate(CarrierSchema $carrierSchema): bool
-    {
-        return $carrierSchema->canHaveSignature();
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['requires_signature'];
     }
 }

--- a/src/App/Options/Definition/TrackedDefinition.php
+++ b/src/App/Options/Definition/TrackedDefinition.php
@@ -4,37 +4,29 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Options\Definition;
 
-use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
-use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Settings\Model\ProductSettings;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
-use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentShipmentOptions;
+use MyParcelNL\Sdk\Support\Str;
 
-final class TrackedDefinition implements OrderOptionDefinitionInterface
+final class TrackedDefinition extends AbstractOrderOptionDefinition
 {
-    public function getCarrierSettingsKey(): ?string
-    {
-        return CarrierSettings::EXPORT_TRACKED;
-    }
-
-    public function getProductSettingsKey(): ?string
-    {
-        return ProductSettings::EXPORT_TRACKED;
-    }
-
     public function getShipmentOptionsKey(): ?string
     {
-        return ShipmentOptions::TRACKED;
+        return Str::camel(RefShipmentShipmentOptions::attributeMap()['tracked']);
     }
 
-    public function getPropositionKey(): ?string
+    public function getCapabilitiesOptionsKey(): ?string
     {
-        return PropositionCarrierFeatures::SHIPMENT_OPTION_TRACKED_NAME;
+        return RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()['tracked'];
     }
 
-    public function validate(CarrierSchema $carrierSchema): bool
+    public function getAllowSettingsKey(): ?string
     {
-        return $carrierSchema->canHaveTracked();
+        return null;
+    }
+
+    public function getPriceSettingsKey(): ?string
+    {
+        return null;
     }
 }

--- a/src/App/Options/Helper/CapabilitiesDefaultHelper.php
+++ b/src/App/Options/Helper/CapabilitiesDefaultHelper.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\App\Options\Helper;
+
+use MyParcelNL\Pdk\App\Options\Contract\OptionDefinitionHelperInterface;
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
+use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\Types\Service\TriStateService;
+
+/**
+ * Provides isSelectedByDefault from carrier capabilities as the lowest-priority default.
+ *
+ * Sits at the end of the resolution chain so it only takes effect when all other
+ * sources (shipment options, product settings, carrier settings) are INHERIT.
+ */
+final class CapabilitiesDefaultHelper implements OptionDefinitionHelperInterface
+{
+    /**
+     * @var \MyParcelNL\Pdk\App\Order\Model\PdkOrder
+     */
+    private $order;
+
+    /**
+     * @param  \MyParcelNL\Pdk\App\Order\Model\PdkOrder $order
+     */
+    public function __construct(PdkOrder $order)
+    {
+        $this->order = $order;
+    }
+
+    /**
+     * @param  \MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface $definition
+     *
+     * @return int
+     */
+    public function get(OrderOptionDefinitionInterface $definition)
+    {
+        $capabilitiesKey = $definition->getCapabilitiesOptionsKey();
+
+        if (! $capabilitiesKey) {
+            return TriStateService::INHERIT;
+        }
+
+        $carrier = $this->order->deliveryOptions->carrier;
+
+        $option = $carrier->getOptionMetadata($capabilitiesKey);
+
+        if ($option && ($option->getIsRequired() || $option->getIsSelectedByDefault())) {
+            return TriStateService::ENABLED;
+        }
+
+        return TriStateService::INHERIT;
+    }
+}

--- a/src/App/Order/Calculator/General/InsuranceCalculator.php
+++ b/src/App/Order/Calculator/General/InsuranceCalculator.php
@@ -19,12 +19,14 @@ use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
 final class InsuranceCalculator extends AbstractPdkOrderOptionCalculator
 {
     /**
-     * Placeholder until we can get this from the Capabilities API.
+     * Schema path used to resolve carrier- and context-specific insurance tier deviations from the base JSON schemas.
+     * The JSON schemas act as an override for specific carrier/country/packageType/deliveryType combinations.
      *
-     * @deprecated This is a temporary solution and should be replaced with a proper implementation through the Capabilities API.
+     * @TODO INT-930: replace schema-based tier deviations with capabilities API tier lists when the API supports
+     *               explicit per-carrier tier definitions.
      * @var string
      */
-    public const INSURANCE_SCHEMA_PREFIX = 'properties.deliveryOptions.properties.shipmentOptions.properties.' . ShipmentOptions::INSURANCE;
+    public const INSURANCE_SCHEMA_PREFIX = 'properties.deliveryOptions.properties.shipmentOptions.properties.insurance';
 
     /**
      * @var \MyParcelNL\Pdk\Base\Contract\CountryServiceInterface

--- a/src/App/Order/Calculator/General/PackageTypeShipmentOptionsCalculator.php
+++ b/src/App/Order/Calculator/General/PackageTypeShipmentOptionsCalculator.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\App\Order\Calculator\General;
 
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
 use MyParcelNL\Pdk\App\Order\Calculator\AbstractPdkOrderOptionCalculator;
-use MyParcelNL\Pdk\Base\Service\CountryCodes;
+use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
 use MyParcelNL\Pdk\Types\Service\TriStateService;
 
 /**
  * Disables all shipment options if package type is not package.
+ * Iterates registered definitions so new options are automatically included.
  */
 final class PackageTypeShipmentOptionsCalculator extends AbstractPdkOrderOptionCalculator
 {
@@ -23,16 +24,19 @@ final class PackageTypeShipmentOptionsCalculator extends AbstractPdkOrderOptionC
             return;
         }
 
-        $this->order->deliveryOptions->shipmentOptions->fill([
-            ShipmentOptions::AGE_CHECK         => TriStateService::DISABLED,
-            ShipmentOptions::DIRECT_RETURN     => TriStateService::DISABLED,
-            ShipmentOptions::HIDE_SENDER       => TriStateService::DISABLED,
-            ShipmentOptions::LARGE_FORMAT      => TriStateService::DISABLED,
-            ShipmentOptions::ONLY_RECIPIENT    => TriStateService::DISABLED,
-            ShipmentOptions::SAME_DAY_DELIVERY => TriStateService::DISABLED,
-            ShipmentOptions::SIGNATURE         => TriStateService::DISABLED,
-            ShipmentOptions::RECEIPT_CODE      => TriStateService::DISABLED,
-        ]);
-    }
+        /** @var OrderOptionDefinitionInterface[] $definitions */
+        $definitions = Pdk::get('orderOptionDefinitions');
 
+        $disabled = [];
+
+        foreach ($definitions as $definition) {
+            $key = $definition->getShipmentOptionsKey();
+
+            if ($key !== null) {
+                $disabled[$key] = TriStateService::DISABLED;
+            }
+        }
+
+        $this->order->deliveryOptions->shipmentOptions->fill($disabled);
+    }
 }

--- a/src/Base/Concern/ResolvesOptionAttributes.php
+++ b/src/Base/Concern/ResolvesOptionAttributes.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Base\Concern;
+
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
+use MyParcelNL\Pdk\Facade\Pdk;
+
+trait ResolvesOptionAttributes
+{
+    /**
+     * Build arrays of attributes and casts from registered option definitions.
+     *
+     * @param  callable(OrderOptionDefinitionInterface): ?string $keyExtractor
+     * @param  mixed                                             $default
+     * @param  callable(OrderOptionDefinitionInterface): string  $castExtractor
+     *
+     * @return array{0: array, 1: array} [$attributes, $casts]
+     */
+    protected function resolveOptionAttributes(callable $keyExtractor, $default, callable $castExtractor): array
+    {
+        /** @var OrderOptionDefinitionInterface[] $definitions */
+        $definitions = Pdk::get('orderOptionDefinitions');
+        $attributes  = [];
+        $casts       = [];
+
+        foreach ($definitions as $definition) {
+            $key = $keyExtractor($definition);
+
+            if ($key !== null) {
+                $attributes[$key] = $default;
+                $casts[$key]      = $castExtractor($definition);
+            }
+        }
+
+        return [$attributes, $casts];
+    }
+}

--- a/src/Base/Support/Utils.php
+++ b/src/Base/Support/Utils.php
@@ -20,6 +20,11 @@ class Utils extends \MyParcelNL\Sdk\Helper\Utils
      */
     private static $classCastCache = [];
 
+    public static function clearCastCache(): void
+    {
+        self::$classCastCache = [];
+    }
+
     /**
      * @template T
      * @param  class-string<T> $class

--- a/src/Carrier/Concern/HasCarrierAttribute.php
+++ b/src/Carrier/Concern/HasCarrierAttribute.php
@@ -32,7 +32,7 @@ trait HasCarrierAttribute
      */
     public function getCarrierAttribute(): Carrier
     {
-        $carrierName = $this->attributes['carrier'];
+        $carrierName = $this->attributes['carrier'] ?? null;
 
         if (! $carrierName) {
             return Pdk::get(PropositionService::class)->getDefaultCarrier();

--- a/src/Frontend/View/CarrierSettingsItemView.php
+++ b/src/Frontend/View/CarrierSettingsItemView.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\Frontend\View;
 
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
+use MyParcelNL\Pdk\App\Options\Definition\AgeCheckDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\InsuranceDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\LargeFormatDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\OnlyRecipientDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\SameDayDeliveryDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\SaturdayDeliveryDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\SignatureDefinition;
+use MyParcelNL\Pdk\App\Options\Definition\TrackedDefinition;
 use MyParcelNL\Pdk\App\Service\DeliveryOptionsResetService;
 use MyParcelNL\Pdk\Base\Contract\CurrencyServiceInterface;
 use MyParcelNL\Pdk\Carrier\Model\Carrier;
@@ -14,12 +23,11 @@ use MyParcelNL\Pdk\Frontend\Form\Builder\FormOperationBuilder;
 use MyParcelNL\Pdk\Frontend\Form\Components;
 use MyParcelNL\Pdk\Frontend\Form\InteractiveElement;
 use MyParcelNL\Pdk\Frontend\Form\SettingsDivider;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
 use MyParcelNL\Pdk\Proposition\Service\PropositionService;
 use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
-use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
 use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageTypeV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesDeliveryTypeV2;
 use MyParcelNL\Sdk\Support\Str;
 
 /**
@@ -73,7 +81,6 @@ class CarrierSettingsItemView extends AbstractSettingsView
         $schema->setCarrier($carrier);
 
         $this->carrierSchema = $schema;
-
     }
 
     /**
@@ -90,18 +97,6 @@ class CarrierSettingsItemView extends AbstractSettingsView
     public function getTitle(): string
     {
         return "carrier_{$this->getFormattedCarrierName()}";
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getTitleSuffix(): ?string
-    {
-        if ($this->carrier->isDefault) {
-            return null;
-        }
-
-        return sprintf('%s_type_%s', $this->getLabelPrefix(), $this->carrier->type);
     }
 
     /**
@@ -149,7 +144,7 @@ class CarrierSettingsItemView extends AbstractSettingsView
      */
     private function createInsuranceElement(string $name): InteractiveElement
     {
-        $hasInsurance = $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_INSURANCE_NAME);
+        $hasInsurance = $this->carrierSchema->canHaveShipmentOption(InsuranceDefinition::class);
 
         if ($hasInsurance) {
             $insuranceAmounts = $this->carrier->outboundFeatures['metadata']['insuranceOptions'] ?? [];
@@ -179,11 +174,13 @@ class CarrierSettingsItemView extends AbstractSettingsView
         );
 
         // Add tracked toggle for carriers with custom mailbox contract, only visible when international mailbox is enabled
-        if ($this->carrierSchema->canHaveTracked() && AccountSettings::hasCarrierSmallPackageContract()) {
-            $fields[] = (new InteractiveElement(CarrierSettings::EXPORT_TRACKED, Components::INPUT_TOGGLE))
+        if ($this->carrierSchema->canHaveShipmentOption(TrackedDefinition::class) && AccountSettings::hasCarrierSmallPackageContract()) {
+            $trackedElement = (new InteractiveElement(CarrierSettings::EXPORT_TRACKED, Components::INPUT_TOGGLE))
                 ->builder(function (FormOperationBuilder $builder) {
                     $builder->visibleWhen(CarrierSettings::ALLOW_INTERNATIONAL_MAILBOX);
                 });
+            $this->makeReadOnlyWhenRequired($trackedElement, 'tracked');
+            $fields[] = $trackedElement;
         }
 
         return $fields;
@@ -236,80 +233,111 @@ class CarrierSettingsItemView extends AbstractSettingsView
      */
     private function getDefaultExportFields(): array
     {
-        return [
-            /**
-             * Export settings for regular shipments.
-             */
-            new SettingsDivider($this->createGenericLabel('export')),
+        /** @var OrderOptionDefinitionInterface[] $definitions */
+        $definitions = Pdk::get('orderOptionDefinitions');
 
-            $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_AGE_CHECK_NAME)
-                ? [
-                (new InteractiveElement(CarrierSettings::EXPORT_AGE_CHECK, Components::INPUT_TOGGLE))
-                    ->builder(function (FormOperationBuilder $builder) {
-                        $builder->afterUpdate(function (FormAfterUpdateBuilder $afterUpdate) {
-                            $afterUpdate
-                                ->setValue(true)
-                                ->on(CarrierSettings::EXPORT_SIGNATURE)
-                                ->if->eq(true);
-
-                            $afterUpdate
-                                ->setValue(true)
-                                ->on(CarrierSettings::EXPORT_ONLY_RECIPIENT)
-                                ->if->eq(true);
-                        });
-                    }),
-            ]
-                : [],
-
-            // Disable the signature / only recipient options when age check is enabled. With age check these are mandatory.
-            $this->withOperation(
-                function (FormOperationBuilder $builder) {
-                    if (!$this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_AGE_CHECK_NAME)) {
-                        return;
-                    }
-
-                    $builder->readOnlyWhen(CarrierSettings::EXPORT_AGE_CHECK);
-                },
-                $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_SIGNATURE_NAME)
-                    ? [new InteractiveElement(CarrierSettings::EXPORT_SIGNATURE, Components::INPUT_TOGGLE)]
-                    : [],
-                $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_ONLY_RECIPIENT_NAME)
-                    ? [new InteractiveElement(CarrierSettings::EXPORT_ONLY_RECIPIENT, Components::INPUT_TOGGLE)]
-                    : []
-            ),
-
-            $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_RECEIPT_CODE_NAME) ? [
-                new InteractiveElement(CarrierSettings::EXPORT_RECEIPT_CODE, Components::INPUT_TOGGLE),
-            ] : [],
-
-            $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_LARGE_FORMAT_NAME)
-                ? [new InteractiveElement(CarrierSettings::EXPORT_LARGE_FORMAT, Components::INPUT_TOGGLE)]
-                : [],
-
-            $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_DIRECT_RETURN_NAME)
-                ? [new InteractiveElement(CarrierSettings::EXPORT_RETURN, Components::INPUT_TOGGLE)]
-                : [],
-
-            $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_HIDE_SENDER_NAME)
-                ? [new InteractiveElement(CarrierSettings::EXPORT_HIDE_SENDER, Components::INPUT_TOGGLE)]
-                : [],
-
-            $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_INSURANCE_NAME)
-                ? $this->getExportInsuranceFields()
-                : [],
-
-            $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_COLLECT_NAME)
-                ? [new InteractiveElement(CarrierSettings::EXPORT_COLLECT, Components::INPUT_TOGGLE)]
-                : [],
-
-            $this->carrierSchema->canHaveFreshFood()
-                ? [new InteractiveElement(CarrierSettings::EXPORT_FRESH_FOOD, Components::INPUT_TOGGLE)]
-                : [],
-
-            $this->carrierSchema->canHaveFrozen()
-                ? [new InteractiveElement(CarrierSettings::EXPORT_FROZEN, Components::INPUT_TOGGLE)]
-                : [],
+        // Definitions with custom UI handling — processed explicitly below, then excluded from the generic loop
+        $specialCasedDefinitions = [
+            AgeCheckDefinition::class,
+            SignatureDefinition::class,
+            OnlyRecipientDefinition::class,
+            InsuranceDefinition::class,
         ];
+
+        $ageCheckDefinition      = null;
+        $signatureDefinition     = null;
+        $onlyRecipientDefinition = null;
+
+        foreach ($definitions as $definition) {
+            if ($definition instanceof AgeCheckDefinition) {
+                $ageCheckDefinition = $definition;
+            } elseif ($definition instanceof SignatureDefinition) {
+                $signatureDefinition = $definition;
+            } elseif ($definition instanceof OnlyRecipientDefinition) {
+                $onlyRecipientDefinition = $definition;
+            }
+        }
+
+        $fields = [
+            new SettingsDivider($this->createGenericLabel('export')),
+        ];
+
+        // Age check toggle with afterUpdate logic (forces signature + only recipient on)
+        if ($ageCheckDefinition && $this->carrierSchema->canHaveShipmentOption($ageCheckDefinition)) {
+            $signatureKey     = $signatureDefinition ? $signatureDefinition->getCarrierSettingsKey() : null;
+            $onlyRecipientKey = $onlyRecipientDefinition ? $onlyRecipientDefinition->getCarrierSettingsKey() : null;
+
+            $ageCheckElement = (new InteractiveElement($ageCheckDefinition->getCarrierSettingsKey(), Components::INPUT_TOGGLE))
+                ->builder(function (FormOperationBuilder $builder) use ($signatureKey, $onlyRecipientKey) {
+                    $builder->afterUpdate(function (FormAfterUpdateBuilder $afterUpdate) use ($signatureKey, $onlyRecipientKey) {
+                        if ($signatureKey) {
+                            $afterUpdate->setValue(true)->on($signatureKey)->if->eq(true);
+                        }
+                        if ($onlyRecipientKey) {
+                            $afterUpdate->setValue(true)->on($onlyRecipientKey)->if->eq(true);
+                        }
+                    });
+                });
+            $this->makeReadOnlyWhenRequired($ageCheckElement, $ageCheckDefinition->getCapabilitiesOptionsKey());
+            $fields[] = [$ageCheckElement];
+        }
+
+        // Signature and only recipient — read-only when age check is enabled
+        $signatureElements     = [];
+        $onlyRecipientElements = [];
+
+        if ($signatureDefinition && $this->carrierSchema->canHaveShipmentOption($signatureDefinition)) {
+            $signatureElement = new InteractiveElement($signatureDefinition->getCarrierSettingsKey(), Components::INPUT_TOGGLE);
+            $this->makeReadOnlyWhenRequired($signatureElement, $signatureDefinition->getCapabilitiesOptionsKey());
+            $signatureElements = [$signatureElement];
+        }
+
+        if ($onlyRecipientDefinition && $this->carrierSchema->canHaveShipmentOption($onlyRecipientDefinition)) {
+            $onlyRecipientElement = new InteractiveElement($onlyRecipientDefinition->getCarrierSettingsKey(), Components::INPUT_TOGGLE);
+            $this->makeReadOnlyWhenRequired($onlyRecipientElement, $onlyRecipientDefinition->getCapabilitiesOptionsKey());
+            $onlyRecipientElements = [$onlyRecipientElement];
+        }
+
+        $fields[] = $this->withOperation(
+            function (FormOperationBuilder $builder) use ($ageCheckDefinition) {
+                if (! $ageCheckDefinition || ! $this->carrierSchema->canHaveShipmentOption($ageCheckDefinition)) {
+                    return;
+                }
+                $builder->readOnlyWhen($ageCheckDefinition->getCarrierSettingsKey());
+            },
+            $signatureElements,
+            $onlyRecipientElements
+        );
+
+        // Generic loop for all other export options
+        foreach ($definitions as $definition) {
+            $carrierKey = $definition->getCarrierSettingsKey();
+
+            if (! $carrierKey || ! $this->carrierSchema->canHaveShipmentOption($definition)) {
+                continue;
+            }
+
+            if (in_array(get_class($definition), $specialCasedDefinitions, true)) {
+                continue;
+            }
+
+            $element = new InteractiveElement($carrierKey, Components::INPUT_TOGGLE);
+
+            $capabilitiesKey = $definition->getCapabilitiesOptionsKey();
+
+            if ($capabilitiesKey) {
+                $this->makeReadOnlyWhenRequired($element, $capabilitiesKey);
+            }
+
+            $fields[] = [$element];
+        }
+
+        // Insurance — custom SELECT UI handled after the generic loop
+        if ($this->carrierSchema->canHaveShipmentOption(InsuranceDefinition::class)) {
+            $fields[] = $this->getExportInsuranceFields();
+        }
+
+        return $fields;
     }
 
     /**
@@ -318,7 +346,7 @@ class CarrierSettingsItemView extends AbstractSettingsView
     private function getDefaultExportReturnsFields(): array
     {
         $hasPackageTypeOptions = !empty($this->carrier->outboundFeatures->packageTypes);
-        $canHaveLargeFormat    = $this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_LARGE_FORMAT_NAME);
+        $canHaveLargeFormat    = $this->carrierSchema->canHaveShipmentOption(LargeFormatDefinition::class);
 
         if (! $hasPackageTypeOptions && ! $canHaveLargeFormat) {
             return [];
@@ -331,7 +359,7 @@ class CarrierSettingsItemView extends AbstractSettingsView
                 CarrierSettings::EXPORT_RETURN_PACKAGE_TYPE,
                 Components::INPUT_SELECT,
                 [
-                    'options' => $this->createPackageTypeOptions($this->carrier->outboundFeatures->packageTypes),
+                    'options' => $this->createPackageTypeOptions($this->carrier->packageTypes),
                 ]
             );
         }
@@ -416,14 +444,16 @@ class CarrierSettingsItemView extends AbstractSettingsView
         $elements[] = $this->withOperation(
             function (FormOperationBuilder $builder) {
                 $builder->visibleWhen(CarrierSettings::DELIVERY_OPTIONS_ENABLED)
-                ->and(CarrierSettings::ALLOW_DELIVERY_OPTIONS); // "allow home delivery" toggle
+                    ->and(CarrierSettings::ALLOW_DELIVERY_OPTIONS); // "allow home delivery" toggle
             },
             ...$homeDeliveryOptionsConfig
         );
 
         // Show pickup locations
-        if ($this->carrier->outboundFeatures['deliveryTypes'] &&
-            in_array(PropositionCarrierFeatures::DELIVERY_TYPE_PICKUP_NAME, $this->carrier->outboundFeatures['deliveryTypes'])) {
+        if (
+            $this->carrier->deliveryTypes &&
+            in_array(RefTypesDeliveryTypeV2::PICKUP, $this->carrier->deliveryTypes, true)
+        ) {
             $pickupDeliveryOptionsConfig[] = new SettingsDivider($this->createGenericLabel('delivery_options_pickup'), SettingsDivider::LEVEL_3);
             $pickupDeliveryOptionsConfig = array_merge(
                 $pickupDeliveryOptionsConfig,
@@ -450,14 +480,14 @@ class CarrierSettingsItemView extends AbstractSettingsView
      */
     private function getSameDayDeliverySettings(): array
     {
-        if (!$this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::DELIVERY_TYPE_SAME_DAY_NAME)) {
+        if (!$this->carrierSchema->canHaveShipmentOption(SameDayDeliveryDefinition::class)) {
             return [];
         }
 
         return array_merge(
             $this->createSettingWithPriceFields(
                 CarrierSettings::ALLOW_SAME_DAY_DELIVERY,
-                CarrierSettings::PRICE_DELIVERY_TYPE_SAME_DAY
+                CarrierSettings::PRICE_DELIVERY_TYPE_SAME_DAY_DELIVERY
             ),
             [new InteractiveElement(CarrierSettings::CUTOFF_TIME_SAME_DAY, Components::INPUT_TIME)]
         );
@@ -468,13 +498,13 @@ class CarrierSettingsItemView extends AbstractSettingsView
      */
     private function getSaturdayDeliverySettings(): array
     {
-        if (!$this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_SATURDAY_DELIVERY_NAME)) {
+        if (!$this->carrierSchema->canHaveShipmentOption(SaturdayDeliveryDefinition::class)) {
             return [];
         }
 
         return $this->createSettingWithPriceFields(
             CarrierSettings::ALLOW_SATURDAY_DELIVERY,
-            CarrierSettings::PRICE_DELIVERY_TYPE_SATURDAY
+            CarrierSettings::PRICE_DELIVERY_TYPE_SATURDAY_DELIVERY
         );
     }
 
@@ -483,13 +513,13 @@ class CarrierSettingsItemView extends AbstractSettingsView
      */
     private function getMondayDeliverySettings(): array
     {
-        if (!$this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_MONDAY_DELIVERY_NAME)) {
+        if (!$this->carrierSchema->canHaveMondayDelivery()) {
             return [];
         }
 
         return $this->createSettingWithPriceFields(
             CarrierSettings::ALLOW_MONDAY_DELIVERY,
-            CarrierSettings::PRICE_DELIVERY_TYPE_MONDAY
+            CarrierSettings::PRICE_DELIVERY_TYPE_MONDAY_DELIVERY
         );
     }
 
@@ -500,24 +530,34 @@ class CarrierSettingsItemView extends AbstractSettingsView
     {
         $settings = [];
 
-        if (!$this->carrier->outboundFeatures['deliveryTypes']) {
+        if (!$this->carrier->deliveryTypes) {
             return $settings;
         }
 
-        foreach ($this->carrier->outboundFeatures['deliveryTypes'] as $deliveryType) {
-            // Convert new delivery type names to the ones used for delivery options
-            $deliveryType = $this->propositionService->deliveryTypeNameForDeliveryOptions($deliveryType);
-
+        foreach ($this->carrier->deliveryTypes as $deliveryType) {
             // Ignore unsupported types and pickup (pickup is handled in a separate section in getDeliveryOptionsFields())
-            if ($deliveryType === null || $deliveryType === DeliveryOptions::DELIVERY_TYPE_PICKUP_NAME) {
+            if ($deliveryType === RefTypesDeliveryTypeV2::PICKUP) {
+                continue;
+            }
+
+            // @TODO: in the future, make this fully dynamic by also allowing custom delivery types from carriers and not relying on predefined constants
+            if (\defined(CarrierSettings::class . "::ALLOW_" . strtoupper($deliveryType))) {
+                $typeAllowedSetting = constant(CarrierSettings::class . "::ALLOW_" . strtoupper($deliveryType));
+            } else {
+                continue;
+            }
+
+            if (\defined(CarrierSettings::class . "::PRICE_DELIVERY_TYPE_" . strtoupper($deliveryType))) {
+                $typePriceSetting = constant(CarrierSettings::class . "::PRICE_DELIVERY_TYPE_" . strtoupper($deliveryType));
+            } else {
                 continue;
             }
 
             $settings = array_merge(
                 $settings,
                 $this->createSettingWithPriceFields(
-                    constant(CarrierSettings::class . "::ALLOW_" . strtoupper($deliveryType) . "_DELIVERY"),
-                    constant(CarrierSettings::class . "::PRICE_DELIVERY_TYPE_" . strtoupper($deliveryType))
+                    $typeAllowedSetting,
+                    $typePriceSetting
                 )
             );
         }
@@ -526,43 +566,36 @@ class CarrierSettingsItemView extends AbstractSettingsView
     }
 
     /**
-     * Get shipment options settings based on carrier capabilities
+     * Get shipment options settings based on carrier capabilities.
+     * Uses registered option definitions to dynamically build delivery options toggles.
      */
     private function getShipmentOptionsSettings(): array
     {
-        $settings = [];
+        /** @var OrderOptionDefinitionInterface[] $definitions */
+        $definitions = Pdk::get('orderOptionDefinitions');
+        $settings    = [];
 
-        // Signature option
-        if ($this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_SIGNATURE_NAME)) {
-            $settings = array_merge(
-                $settings,
-                $this->createSettingWithPriceFields(
-                    CarrierSettings::ALLOW_SIGNATURE,
-                    CarrierSettings::PRICE_SIGNATURE
-                )
-            );
-        }
+        foreach ($definitions as $definition) {
+            $allowKey = $definition->getAllowSettingsKey();
+            $priceKey = $definition->getPriceSettingsKey();
 
-        // Only recipient option
-        if ($this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_ONLY_RECIPIENT_NAME)) {
-            $settings = array_merge(
-                $settings,
-                $this->createSettingWithPriceFields(
-                    CarrierSettings::ALLOW_ONLY_RECIPIENT,
-                    CarrierSettings::PRICE_ONLY_RECIPIENT
-                )
-            );
-        }
+            if (! $allowKey || ! $this->carrierSchema->canHaveShipmentOption($definition)) {
+                continue;
+            }
 
-        // Priority delivery option
-        if ($this->carrierSchema->hasShipmentOptionName(PropositionCarrierFeatures::SHIPMENT_OPTION_PRIORITY_DELIVERY_NAME)) {
-            $settings = array_merge(
-                $settings,
-                $this->createSettingWithPriceFields(
-                    CarrierSettings::ALLOW_PRIORITY_DELIVERY,
-                    CarrierSettings::PRICE_PRIORITY_DELIVERY
-                )
-            );
+            if ($priceKey) {
+                $elements = $this->createSettingWithPriceFields($allowKey, $priceKey);
+            } else {
+                $elements = [new InteractiveElement($allowKey, Components::INPUT_TOGGLE)];
+            }
+
+            $capabilitiesKey = $definition->getCapabilitiesOptionsKey();
+
+            if ($capabilitiesKey) {
+                $this->makeReadOnlyWhenRequired($elements[0], $capabilitiesKey);
+            }
+
+            $settings = array_merge($settings, $elements);
         }
 
         return $settings;
@@ -607,12 +640,32 @@ class CarrierSettingsItemView extends AbstractSettingsView
     }
 
     /**
+     * Mark a form element as read-only when the carrier's capability metadata indicates it is required.
+     *
+     * @param  \MyParcelNL\Pdk\Frontend\Form\InteractiveElement $element
+     * @param  string                                           $capabilitiesKey
+     *
+     * @return void
+     */
+    private function makeReadOnlyWhenRequired(InteractiveElement $element, string $capabilitiesKey): void
+    {
+        $option = $this->carrier->getOptionMetadata($capabilitiesKey);
+
+        if (! $option || ! $option->getIsRequired()) {
+            return;
+        }
+
+        $element->builder(function (FormOperationBuilder $builder) {
+            $builder->readOnlyWhen();
+        });
+    }
+
+    /**
      * @return string
      */
     private function getFormattedCarrierName(): string
     {
-        $legacyName = Carrier::CARRIER_NAME_TO_LEGACY_MAP[$this->carrier->name] ?? $this->carrier->name;
-        return Str::snake(str_replace('.', '_', strtolower($legacyName)));
+        return Str::snake(str_replace('.', '_', Str::lower($this->carrier->carrier)));
     }
 
     /**
@@ -620,7 +673,7 @@ class CarrierSettingsItemView extends AbstractSettingsView
      */
     private function getPackageTypeFields(): array
     {
-        $allowedPackageTypes = $this->carrier->outboundFeatures->packageTypes ?? [];
+        $allowedPackageTypes = $this->carrier->packageTypes ?? [];
 
         $fields = [
             new InteractiveElement(CarrierSettings::DEFAULT_PACKAGE_TYPE, Components::INPUT_SELECT, [
@@ -628,14 +681,14 @@ class CarrierSettingsItemView extends AbstractSettingsView
             ]),
         ];
 
-        if (in_array(PropositionCarrierFeatures::PACKAGE_TYPE_PACKAGE_SMALL_NAME, $allowedPackageTypes, true)) {
+        if (in_array(RefShipmentPackageTypeV2::SMALL_PACKAGE, $allowedPackageTypes, true)) {
             $fields[] = new InteractiveElement(
                 CarrierSettings::PRICE_PACKAGE_TYPE_PACKAGE_SMALL,
                 Components::INPUT_CURRENCY
             );
         }
 
-        if (in_array(PropositionCarrierFeatures::PACKAGE_TYPE_MAILBOX_NAME, $allowedPackageTypes, true)) {
+        if (in_array(RefShipmentPackageTypeV2::MAILBOX, $allowedPackageTypes, true)) {
             $fields[] = new InteractiveElement(
                 CarrierSettings::PRICE_PACKAGE_TYPE_MAILBOX,
                 Components::INPUT_CURRENCY
@@ -644,7 +697,7 @@ class CarrierSettingsItemView extends AbstractSettingsView
             $fields[] = $this->createInternationalMailboxFields();
         }
 
-        if (in_array(PropositionCarrierFeatures::PACKAGE_TYPE_DIGITAL_STAMP_NAME, $allowedPackageTypes, true)) {
+        if (in_array(RefShipmentPackageTypeV2::DIGITAL_STAMP, $allowedPackageTypes, true)) {
             $fields[] = new InteractiveElement(
                 CarrierSettings::PRICE_PACKAGE_TYPE_DIGITAL_STAMP,
                 Components::INPUT_CURRENCY

--- a/src/Frontend/View/ProductSettingsView.php
+++ b/src/Frontend/View/ProductSettingsView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\Frontend\View;
 
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
 use MyParcelNL\Pdk\Base\Contract\CountryServiceInterface;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Frontend\Form\Components;
@@ -85,18 +86,41 @@ class ProductSettingsView extends AbstractSettingsView
             ),
 
             /**
-             * Export options.
+             * Export options — dynamically built from definitions that have both
+             * a product settings key and a shipment options key. Product-only
+             * definitions (countryOfOrigin, customsCode, etc.) stay in their
+             * dedicated sections above.
              */
             new SettingsDivider($this->getSettingKey('export_options')),
-            new InteractiveElement(ProductSettings::EXPORT_AGE_CHECK, Components::INPUT_TRI_STATE),
-            new InteractiveElement(ProductSettings::EXPORT_INSURANCE, Components::INPUT_TRI_STATE),
-            new InteractiveElement(ProductSettings::EXPORT_LARGE_FORMAT, Components::INPUT_TRI_STATE),
-            new InteractiveElement(ProductSettings::EXPORT_ONLY_RECIPIENT, Components::INPUT_TRI_STATE),
-            new InteractiveElement(ProductSettings::EXPORT_SIGNATURE, Components::INPUT_TRI_STATE),
-            new InteractiveElement(ProductSettings::EXPORT_RETURN, Components::INPUT_TRI_STATE),
-            new InteractiveElement(ProductSettings::EXPORT_FRESH_FOOD, Components::INPUT_TRI_STATE),
-            new InteractiveElement(ProductSettings::EXPORT_FROZEN, Components::INPUT_TRI_STATE),
+            ...$this->getExportOptionElements(),
         ];
+    }
+
+    /**
+     * Build export option elements from registered definitions.
+     * Only includes definitions with both a product settings key and a shipment options key —
+     * product-only settings (countryOfOrigin, packageType, etc.) are rendered in dedicated sections.
+     *
+     * @return InteractiveElement[]
+     */
+    private function getExportOptionElements(): array
+    {
+        /** @var OrderOptionDefinitionInterface[] $definitions */
+        $definitions = Pdk::get('orderOptionDefinitions');
+        $elements    = [];
+
+        foreach ($definitions as $definition) {
+            $productKey  = $definition->getProductSettingsKey();
+            $shipmentKey = $definition->getShipmentOptionsKey();
+
+            if (! $productKey || ! $shipmentKey) {
+                continue;
+            }
+
+            $elements[] = new InteractiveElement($productKey, Components::INPUT_TRI_STATE);
+        }
+
+        return $elements;
     }
 
     /**

--- a/src/Fulfilment/Model/ShipmentOptions.php
+++ b/src/Fulfilment/Model/ShipmentOptions.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\Fulfilment\Model;
 
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
 use MyParcelNL\Pdk\App\Order\Contract\PdkOrderOptionsServiceInterface;
 use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\Base\Concern\ResolvesOptionAttributes;
 use MyParcelNL\Pdk\Base\Model\Model;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
+use MyParcelNL\Pdk\Types\Service\TriStateService;
 
 /**
  * @property bool   $ageCheck
@@ -24,6 +27,7 @@ use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
  * @property bool   $onlyRecipient
  * @property bool   $priorityDelivery
  * @property int    $packageType
+ * @property bool   $receiptCode
  * @property bool   $return
  * @property bool   $sameDayDelivery
  * @property bool   $saturdayDelivery
@@ -31,43 +35,45 @@ use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
  */
 class ShipmentOptions extends Model
 {
+    use ResolvesOptionAttributes;
+
+    // Non-option attributes remain static
     public $attributes = [
-        'ageCheck'         => null,
-        'collect'          => null,
-        'cooledDelivery'   => null,
         'deliveryDate'     => null,
         'deliveryType'     => null,
-        'hideSender'       => null,
-        'insurance'        => null,
         'labelDescription' => '',
-        'largeFormat'      => null,
-        'onlyRecipient'    => null,
-        'priorityDelivery' => null,
         'packageType'      => null,
-        'return'           => null,
-        'sameDayDelivery'  => null,
-        'saturdayDelivery' => null,
-        'signature'        => null,
     ];
 
-    public $casts      = [
-        'ageCheck'         => 'bool',
-        'collect'          => 'bool',
-        'cooledDelivery'   => 'bool',
+    public $casts = [
         'deliveryDate'     => 'string',
         'deliveryType'     => 'int',
-        'hideSender'       => 'bool',
-        'insurance'        => 'int',
         'labelDescription' => 'string',
-        'largeFormat'      => 'bool',
-        'onlyRecipient'    => 'bool',
-        'priorityDelivery' => 'bool',
         'packageType'      => 'int',
-        'return'           => 'bool',
-        'sameDayDelivery'  => 'bool',
-        'saturdayDelivery' => 'bool',
-        'signature'        => 'bool',
     ];
+
+    /**
+     * Populate option attributes dynamically from definitions.
+     * Fulfilment uses null as default and converts tri-state casts to bool.
+     */
+    protected function initializeResolvesOptionAttributes(): void
+    {
+        [$optionAttributes, $optionCasts] = $this->resolveOptionAttributes(
+            static function (OrderOptionDefinitionInterface $definition): ?string {
+                return $definition->getShipmentOptionsKey();
+            },
+            null,
+            static function (OrderOptionDefinitionInterface $definition): string {
+                $cast = $definition->getShipmentOptionsCast();
+
+                // Fulfilment uses simple booleans instead of tri-state
+                return $cast === TriStateService::TYPE_STRICT ? 'bool' : $cast;
+            }
+        );
+
+        $this->attributes = array_merge($optionAttributes, $this->attributes);
+        $this->casts      = array_merge($optionCasts, $this->casts);
+    }
 
     /**
      * @param  null|\MyParcelNL\Pdk\Shipment\Model\DeliveryOptions $pdkDeliveryOptions

--- a/src/Settings/Model/CarrierSettings.php
+++ b/src/Settings/Model/CarrierSettings.php
@@ -49,6 +49,7 @@ use MyParcelNL\Pdk\Types\Service\TriStateService;
  * @property int<-1|0|1>          $exportCollect
  * @property int<-1|0|1>          $exportFreshFood
  * @property int<-1|0|1>          $exportFrozen
+ * @property int<-1|0|1>          $exportPriorityDelivery
  * @property int                  $exportInsuranceFromAmount
  * @property int                  $exportInsurancePricePercentage
  * @property int                  $exportInsuranceUpTo
@@ -97,7 +98,7 @@ class CarrierSettings extends AbstractSettingsModel
     public const  ALLOW_EXPRESS_DELIVERY                  = 'allowExpressDelivery';
 
     /**
-     * @deprecated now dynamically derived from PriorityDeliveryDefinition::getCarrierSettingsKey()
+     * @deprecated now dynamically derived from PriorityDeliveryDefinition::getAllowSettingsKey()
      */
     public const  ALLOW_PRIORITY_DELIVERY                 = 'allowPriorityDelivery';
 
@@ -203,6 +204,11 @@ class CarrierSettings extends AbstractSettingsModel
      * @deprecated now dynamically derived from FrozenDefinition::getCarrierSettingsKey()
      */
     public const  EXPORT_FROZEN                           = 'exportFrozen';
+
+    /**
+     * @deprecated now dynamically derived from PriorityDeliveryDefinition::getCarrierSettingsKey()
+     */
+    public const  EXPORT_PRIORITY_DELIVERY                = 'exportPriorityDelivery';
     public const  PRICE_DELIVERY_TYPE_EVENING_DELIVERY    = 'priceDeliveryTypeEvening';
     public const  PRICE_DELIVERY_TYPE_MONDAY_DELIVERY     = 'priceDeliveryTypeMonday';
     public const  PRICE_DELIVERY_TYPE_MORNING_DELIVERY    = 'priceDeliveryTypeMorning';

--- a/src/Settings/Model/CarrierSettings.php
+++ b/src/Settings/Model/CarrierSettings.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\Settings\Model;
 
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
+use MyParcelNL\Pdk\Base\Concern\ResolvesOptionAttributes;
 use MyParcelNL\Pdk\Carrier\Model\Carrier;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Facade\Settings;
-use MyParcelNL\Pdk\Proposition\Service\PropositionService;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
+use MyParcelNL\Pdk\Types\Service\TriStateService;
 
 /**
  * @property string               $id
@@ -34,16 +36,19 @@ use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
  * @property int                  $digitalStampDefaultWeight
  * @property int                  $dropOffDelay
  * @property DropOffPossibilities $dropOffPossibilities
- * @property bool                 $exportAgeCheck
- * @property bool                 $exportHideSender
- * @property bool                 $exportInsurance
- * @property bool                 $exportLargeFormat
- * @property bool                 $exportOnlyRecipient
- * @property bool                 $exportReceiptCode
- * @property bool                 $exportReturn
- * @property bool                 $exportReturnLargeFormat
- * @property bool                 $exportSignature
- * @property bool                 $exportTracked
+ * @property int<-1|0|1>          $exportAgeCheck
+ * @property int<-1|0|1>          $exportHideSender
+ * @property int<-1|0|1>          $exportInsurance
+ * @property int<-1|0|1>          $exportLargeFormat
+ * @property int<-1|0|1>          $exportOnlyRecipient
+ * @property int<-1|0|1>          $exportReceiptCode
+ * @property int<-1|0|1>          $exportReturn
+ * @property int<-1|0|1>          $exportReturnLargeFormat
+ * @property int<-1|0|1>          $exportSignature
+ * @property int<-1|0|1>          $exportTracked
+ * @property int<-1|0|1>          $exportCollect
+ * @property int<-1|0|1>          $exportFreshFood
+ * @property int<-1|0|1>          $exportFrozen
  * @property int                  $exportInsuranceFromAmount
  * @property int                  $exportInsurancePricePercentage
  * @property int                  $exportInsuranceUpTo
@@ -69,6 +74,8 @@ use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
  */
 class CarrierSettings extends AbstractSettingsModel
 {
+    use ResolvesOptionAttributes;
+
     /**
      * Settings category ID.
      */
@@ -76,14 +83,22 @@ class CarrierSettings extends AbstractSettingsModel
     public const CARRIER_NAME = 'carrierName';
     /**
      * Settings in this category.
+     * @TODO these settings need to be made generic based on available definitions in API spec
      */
     public const  ALLOW_DELIVERY_OPTIONS                  = 'allowDeliveryOptions';
     public const  ALLOW_STANDARD_DELIVERY                 = 'allowStandardDelivery';
     public const  ALLOW_EVENING_DELIVERY                  = 'allowEveningDelivery';
     public const  ALLOW_MONDAY_DELIVERY                   = 'allowMondayDelivery';
     public const  ALLOW_MORNING_DELIVERY                  = 'allowMorningDelivery';
+    /**
+     * @deprecated now dynamically derived from OnlyRecipientDefinition::getAllowSettingsKey()
+     */
     public const  ALLOW_ONLY_RECIPIENT                    = 'allowOnlyRecipient';
     public const  ALLOW_EXPRESS_DELIVERY                  = 'allowExpressDelivery';
+
+    /**
+     * @deprecated now dynamically derived from PriorityDeliveryDefinition::getCarrierSettingsKey()
+     */
     public const  ALLOW_PRIORITY_DELIVERY                 = 'allowPriorityDelivery';
 
     /**
@@ -92,8 +107,19 @@ class CarrierSettings extends AbstractSettingsModel
     public const  ALLOW_PICKUP_LOCATIONS                  = 'allowPickupLocations';
     public const  ALLOW_PICKUP_DELIVERY                   = 'allowPickupLocations';
 
+    /**
+     * @deprecated now dynamically derived from SameDayDeliveryDefinition::getAllowSettingsKey()
+     */
     public const  ALLOW_SAME_DAY_DELIVERY                 = 'allowSameDayDelivery';
+
+    /**
+     * @deprecated now dynamically derived from SaturdayDeliveryDefinition::getAllowSettingsKey()
+     */
     public const  ALLOW_SATURDAY_DELIVERY                 = 'allowSaturdayDelivery';
+
+    /**
+     * @deprecated now dynamically derived from SignatureDefinition::getAllowSettingsKey()
+     */
     public const  ALLOW_SIGNATURE                         = 'allowSignature';
 
     /**
@@ -110,8 +136,19 @@ class CarrierSettings extends AbstractSettingsModel
     public const  DIGITAL_STAMP_DEFAULT_WEIGHT            = 'digitalStampDefaultWeight';
     public const  DROP_OFF_DELAY                          = 'dropOffDelay';
     public const  DROP_OFF_POSSIBILITIES                  = 'dropOffPossibilities';
+    /**
+     * @deprecated now dynamically derived from AgeCheckDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_AGE_CHECK                        = 'exportAgeCheck';
+
+    /**
+     * @deprecated now dynamically derived from HideSenderDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_HIDE_SENDER                      = 'exportHideSender';
+
+    /**
+     * @deprecated now dynamically derived from InsuranceDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_INSURANCE                        = 'exportInsurance';
     public const  EXPORT_INSURANCE_FROM_AMOUNT            = 'exportInsuranceFromAmount';
     public const  EXPORT_INSURANCE_PRICE_PERCENTAGE       = 'exportInsurancePricePercentage';
@@ -119,34 +156,85 @@ class CarrierSettings extends AbstractSettingsModel
     public const  EXPORT_INSURANCE_UP_TO_EU               = 'exportInsuranceUpToEu';
     public const  EXPORT_INSURANCE_UP_TO_ROW              = 'exportInsuranceUpToRow';
     public const  EXPORT_INSURANCE_UP_TO_UNIQUE           = 'exportInsuranceUpToUnique';
+
+    /**
+     * @deprecated now dynamically derived from LargeFormatDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_LARGE_FORMAT                     = 'exportLargeFormat';
+
+    /**
+     * @deprecated now dynamically derived from OnlyRecipientDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_ONLY_RECIPIENT                   = 'exportOnlyRecipient';
+
+    /**
+     * @deprecated now dynamically derived from ReceiptCodeDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_RECEIPT_CODE                     = 'exportReceiptCode';
+
+    /**
+     * @deprecated now dynamically derived from DirectReturnDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_RETURN                           = 'exportReturn';
     public const  EXPORT_RETURN_LARGE_FORMAT              = 'exportReturnLargeFormat';
     public const  EXPORT_RETURN_PACKAGE_TYPE              = 'exportReturnPackageType';
+
+    /**
+     * @deprecated now dynamically derived from SignatureDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_SIGNATURE                        = 'exportSignature';
+
+    /**
+     * @deprecated now dynamically derived from TrackedDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_TRACKED                          = 'exportTracked';
+
+    /**
+     * @deprecated now dynamically derived from CollectDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_COLLECT                          = 'exportCollect';
+
+    /**
+     * @deprecated now dynamically derived from FreshFoodDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_FRESH_FOOD                       = 'exportFreshFood';
+
+    /**
+     * @deprecated now dynamically derived from FrozenDefinition::getCarrierSettingsKey()
+     */
     public const  EXPORT_FROZEN                           = 'exportFrozen';
-    public const  PRICE_DELIVERY_TYPE_EVENING             = 'priceDeliveryTypeEvening';
-    public const  PRICE_DELIVERY_TYPE_MONDAY              = 'priceDeliveryTypeMonday';
-    public const  PRICE_DELIVERY_TYPE_MORNING             = 'priceDeliveryTypeMorning';
+    public const  PRICE_DELIVERY_TYPE_EVENING_DELIVERY    = 'priceDeliveryTypeEvening';
+    public const  PRICE_DELIVERY_TYPE_MONDAY_DELIVERY     = 'priceDeliveryTypeMonday';
+    public const  PRICE_DELIVERY_TYPE_MORNING_DELIVERY    = 'priceDeliveryTypeMorning';
     public const  PRICE_DELIVERY_TYPE_PICKUP              = 'priceDeliveryTypePickup';
-    public const  PRICE_DELIVERY_TYPE_SAME_DAY            = 'priceDeliveryTypeSameDay';
-    public const  PRICE_DELIVERY_TYPE_SATURDAY            = 'priceDeliveryTypeSaturday';
-    public const  PRICE_DELIVERY_TYPE_STANDARD            = 'priceDeliveryTypeStandard';
+    public const  PRICE_DELIVERY_TYPE_SAME_DAY_DELIVERY   = 'priceDeliveryTypeSameDay';
+    public const  PRICE_DELIVERY_TYPE_SATURDAY_DELIVERY   = 'priceDeliveryTypeSaturday';
+    public const  PRICE_DELIVERY_TYPE_STANDARD_DELIVERY   = 'priceDeliveryTypeStandard';
+    public const  PRICE_DELIVERY_TYPE_EXPRESS_DELIVERY    = 'priceDeliveryTypeExpress';
+    /**
+     * @deprecated now dynamically derived from OnlyRecipientDefinition::getPriceSettingsKey()
+     */
     public const  PRICE_ONLY_RECIPIENT                    = 'priceOnlyRecipient';
     public const  PRICE_PACKAGE_TYPE_DIGITAL_STAMP        = 'pricePackageTypeDigitalStamp';
     public const  PRICE_PACKAGE_TYPE_MAILBOX              = 'pricePackageTypeMailbox';
     public const  PRICE_PACKAGE_TYPE_PACKAGE_SMALL        = 'pricePackageTypePackageSmall';
+
+    /**
+     * @deprecated now dynamically derived from SignatureDefinition::getPriceSettingsKey()
+     */
     public const  PRICE_SIGNATURE                         = 'priceSignature';
+
+    /**
+     * @deprecated now dynamically derived from PriorityDeliveryDefinition::getPriceSettingsKey()
+     */
     public const  PRICE_PRIORITY_DELIVERY                 = 'pricePriorityDelivery';
     public const  ALLOW_INTERNATIONAL_MAILBOX             = 'allowInternationalMailbox';
     public const  PRICE_INTERNATIONAL_MAILBOX             = 'priceInternationalMailbox';
+
+    /**
+     * @deprecated now dynamically derived from CollectDefinition::getPriceSettingsKey()
+     */
     public const  PRICE_COLLECT                           = 'priceCollect';
-    public const  PRICE_DELIVERY_TYPE_EXPRESS             = 'priceDeliveryTypeExpress';
 
 
     protected $attributes = [
@@ -158,13 +246,8 @@ class CarrierSettings extends AbstractSettingsModel
         self::ALLOW_EVENING_DELIVERY                  => false,
         self::ALLOW_MONDAY_DELIVERY                   => false,
         self::ALLOW_MORNING_DELIVERY                  => false,
-        self::ALLOW_ONLY_RECIPIENT                    => false,
         self::ALLOW_EXPRESS_DELIVERY                  => false,
-        self::ALLOW_PRIORITY_DELIVERY                 => false,
         self::ALLOW_PICKUP_DELIVERY                   => false,
-        self::ALLOW_SAME_DAY_DELIVERY                 => false,
-        self::ALLOW_SATURDAY_DELIVERY                 => false,
-        self::ALLOW_SIGNATURE                         => false,
         self::CUTOFF_TIME                             => '16:00',
         self::CUTOFF_TIME_SAME_DAY                    => '10:00',
         self::DEFAULT_PACKAGE_TYPE                    => DeliveryOptions::DEFAULT_PACKAGE_TYPE_NAME,
@@ -174,43 +257,27 @@ class CarrierSettings extends AbstractSettingsModel
         self::DIGITAL_STAMP_DEFAULT_WEIGHT            => 0,
         self::DROP_OFF_DELAY                          => 0,
         self::DROP_OFF_POSSIBILITIES                  => DropOffPossibilities::class,
-        self::EXPORT_AGE_CHECK                        => false,
-        self::EXPORT_HIDE_SENDER                      => false,
-        self::EXPORT_INSURANCE                        => false,
         self::EXPORT_INSURANCE_FROM_AMOUNT            => 0,
         self::EXPORT_INSURANCE_PRICE_PERCENTAGE       => 100,
         self::EXPORT_INSURANCE_UP_TO                  => 0,
         self::EXPORT_INSURANCE_UP_TO_EU               => 0,
         self::EXPORT_INSURANCE_UP_TO_ROW              => 0,
         self::EXPORT_INSURANCE_UP_TO_UNIQUE           => 0,
-        self::EXPORT_LARGE_FORMAT                     => false,
-        self::EXPORT_ONLY_RECIPIENT                   => false,
-        self::EXPORT_RECEIPT_CODE                     => false,
-        self::EXPORT_RETURN                           => false,
-        self::EXPORT_RETURN_LARGE_FORMAT              => false,
+        self::EXPORT_RETURN_LARGE_FORMAT              => -1,
         self::EXPORT_RETURN_PACKAGE_TYPE              => DeliveryOptions::DEFAULT_PACKAGE_TYPE_NAME,
-        self::EXPORT_SIGNATURE                        => false,
-        self::EXPORT_TRACKED                          => false,
-        self::EXPORT_COLLECT                          => false,
-        self::EXPORT_FRESH_FOOD                       => false,
-        self::EXPORT_FROZEN                           => false,
-        self::PRICE_DELIVERY_TYPE_EVENING             => 0,
-        self::PRICE_DELIVERY_TYPE_MONDAY              => 0,
-        self::PRICE_DELIVERY_TYPE_MORNING             => 0,
+        self::PRICE_DELIVERY_TYPE_EVENING_DELIVERY    => 0,
+        self::PRICE_DELIVERY_TYPE_MONDAY_DELIVERY     => 0,
+        self::PRICE_DELIVERY_TYPE_MORNING_DELIVERY    => 0,
         self::PRICE_DELIVERY_TYPE_PICKUP              => 0,
-        self::PRICE_DELIVERY_TYPE_SAME_DAY            => 0,
-        self::PRICE_DELIVERY_TYPE_SATURDAY            => 0,
-        self::PRICE_DELIVERY_TYPE_STANDARD            => 0,
-        self::PRICE_ONLY_RECIPIENT                    => 0,
+        self::PRICE_DELIVERY_TYPE_SAME_DAY_DELIVERY   => 0,
+        self::PRICE_DELIVERY_TYPE_SATURDAY_DELIVERY   => 0,
+        self::PRICE_DELIVERY_TYPE_STANDARD_DELIVERY   => 0,
         self::PRICE_PACKAGE_TYPE_DIGITAL_STAMP        => 0,
         self::PRICE_PACKAGE_TYPE_MAILBOX              => 0,
         self::PRICE_PACKAGE_TYPE_PACKAGE_SMALL        => 0,
-        self::PRICE_SIGNATURE                         => 0,
-        self::PRICE_PRIORITY_DELIVERY                 => 0,
         self::ALLOW_INTERNATIONAL_MAILBOX             => false,
         self::PRICE_INTERNATIONAL_MAILBOX             => 0,
-        self::PRICE_COLLECT                           => 0,
-        self::PRICE_DELIVERY_TYPE_EXPRESS             => 0,
+        self::PRICE_DELIVERY_TYPE_EXPRESS_DELIVERY    => 0,
     ];
 
     protected $casts      = [
@@ -221,13 +288,8 @@ class CarrierSettings extends AbstractSettingsModel
         self::ALLOW_EVENING_DELIVERY                  => 'bool',
         self::ALLOW_MONDAY_DELIVERY                   => 'bool',
         self::ALLOW_MORNING_DELIVERY                  => 'bool',
-        self::ALLOW_ONLY_RECIPIENT                    => 'bool',
         self::ALLOW_DELIVERY_TYPE_EXPRESS             => 'bool',
-        self::ALLOW_PRIORITY_DELIVERY                 => 'bool',
         self::ALLOW_PICKUP_DELIVERY                   => 'bool',
-        self::ALLOW_SAME_DAY_DELIVERY                 => 'bool',
-        self::ALLOW_SATURDAY_DELIVERY                 => 'bool',
-        self::ALLOW_SIGNATURE                         => 'bool',
         self::CUTOFF_TIME                             => 'string',
         self::CUTOFF_TIME_SAME_DAY                    => 'string',
         self::DEFAULT_PACKAGE_TYPE                    => 'string',
@@ -238,68 +300,87 @@ class CarrierSettings extends AbstractSettingsModel
         self::DIGITAL_STAMP_DEFAULT_WEIGHT            => 'int',
         self::DROP_OFF_DELAY                          => 'int',
         self::DROP_OFF_POSSIBILITIES                  => DropOffPossibilities::class,
-        self::EXPORT_AGE_CHECK                        => 'bool',
-        self::EXPORT_RECEIPT_CODE                     => 'bool',
-        self::EXPORT_INSURANCE                        => 'bool',
         self::EXPORT_INSURANCE_FROM_AMOUNT            => 'int',
         self::EXPORT_INSURANCE_PRICE_PERCENTAGE       => 'float',
         self::EXPORT_INSURANCE_UP_TO                  => 'int',
         self::EXPORT_INSURANCE_UP_TO_EU               => 'int',
         self::EXPORT_INSURANCE_UP_TO_ROW              => 'int',
         self::EXPORT_INSURANCE_UP_TO_UNIQUE           => 'int',
-        self::EXPORT_LARGE_FORMAT                     => 'bool',
-        self::EXPORT_ONLY_RECIPIENT                   => 'bool',
-        self::EXPORT_RETURN                           => 'bool',
-        self::EXPORT_RETURN_LARGE_FORMAT              => 'bool',
+        self::EXPORT_RETURN_LARGE_FORMAT              => TriStateService::TYPE_STRICT,
         self::EXPORT_RETURN_PACKAGE_TYPE              => 'string',
-        self::EXPORT_SIGNATURE                        => 'bool',
-        self::EXPORT_TRACKED                          => 'bool',
-        self::EXPORT_COLLECT                          => 'bool',
-        self::EXPORT_FRESH_FOOD                       => 'bool',
-        self::EXPORT_FROZEN                           => 'bool',
-        self::PRICE_DELIVERY_TYPE_EVENING             => 'float',
-        self::PRICE_DELIVERY_TYPE_MONDAY              => 'float',
-        self::PRICE_DELIVERY_TYPE_MORNING             => 'float',
+        self::PRICE_DELIVERY_TYPE_EVENING_DELIVERY    => 'float',
+        self::PRICE_DELIVERY_TYPE_MONDAY_DELIVERY     => 'float',
+        self::PRICE_DELIVERY_TYPE_MORNING_DELIVERY    => 'float',
         self::PRICE_DELIVERY_TYPE_PICKUP              => 'float',
-        self::PRICE_DELIVERY_TYPE_SAME_DAY            => 'float',
-        self::PRICE_DELIVERY_TYPE_SATURDAY            => 'float',
-        self::PRICE_DELIVERY_TYPE_STANDARD            => 'float',
-        self::PRICE_ONLY_RECIPIENT                    => 'float',
+        self::PRICE_DELIVERY_TYPE_SAME_DAY_DELIVERY   => 'float',
+        self::PRICE_DELIVERY_TYPE_SATURDAY_DELIVERY   => 'float',
+        self::PRICE_DELIVERY_TYPE_STANDARD_DELIVERY   => 'float',
         self::PRICE_PACKAGE_TYPE_DIGITAL_STAMP        => 'float',
         self::PRICE_PACKAGE_TYPE_MAILBOX              => 'float',
         self::PRICE_PACKAGE_TYPE_PACKAGE_SMALL        => 'float',
-        self::PRICE_SIGNATURE                         => 'float',
-        self::PRICE_PRIORITY_DELIVERY                 => 'float',
         self::ALLOW_INTERNATIONAL_MAILBOX             => 'bool',
         self::PRICE_INTERNATIONAL_MAILBOX             => 'float',
-        self::PRICE_COLLECT                           => 'float',
-        self::PRICE_DELIVERY_TYPE_EXPRESS             => 'float',
+        self::PRICE_DELIVERY_TYPE_EXPRESS_DELIVERY    => 'float',
     ];
 
     /**
-     * @param  string|\MyParcelNL\Pdk\Carrier\Model\Carrier $carrier
+     * Populate attributes and casts dynamically from registered option definitions.
+     * Dynamic entries are added first so static definitions win on collision via array_merge.
+     */
+    protected function initializeResolvesOptionAttributes(): void
+    {
+        // Export settings (e.g. exportSignature): merchant-controlled default for shipment creation.
+        // Cast is definition-specific: most are tri-state (-1/0/1), but some like insurance use 'int'.
+        [$exportAttributes, $exportCasts] = $this->resolveOptionAttributes(
+            static function (OrderOptionDefinitionInterface $definition): ?string {
+                return $definition->getCarrierSettingsKey();
+            },
+            TriStateService::INHERIT,
+            static function (OrderOptionDefinitionInterface $definition): string {
+                return $definition->getShipmentOptionsCast();
+            }
+        );
+
+        // Allow settings (e.g. allowSignature): whether the consumer can toggle this option at checkout.
+        // Always boolean — the option is either shown or not in the delivery options widget.
+        [$allowAttributes, $allowCasts] = $this->resolveOptionAttributes(
+            static function (OrderOptionDefinitionInterface $definition): ?string {
+                return $definition->getAllowSettingsKey();
+            },
+            false,
+            static function (): string {
+                return 'bool';
+            }
+        );
+
+        // Price settings (e.g. priceSignature): surcharge added to shipping cost when option is active.
+        // Always float — represents a monetary value added to the base shipping price.
+        [$priceAttributes, $priceCasts] = $this->resolveOptionAttributes(
+            static function (OrderOptionDefinitionInterface $definition): ?string {
+                return $definition->getPriceSettingsKey();
+            },
+            0,
+            static function (): string {
+                return 'float';
+            }
+        );
+
+        $dynamicAttributes = array_merge($exportAttributes, $allowAttributes, $priceAttributes);
+        $dynamicCasts      = array_merge($exportCasts, $allowCasts, $priceCasts);
+
+        $this->attributes = array_merge($dynamicAttributes, $this->attributes);
+        $this->casts      = array_merge($dynamicCasts, $this->casts);
+    }
+
+    /**
+     * @param  \MyParcelNL\Pdk\Carrier\Model\Carrier $carrier
      *
      * @return self
      */
-    public static function fromCarrier($carrier): self
+    public static function fromCarrier(Carrier $carrier): self
     {
-        if ($carrier instanceof Carrier) {
-            $carrier = $carrier->externalIdentifier;
-        }
-
-        // Try to get settings using the carrier identifier as-is (for backwards compatibility)
         /** @var null|\MyParcelNL\Pdk\Settings\Model\CarrierSettings $settings */
-        $settings = Settings::all()->carrier->get($carrier);
-
-        if (! $settings) {
-            // If not found, try mapping the carrier name to legacy format
-            $propositionService = Pdk::get(PropositionService::class);
-            $legacyIdentifier = $propositionService->mapNewToLegacyCarrierName($carrier);
-
-            if ($legacyIdentifier !== $carrier) {
-                $settings = Settings::all()->carrier->get($legacyIdentifier);
-            }
-        }
+        $settings = Settings::all()->carrier->get($carrier->carrier);
 
         if (! $settings) {
             return new CarrierSettings();

--- a/src/Settings/Model/ProductSettings.php
+++ b/src/Settings/Model/ProductSettings.php
@@ -125,6 +125,10 @@ class ProductSettings extends AbstractSettingsModel
     /**
      * Populate attributes and casts dynamically from registered option definitions.
      * Dynamic entries are added first so static definitions win on collision via array_merge.
+     *
+     * Product-level export settings are always tri-state (inherit/off/on), regardless of the
+     * shipment option cast. For example, exportInsurance on a product is a toggle (-1/0/1),
+     * not an amount — the amount is resolved at carrier settings level.
      */
     protected function initializeResolvesOptionAttributes(): void
     {
@@ -133,8 +137,8 @@ class ProductSettings extends AbstractSettingsModel
                 return $definition->getProductSettingsKey();
             },
             TriStateService::INHERIT,
-            static function (OrderOptionDefinitionInterface $definition): string {
-                return $definition->getShipmentOptionsCast();
+            static function (): string {
+                return TriStateService::TYPE_STRICT;
             }
         );
 

--- a/src/Settings/Model/ProductSettings.php
+++ b/src/Settings/Model/ProductSettings.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\Settings\Model;
 
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
+use MyParcelNL\Pdk\Base\Concern\ResolvesOptionAttributes;
+use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Types\Service\TriStateService;
 
 /**
@@ -26,26 +29,74 @@ use MyParcelNL\Pdk\Types\Service\TriStateService;
  */
 class ProductSettings extends AbstractSettingsModel
 {
+    use ResolvesOptionAttributes;
+
     public const ID                       = 'product';
     public const COUNTRY_OF_ORIGIN        = 'countryOfOrigin';
     public const COUNTRY_OF_ORIGIN_NONE   = 'none';
     public const CUSTOMS_CODE             = 'customsCode';
     public const DISABLE_DELIVERY_OPTIONS = 'disableDeliveryOptions';
     public const DROP_OFF_DELAY           = 'dropOffDelay';
-    public const EXPORT_AGE_CHECK         = 'exportAgeCheck';
-    public const EXPORT_HIDE_SENDER       = 'exportHideSender';
-    public const EXPORT_INSURANCE         = 'exportInsurance';
-    public const EXPORT_LARGE_FORMAT      = 'exportLargeFormat';
-    public const EXPORT_ONLY_RECIPIENT    = 'exportOnlyRecipient';
-    public const EXPORT_RETURN            = 'exportReturn';
-    public const EXPORT_SIGNATURE         = 'exportSignature';
-    public const EXPORT_TRACKED           = 'exportTracked';
-    public const EXPORT_FRESH_FOOD        = 'exportFreshFood';
-    public const EXPORT_FROZEN            = 'exportFrozen';
-    public const FIT_IN_DIGITAL_STAMP     = 'fitInDigitalStamp';
-    public const FIT_IN_MAILBOX           = 'fitInMailbox';
-    public const PACKAGE_TYPE             = 'packageType';
-    public const EXCLUDE_PARCEL_LOCKERS   = 'excludeParcelLockers';
+
+    /**
+     * @deprecated now dynamically derived from AgeCheckDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_AGE_CHECK = 'exportAgeCheck';
+
+    /**
+     * @deprecated now dynamically derived from HideSenderDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_HIDE_SENDER = 'exportHideSender';
+
+    /**
+     * @deprecated now dynamically derived from InsuranceDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_INSURANCE = 'exportInsurance';
+
+    /**
+     * @deprecated now dynamically derived from LargeFormatDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_LARGE_FORMAT = 'exportLargeFormat';
+
+    /**
+     * @deprecated now dynamically derived from OnlyRecipientDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_ONLY_RECIPIENT = 'exportOnlyRecipient';
+
+    /**
+     * @deprecated now dynamically derived from DirectReturnDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_RETURN = 'exportReturn';
+
+    /**
+     * @deprecated now dynamically derived from SignatureDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_SIGNATURE = 'exportSignature';
+
+    /**
+     * @deprecated now dynamically derived from TrackedDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_TRACKED = 'exportTracked';
+
+    /**
+     * @deprecated now dynamically derived from FreshFoodDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_FRESH_FOOD = 'exportFreshFood';
+
+    /**
+     * @deprecated now dynamically derived from FrozenDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_FROZEN = 'exportFrozen';
+
+    /**
+     * @deprecated now dynamically derived from CooledDeliveryDefinition::getProductSettingsKey()
+     */
+    public const EXPORT_COOLED_DELIVERY = 'exportCooledDelivery';
+
+    public const FIT_IN_DIGITAL_STAMP   = 'fitInDigitalStamp';
+    public const FIT_IN_MAILBOX         = 'fitInMailbox';
+    public const PACKAGE_TYPE           = 'packageType';
+    public const EXCLUDE_PARCEL_LOCKERS = 'excludeParcelLockers';
 
     protected $attributes = [
         'id' => self::ID,
@@ -54,40 +105,40 @@ class ProductSettings extends AbstractSettingsModel
         self::CUSTOMS_CODE             => TriStateService::INHERIT,
         self::DISABLE_DELIVERY_OPTIONS => TriStateService::INHERIT,
         self::DROP_OFF_DELAY           => TriStateService::INHERIT,
-        self::EXPORT_AGE_CHECK         => TriStateService::INHERIT,
-        self::EXPORT_HIDE_SENDER       => TriStateService::INHERIT,
-        self::EXPORT_INSURANCE         => TriStateService::INHERIT,
-        self::EXPORT_LARGE_FORMAT      => TriStateService::INHERIT,
-        self::EXPORT_ONLY_RECIPIENT    => TriStateService::INHERIT,
-        self::EXPORT_RETURN            => TriStateService::INHERIT,
-        self::EXPORT_SIGNATURE         => TriStateService::INHERIT,
-        self::EXPORT_TRACKED           => TriStateService::INHERIT,
-        self::EXPORT_FRESH_FOOD        => TriStateService::INHERIT,
-        self::EXPORT_FROZEN            => TriStateService::INHERIT,
         self::FIT_IN_DIGITAL_STAMP     => TriStateService::INHERIT,
         self::FIT_IN_MAILBOX           => TriStateService::INHERIT,
         self::PACKAGE_TYPE             => TriStateService::INHERIT,
         self::EXCLUDE_PARCEL_LOCKERS   => TriStateService::INHERIT,
     ];
 
-    protected $casts      = [
+    protected $casts = [
         self::COUNTRY_OF_ORIGIN        => TriStateService::TYPE_COERCED,
         self::CUSTOMS_CODE             => TriStateService::TYPE_COERCED,
         self::DISABLE_DELIVERY_OPTIONS => TriStateService::TYPE_STRICT,
         self::DROP_OFF_DELAY           => 'int',
-        self::EXPORT_AGE_CHECK         => TriStateService::TYPE_STRICT,
-        self::EXPORT_HIDE_SENDER       => TriStateService::TYPE_STRICT,
-        self::EXPORT_INSURANCE         => TriStateService::TYPE_STRICT,
-        self::EXPORT_LARGE_FORMAT      => TriStateService::TYPE_STRICT,
-        self::EXPORT_ONLY_RECIPIENT    => TriStateService::TYPE_STRICT,
-        self::EXPORT_RETURN            => TriStateService::TYPE_STRICT,
-        self::EXPORT_SIGNATURE         => TriStateService::TYPE_STRICT,
-        self::EXPORT_TRACKED           => TriStateService::TYPE_STRICT,
-        self::EXPORT_FRESH_FOOD        => TriStateService::TYPE_STRICT,
-        self::EXPORT_FROZEN            => TriStateService::TYPE_STRICT,
         self::FIT_IN_DIGITAL_STAMP     => 'int',
         self::FIT_IN_MAILBOX           => 'int',
         self::PACKAGE_TYPE             => TriStateService::TYPE_COERCED,
         self::EXCLUDE_PARCEL_LOCKERS   => TriStateService::TYPE_STRICT,
     ];
+
+    /**
+     * Populate attributes and casts dynamically from registered option definitions.
+     * Dynamic entries are added first so static definitions win on collision via array_merge.
+     */
+    protected function initializeResolvesOptionAttributes(): void
+    {
+        [$dynamicAttributes, $dynamicCasts] = $this->resolveOptionAttributes(
+            static function (OrderOptionDefinitionInterface $definition): ?string {
+                return $definition->getProductSettingsKey();
+            },
+            TriStateService::INHERIT,
+            static function (OrderOptionDefinitionInterface $definition): string {
+                return $definition->getShipmentOptionsCast();
+            }
+        );
+
+        $this->attributes = array_merge($dynamicAttributes, $this->attributes);
+        $this->casts      = array_merge($dynamicCasts, $this->casts);
+    }
 }

--- a/src/Shipment/Model/ShipmentOptions.php
+++ b/src/Shipment/Model/ShipmentOptions.php
@@ -227,11 +227,15 @@ class ShipmentOptions extends Model
                 continue;
             }
 
+            $modelKey = $definition->getShipmentOptionsKey();
+
             // Map the shipment option name to the corresponding shipment option key and retain the value
-            $data[$definition->getShipmentOptionsKey()] = $value;
+            $data[$modelKey] = $value;
 
             // Unset the original shipment option name as it's not used in the ShipmentOptions model
-            unset($data[$shipmentOptionName]);
+            if ($shipmentOptionName !== $modelKey) {
+                unset($data[$shipmentOptionName]);
+            }
         }
 
         return new self($data);

--- a/src/Shipment/Model/ShipmentOptions.php
+++ b/src/Shipment/Model/ShipmentOptions.php
@@ -4,10 +4,19 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\Shipment\Model;
 
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
+use MyParcelNL\Pdk\Base\Concern\ResolvesOptionAttributes;
 use MyParcelNL\Pdk\Base\Model\Model;
+use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Types\Service\TriStateService;
+use MyParcelNL\Sdk\Support\Arr;
 
 /**
+ * This model represents the shipment options as they exist within the DeliveryOptions of a Shipment.
+ * They mostly correspond to the shipment options as they exist within the MyParcel API delivery options endpoint, not the shipment options are supported by capabilities and POST /shipments endpoint.
+ *
+ * @TODO: This should be based off of dynamic shipment option names, but currently from the openApi spec there are no enum equivalents, only Models with (runtime) attribute constraints.
+ *
  * @property int<-1>|string|null $labelDescription
  * @property int                 $insurance
  * @property int<-1|0|1>         $ageCheck
@@ -28,28 +37,103 @@ use MyParcelNL\Pdk\Types\Service\TriStateService;
  */
 class ShipmentOptions extends Model
 {
+    use ResolvesOptionAttributes;
+
     public const LABEL_DESCRIPTION = 'labelDescription';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const INSURANCE         = 'insurance';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const AGE_CHECK         = 'ageCheck';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const DIRECT_RETURN     = 'return';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const HIDE_SENDER       = 'hideSender';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const LARGE_FORMAT      = 'largeFormat';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const ONLY_RECIPIENT    = 'onlyRecipient';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const PRIORITY_DELIVERY = 'priorityDelivery';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const RECEIPT_CODE      = 'receiptCode';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const SAME_DAY_DELIVERY = 'sameDayDelivery';
 
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const SATURDAY_DELIVERY = 'saturdayDelivery';
 
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const MONDAY_DELIVERY   = 'mondayDelivery';
 
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const SIGNATURE         = 'signature';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const TRACKED           = 'tracked';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const COLLECT           = 'collect';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const EXCLUDE_PARCEL_LOCKERS = 'excludeParcelLockers';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const FRESH_FOOD        = 'freshFood';
+
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
     public const FROZEN            = 'frozen';
 
+    /**
+     * @deprecated Use definition's getShipmentOptionsKey() instead
+     */
+    public const COOLED_DELIVERY   = 'cooledDelivery';
+
+    /**
+     * @deprecated Use option definitions to determine available shipment options dynamically instead
+     */
     public const ALL_SHIPMENT_OPTIONS = [
         self::LABEL_DESCRIPTION,
         self::INSURANCE,
@@ -72,41 +156,110 @@ class ShipmentOptions extends Model
 
     protected $attributes = [
         self::LABEL_DESCRIPTION => null,
-        self::INSURANCE         => TriStateService::INHERIT,
-        self::AGE_CHECK         => TriStateService::INHERIT,
-        self::DIRECT_RETURN     => TriStateService::INHERIT,
-        self::HIDE_SENDER       => TriStateService::INHERIT,
-        self::LARGE_FORMAT      => TriStateService::INHERIT,
-        self::ONLY_RECIPIENT    => TriStateService::INHERIT,
-        self::PRIORITY_DELIVERY => TriStateService::INHERIT,
-        self::RECEIPT_CODE      => TriStateService::INHERIT,
-        self::SAME_DAY_DELIVERY => TriStateService::INHERIT,
-        self::SIGNATURE         => TriStateService::INHERIT,
-        self::TRACKED           => TriStateService::INHERIT,
-        self::COLLECT           => TriStateService::INHERIT,
-        self::EXCLUDE_PARCEL_LOCKERS => TriStateService::INHERIT,
-        self::FRESH_FOOD        => TriStateService::INHERIT,
-        self::FROZEN            => TriStateService::INHERIT,
-        self::SATURDAY_DELIVERY => TriStateService::INHERIT,
     ];
 
-    protected $casts      = [
+    protected $casts = [
         self::LABEL_DESCRIPTION => TriStateService::TYPE_STRING,
-        self::INSURANCE         => 'int',
-        self::AGE_CHECK         => TriStateService::TYPE_STRICT,
-        self::DIRECT_RETURN     => TriStateService::TYPE_STRICT,
-        self::HIDE_SENDER       => TriStateService::TYPE_STRICT,
-        self::LARGE_FORMAT      => TriStateService::TYPE_STRICT,
-        self::ONLY_RECIPIENT    => TriStateService::TYPE_STRICT,
-        self::PRIORITY_DELIVERY => TriStateService::TYPE_STRICT,
-        self::RECEIPT_CODE      => TriStateService::TYPE_STRICT,
-        self::SAME_DAY_DELIVERY => TriStateService::TYPE_STRICT,
-        self::SIGNATURE         => TriStateService::TYPE_STRICT,
-        self::TRACKED           => TriStateService::TYPE_STRICT,
-        self::COLLECT           => TriStateService::TYPE_STRICT,
-        self::EXCLUDE_PARCEL_LOCKERS => TriStateService::TYPE_STRICT,
-        self::FRESH_FOOD        => TriStateService::TYPE_STRICT,
-        self::FROZEN            => TriStateService::TYPE_STRICT,
-        self::SATURDAY_DELIVERY => TriStateService::TYPE_STRICT,
     ];
+
+    /**
+     * Get all shipment option keys from registered definitions.
+     *
+     * @return string[]
+     */
+    public static function getAllShipmentOptionKeys(): array
+    {
+        /** @var OrderOptionDefinitionInterface[] $definitions */
+        $definitions = Pdk::get('orderOptionDefinitions');
+
+        return array_values(array_filter(array_map(
+            static function (OrderOptionDefinitionInterface $definition): ?string {
+                return $definition->getShipmentOptionsKey();
+            },
+            $definitions
+        )));
+    }
+
+    /**
+     * Populate attributes and casts dynamically from registered option definitions.
+     * Each definition declares its own cast type and default value.
+     * Dynamic entries are added first so static definitions win on collision via array_merge.
+     */
+    protected function initializeResolvesOptionAttributes(): void
+    {
+        [$optionAttributes, $optionCasts] = $this->resolveOptionAttributes(
+            static function (OrderOptionDefinitionInterface $definition) {
+                return $definition->getShipmentOptionsKey();
+            },
+            TriStateService::INHERIT,
+            static function (OrderOptionDefinitionInterface $definition): string {
+                return $definition->getShipmentOptionsCast();
+            }
+        );
+
+        $this->attributes = array_merge($optionAttributes, $this->attributes);
+        $this->casts      = array_merge($optionCasts, $this->casts);
+    }
+
+    /**
+     * Instantiate a ShipmentOptions model based on their OrderOptionDefinition capabilities definition.
+     *
+     * @param array $data
+     * @return ShipmentOptions
+     */
+    public static function fromCapabilitiesDefinitions(array $data): self
+    {
+        // Abuse the OrderOptionsDefinition as they contain the mapping between capabilities and shipment option keys
+
+        /** @var OrderOptionDefinitionInterface[] $definitions */
+        $definitions = Pdk::get('orderOptionDefinitions');
+
+        // Given $data is an array of shipment option in the format ['name' => -1/0/1], find a definition matching the data
+        foreach ($data as $shipmentOptionName => $value) {
+            /**
+             * @var OrderOptionDefinitionInterface|null $definition
+             */
+            $definition = Arr::first($definitions, static function (OrderOptionDefinitionInterface $definition) use ($shipmentOptionName) {
+                return $definition->getCapabilitiesOptionsKey() === $shipmentOptionName;
+            });
+
+            if (!$definition) {
+                continue;
+            }
+
+            // Map the shipment option name to the corresponding shipment option key and retain the value
+            $data[$definition->getShipmentOptionsKey()] = $value;
+
+            // Unset the original shipment option name as it's not used in the ShipmentOptions model
+            unset($data[$shipmentOptionName]);
+        }
+
+        return new self($data);
+    }
+
+    /**
+     * Given an existing ShipmentOptions model, returns an array of that model with the V2 definition keys
+     * @param ShipmentOptions $shipmentOptions
+     * @return array
+     */
+    public static function toCapabilitiesDefinitions(ShipmentOptions $shipmentOptions): array
+    {
+        $data = [];
+
+        /** @var OrderOptionDefinitionInterface[] $definitions */
+        $definitions = Pdk::get('orderOptionDefinitions');
+
+        foreach ($definitions as $definition) {
+            $shipmentOptionsKey = $definition->getShipmentOptionsKey();
+            $capabilitiesOptionsKey = $definition->getCapabilitiesOptionsKey();
+
+            if (!$shipmentOptionsKey || !$capabilitiesOptionsKey) {
+                continue;
+            }
+
+            $data[$capabilitiesOptionsKey] = $shipmentOptions->{$shipmentOptionsKey};
+        }
+
+        return $data;
+    }
 }

--- a/src/Validation/Contract/DeliveryOptionsValidatorInterface.php
+++ b/src/Validation/Contract/DeliveryOptionsValidatorInterface.php
@@ -6,29 +6,13 @@ namespace MyParcelNL\Pdk\Validation\Contract;
 
 interface DeliveryOptionsValidatorInterface
 {
-    public function canHaveAgeCheck(): bool;
-
-    public function canHaveDirectReturn(): bool;
-
     public function canHaveEveningDelivery(): bool;
-
-    public function canHaveHideSender(): bool;
-
-    public function canHaveInsurance(?int $amount): bool;
-
-    public function canHaveLargeFormat(): bool;
 
     public function canHaveMorningDelivery(): bool;
 
     public function canHaveMultiCollo(): bool;
 
-    public function canHaveOnlyRecipient(): bool;
-
     public function canHavePickup(): bool;
-
-    public function canHaveSameDayDelivery(): bool;
-
-    public function canHaveSignature(): bool;
 
     public function canHaveStandardDelivery(): bool;
 

--- a/src/Validation/Validator/CarrierSchema.php
+++ b/src/Validation/Validator/CarrierSchema.php
@@ -6,31 +6,17 @@ namespace MyParcelNL\Pdk\Validation\Validator;
 
 use BadMethodCallException;
 use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
-use MyParcelNL\Pdk\App\Options\Definition\AgeCheckDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\CollectDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\DirectReturnDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\HideSenderDefinition;
 use MyParcelNL\Pdk\App\Options\Definition\InsuranceDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\LargeFormatDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\OnlyRecipientDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\PriorityDeliveryDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\ReceiptCodeDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\SameDayDeliveryDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\SignatureDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\TrackedDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\FreshFoodDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\FrozenDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\MondayDeliveryDefinition;
-use MyParcelNL\Pdk\App\Options\Definition\SaturdayDeliveryDefinition;
 use MyParcelNL\Pdk\Base\Support\Arr;
 use MyParcelNL\Pdk\Carrier\Model\Carrier;
-use MyParcelNL\Pdk\Facade\Logger;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierMetadata;
-use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Pdk\Validation\Contract\DeliveryOptionsValidatorInterface;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageTypeV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrierV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesDeliveryTypeV2;
 
 /**
- * @deprecated Should switch to proposition-related functionality in the future
+ * @deprecated This will be replaced with generic capabilities-focussed functionality in the future.
+ *
  * @package MyParcelNL\Pdk\Validation\Validator
  */
 class CarrierSchema implements DeliveryOptionsValidatorInterface
@@ -45,165 +31,113 @@ class CarrierSchema implements DeliveryOptionsValidatorInterface
      */
     protected $carrier;
 
-    /**
-     * Given a Shipment Option Name from the Proposition config, return whether that's enabled in the schema.
-     *
-     * @todo this should use ENUMs in the future.
-     * @param string $shipmentOptionName
-     * @return bool
-     * @throws BadMethodCallException
-     */
-    public function hasShipmentOptionName(string $shipmentOptionName): bool
-    {
-        return in_array(
-            $shipmentOptionName,
-            $this->getFromSchema('shipmentOptions') ?: [],
-        );
-    }
-
     public function canBeDigitalStamp(): bool
     {
-        return $this->canHavePackageType(DeliveryOptions::PACKAGE_TYPE_DIGITAL_STAMP_NAME);
+        return $this->canHavePackageType(RefShipmentPackageTypeV2::DIGITAL_STAMP);
     }
 
     public function canBeLetter(): bool
     {
-        return $this->canHavePackageType(DeliveryOptions::PACKAGE_TYPE_LETTER_NAME);
+        return $this->canHavePackageType(RefShipmentPackageTypeV2::UNFRANKED);
     }
 
     public function canBeMailbox(): bool
     {
-        return $this->canHavePackageType(DeliveryOptions::PACKAGE_TYPE_MAILBOX_NAME);
+        return $this->canHavePackageType(RefShipmentPackageTypeV2::MAILBOX);
     }
 
     public function canBePackage(): bool
     {
-        return $this->canHavePackageType(DeliveryOptions::PACKAGE_TYPE_PACKAGE_NAME);
+        return $this->canHavePackageType(RefShipmentPackageTypeV2::PACKAGE);
     }
 
     public function canBePackageSmall(): bool
     {
-        return $this->canHavePackageType(DeliveryOptions::PACKAGE_TYPE_PACKAGE_SMALL_NAME);
-    }
-
-    public function canHaveAgeCheck(): bool
-    {
-        return $this->canHave(AgeCheckDefinition::class);
-    }
-
-    public function canHaveCarrierSmallPackageContract(): bool
-    {
-        return $this->canHaveFeature('carrierSmallPackageContract');
-    }
-
-    public function canHaveCollect(): bool
-    {
-        return $this->canHave(CollectDefinition::class);
-    }
-
-    public function canHaveDirectReturn(): bool
-    {
-        return $this->canHave(DirectReturnDefinition::class);
+        return $this->canHavePackageType(RefShipmentPackageTypeV2::SMALL_PACKAGE);
     }
 
     public function canHaveEveningDelivery(): bool
     {
-        return $this->hasDeliveryType(DeliveryOptions::DELIVERY_TYPE_EVENING_NAME);
+        return $this->hasDeliveryType(RefTypesDeliveryTypeV2::EVENING);
     }
 
     public function canHaveExpressDelivery(): bool
     {
-        return $this->hasDeliveryType(DeliveryOptions::DELIVERY_TYPE_EXPRESS_NAME);
+        return $this->hasDeliveryType(RefTypesDeliveryTypeV2::EXPRESS);
     }
 
-    public function canHaveFreshFood(): bool
+    public function canHaveMondayDelivery(): bool
     {
-        return $this->canHave(FreshFoodDefinition::class);
-    }
-
-    public function canHaveFrozen(): bool
-    {
-        return $this->canHave(FrozenDefinition::class);
-    }
-
-    /**
-     * @return bool
-     */
-    public function canHaveHideSender(): bool
-    {
-        return $this->canHave(HideSenderDefinition::class);
-    }
-
-    /**
-     * We can safely ignore the amount here as it's not used in the capabilities.
-     *
-     * @param  null|int $amount
-     *
-     * @return bool
-     */
-    public function canHaveInsurance(?int $amount = 0): bool
-    {
-        return $this->canHave(InsuranceDefinition::class);
-    }
-
-    public function canHaveLargeFormat(): bool
-    {
-        return $this->canHave(LargeFormatDefinition::class);
+        // @TODO: replace with non-carrier specific check.
+        // Currently, we do not have any endpoint to check this with (not an actual shipment option, just for DO)
+        return $this->getCarrier()->carrier === RefTypesCarrierV2::POSTNL;
     }
 
     public function canHaveMorningDelivery(): bool
     {
-        return $this->hasDeliveryType(DeliveryOptions::DELIVERY_TYPE_MORNING_NAME);
+        return $this->hasDeliveryType(RefTypesDeliveryTypeV2::MORNING);
     }
 
     public function canHaveMultiCollo(): bool
     {
-        return $this->canHaveFeature('multiCollo');
-    }
-
-    public function canHaveOnlyRecipient(): bool
-    {
-        return $this->canHave(OnlyRecipientDefinition::class);
-    }
-
-    public function canHavePriorityDelivery(): bool
-    {
-        return $this->canHave(PriorityDeliveryDefinition::class);
+        return $this->getFromSchema('collo') ? $this->getFromSchema('collo')['max'] > 1 : false;
     }
 
     public function canHavePickup(): bool
     {
-        return $this->hasDeliveryType(DeliveryOptions::DELIVERY_TYPE_PICKUP_NAME);
+        return $this->hasDeliveryType(RefTypesDeliveryTypeV2::PICKUP);
     }
 
-    public function canHaveReceiptCode(): bool
+    /**
+     * Proxy legacy canHave*() calls for shipment options to canHaveShipmentOption().
+     * This replaces ~15 individual methods that all delegated to canHaveShipmentOption().
+     * The method name is mapped to a Definition class: canHaveSignature → SignatureDefinition.
+     *
+     * @param  string $name
+     * @param  array  $arguments
+     *
+     * @return mixed
+     */
+    public function __call(string $name, array $arguments)
     {
-        return $this->canHave(ReceiptCodeDefinition::class);
+        if (strpos($name, 'canHave') === 0) {
+            $optionName = substr($name, 7);
+            $definitionClass = sprintf(
+                'MyParcelNL\\Pdk\\App\\Options\\Definition\\%sDefinition',
+                $optionName
+            );
+
+            if (class_exists($definitionClass)) {
+                return $this->canHaveShipmentOption($definitionClass);
+            }
+        }
+
+        throw new \BadMethodCallException(sprintf('Method %s does not exist on %s', $name, static::class));
     }
 
-    public function canHaveSameDayDelivery(): bool
+    /**
+     * Check if a shipment option is available.
+     *
+     * Note that in capabilities, the shipment option is presented as an object/array with optional configuration,
+     * so an empty array/object means the option is available, while a missing key means it's not.
+     *
+     * @param  class-string<OrderOptionDefinitionInterface>|OrderOptionDefinitionInterface $definition
+     *
+     * @return bool
+     */
+    public function canHaveShipmentOption($definition): bool
     {
-        return $this->canHave(SameDayDeliveryDefinition::class);
-    }
+        $resolvedDefinition = $this->resolveDefinition($definition);
 
-    public function canHaveSignature(): bool
-    {
-        return $this->canHave(SignatureDefinition::class);
+        return array_key_exists(
+            $resolvedDefinition->getCapabilitiesOptionsKey(),
+            $this->getFromSchema('options') ?: [],
+        );
     }
 
     public function canHaveStandardDelivery(): bool
     {
-        return $this->hasDeliveryType(DeliveryOptions::DELIVERY_TYPE_STANDARD_NAME);
-    }
-
-    public function canHaveTracked(): bool
-    {
-        return $this->canHave(TrackedDefinition::class);
-    }
-
-    public function canHaveSaturdayDelivery(): bool
-    {
-        return $this->canHave(SaturdayDeliveryDefinition::class);
+        return $this->hasDeliveryType(RefTypesDeliveryTypeV2::STANDARD);
     }
 
     public function canHaveWeight(?int $weight): bool
@@ -216,20 +150,32 @@ class CarrierSchema implements DeliveryOptionsValidatorInterface
         return $this->getFromSchema('deliveryTypes') ?: [];
     }
 
+    public function hasReturnCapabilities(): bool
+    {
+        // @TODO: Replace by a directionality call to capabilities given shipment context.
+        // Currently always true for limited backwards compatibility
+        return true;
+    }
+
     public function getAllowedInsuranceAmounts(): array
     {
-        $allowedAmounts = $this->getMetadataFeature('insuranceOptions');
-        $hasOption = $this->hasShipmentOption(InsuranceDefinition::class);
-        if (!$allowedAmounts && $hasOption) {
-            Logger::warning(
-                'Carrier schema does not have insurance options defined, but the carrier has the insurance option enabled.',
-                [
-                    'carrier' => $this->getCarrier()->externalIdentifier,
-                ]
-            );
-            return [0];
+        $hasOption = $this->canHaveShipmentOption(InsuranceDefinition::class);
+
+        // Take the min and max from the insurance shipment option and return a range in between them
+        // Note: The amount is currently in cents (EUR * 100)
+        if ($hasOption) {
+            $max = $this->getCarrier()->options->getInsurance()->getInsuredAmount()->getMax()->getAmount();
+            $min = $this->getCarrier()->options->getInsurance()->getInsuredAmount()->getMin()->getAmount();
+            // Determine whether the difference between min and max is smaller than 50.000 cents (500 EUR), if so, return a range with a step of 10.000 cents (100 EUR)
+            if ($max - $min <= 50_000) {
+                $step = 10_000;
+            } else {
+                $step = 50_000;
+            }
+
+            return range($min, $max, $step);
         }
-        return $hasOption ? $allowedAmounts : [];
+        return [];
     }
 
     public function getAllowedPackageTypes(): array
@@ -242,21 +188,13 @@ class CarrierSchema implements DeliveryOptionsValidatorInterface
      */
     public function getSchema(): array
     {
-        $identifier = $this->getCarrier()->externalIdentifier;
+        $identifier = $this->getCarrier()->carrier;
 
         if (! isset($this->cache[$identifier])) {
             $this->cache[$identifier] = $this->createSchema();
         }
 
         return $this->cache[$identifier];
-    }
-
-    /**
-     * @return bool
-     */
-    public function needsCustomerInfo(): bool
-    {
-        return (bool) $this->getMetadataFeature('needsCustomerInfo');
     }
 
     /**
@@ -269,22 +207,6 @@ class CarrierSchema implements DeliveryOptionsValidatorInterface
         $this->carrier = $carrier;
 
         return $this;
-    }
-
-    /**
-     * @param  string $feature
-     *
-     * @return bool
-     */
-    protected function canHaveFeature(string $feature): bool
-    {
-        $value = $this->getMetadataFeature($feature);
-
-        if (PropositionCarrierMetadata::FEATURE_CUSTOM_CONTRACT_ONLY === $value) {
-            return $this->carrier->isCustom;
-        }
-
-        return (bool) $value;
     }
 
     /**
@@ -309,41 +231,9 @@ class CarrierSchema implements DeliveryOptionsValidatorInterface
         return $this->carrier;
     }
 
-    /**
-     * @param  class-string<OrderOptionDefinitionInterface>|OrderOptionDefinitionInterface $definition
-     *
-     * @return bool
-     */
-    private function canHave($definition): bool
-    {
-        return $this->hasShipmentOption($definition);
-    }
-
     private function createSchema(): array
     {
-        // Return the outbound features from the proposition config if present.
-        return $this->getCarrier()->outboundFeatures ? $this->getCarrier()->outboundFeatures->toArray() : [];
-    }
-
-    public function hasMetadataFeature(string $feature): bool
-    {
-        $value = $this->getMetadataFeature($feature);
-
-        if (PropositionCarrierMetadata::FEATURE_CUSTOM_CONTRACT_ONLY === $value) {
-            return $this->carrier->isCustom;
-        }
-
-        return (bool) $value;
-    }
-
-    /**
-     * @param  string $feature
-     *
-     * @return mixed
-     */
-    private function getMetadataFeature(string $feature)
-    {
-        return $this->getFromSchema(sprintf('metadata.%s', $feature));
+        return $this->getCarrier()->toArray();
     }
 
     /**
@@ -354,21 +244,6 @@ class CarrierSchema implements DeliveryOptionsValidatorInterface
     private function getFromSchema(string $key)
     {
         return Arr::get($this->getSchema(), $key);
-    }
-
-    /**
-     * @param  class-string<OrderOptionDefinitionInterface>|OrderOptionDefinitionInterface $definition
-     *
-     * @return mixed
-     */
-    private function hasShipmentOption($definition)
-    {
-        $resolvedDefinition = $this->resolveDefinition($definition);
-
-        return in_array(
-            $resolvedDefinition->getPropositionKey(),
-            $this->getFromSchema('shipmentOptions') ?: [],
-        );
     }
 
     /**

--- a/tests/Unit/App/Options/Contract/OrderOptionDefinitionInterfaceTest.php
+++ b/tests/Unit/App/Options/Contract/OrderOptionDefinitionInterfaceTest.php
@@ -71,18 +71,17 @@ it('snapshots all definitions', function () use ($definitions) {
 
 it('can validate', function () use ($definitions) {
     $fakeCarrier = factory(Carrier::class)
-        ->withOutboundFeatures(factory(PropositionCarrierFeatures::class)->withEverything())
+        ->withCarrier('POSTNL')
+        ->withAllCapabilities()
         ->make();
 
     $carrierSchema = Pdk::get(CarrierSchema::class);
     $carrierSchema->setCarrier($fakeCarrier);
 
-    $array = array_map(function ($definition) use ($carrierSchema) {
+    foreach ($definitions as $definition) {
         /** @var \MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface $instance */
         $instance = new $definition();
 
-        return $instance->validate($carrierSchema);
-    }, $definitions);
-
-    expect($array)->each->toBeTrue();
+        \PHPUnit\Framework\Assert::assertTrue($instance->validate($carrierSchema), "Definition {$definition} failed validation");
+    }
 });

--- a/tests/Unit/App/Options/FrontendDefinitionConsistencyTest.php
+++ b/tests/Unit/App/Options/FrontendDefinitionConsistencyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\App\Options;
+
+use MyParcelNL\Pdk\App\DeliveryOptions\Service\DeliveryOptionsService;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Tests\Uses\UsesEachMockPdkInstance;
+use ReflectionClass;
+
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+/**
+ * Phase 2 guardrail: proves that NON_DEFINITION_CARRIER_SETTINGS_MAP contains only
+ * delivery-type, package-type, and other non-shipment-option entries. Shipment option
+ * allow/price keys must NOT appear in this constant — they are built dynamically from
+ * OrderOptionDefinitions via getCarrierSettingsMap().
+ */
+
+usesShared(new UsesEachMockPdkInstance());
+
+it('documents which NON_DEFINITION_CARRIER_SETTINGS_MAP entries are backed by definitions', function () {
+    $definitions = Pdk::get('orderOptionDefinitions');
+
+    $definitionAllowKeys = [];
+    $definitionPriceKeys = [];
+
+    foreach ($definitions as $definition) {
+        $allowKey = $definition->getAllowSettingsKey();
+        $priceKey = $definition->getPriceSettingsKey();
+
+        if ($allowKey) {
+            $definitionAllowKeys[] = $allowKey;
+        }
+
+        if ($priceKey) {
+            $definitionPriceKeys[] = $priceKey;
+        }
+    }
+
+    $reflection = new ReflectionClass(DeliveryOptionsService::class);
+    $constants  = $reflection->getConstants();
+
+    // @TODO: PHP 8.0+: use $reflection->getReflectionConstant('NON_DEFINITION_CARRIER_SETTINGS_MAP')
+    $map = $constants['NON_DEFINITION_CARRIER_SETTINGS_MAP'];
+
+    // No allow* or price* shipment option keys backed by a definition should exist in this constant.
+    // If they appear here, they should be moved to the definitions instead.
+    foreach ($map as $frontendKey => $settingsValue) {
+        $inDefinitions = in_array($settingsValue, $definitionAllowKeys, true)
+            || in_array($settingsValue, $definitionPriceKeys, true);
+
+        expect($inDefinitions)
+            ->toBeFalse(
+                "Entry \"{$frontendKey} => {$settingsValue}\" is backed by a definition and should be removed from NON_DEFINITION_CARRIER_SETTINGS_MAP"
+            );
+    }
+});

--- a/tests/Unit/App/Options/Helper/CapabilitiesDefaultHelperTest.php
+++ b/tests/Unit/App/Options/Helper/CapabilitiesDefaultHelperTest.php
@@ -1,0 +1,74 @@
+<?php
+/** @noinspection StaticClosureCanBeUsedInspection,PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\App\Options\Helper;
+
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
+use MyParcelNL\Pdk\App\Options\Definition\SignatureDefinition;
+use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\Carrier\Model\Carrier;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
+use MyParcelNL\Pdk\Storage\Contract\StorageInterface;
+use MyParcelNL\Pdk\Tests\Uses\UsesAccountMock;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Pdk\Types\Service\TriStateService;
+use function MyParcelNL\Pdk\Tests\factory;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+uses()->group('options', 'tri-state');
+
+usesShared(new UsesMockPdkInstance(), new UsesAccountMock());
+
+it('returns ENABLED when isSelectedByDefault is true', function () {
+    factory(Carrier::class)
+        ->withAllCapabilities()
+        ->withOptionSelectedByDefault('requiresSignature')
+        ->store();
+
+    // Clear the carrier repository cache so the updated carrier is re-fetched from the account.
+    $storage = Pdk::get(StorageInterface::class);
+    $storage->delete('carrier:POSTNL');
+    $storage->delete('carrier:all');
+
+    $order = factory(PdkOrder::class)
+        ->withDeliveryOptions(factory(DeliveryOptions::class)->withCarrier('POSTNL'))
+        ->make();
+
+    $helper = new CapabilitiesDefaultHelper($order);
+
+    expect($helper->get(new SignatureDefinition()))->toEqual(TriStateService::ENABLED);
+});
+
+it('returns INHERIT when isSelectedByDefault is false', function () {
+    factory(Carrier::class)
+        ->withAllCapabilities()
+        ->store();
+
+    $storage = Pdk::get(StorageInterface::class);
+    $storage->delete('carrier:POSTNL');
+    $storage->delete('carrier:all');
+
+    $order = factory(PdkOrder::class)
+        ->withDeliveryOptions(factory(DeliveryOptions::class)->withCarrier('POSTNL'))
+        ->make();
+
+    $helper = new CapabilitiesDefaultHelper($order);
+
+    expect($helper->get(new SignatureDefinition()))->toEqual(TriStateService::INHERIT);
+});
+
+it('returns INHERIT when definition has no capabilities key', function () {
+    $order = factory(PdkOrder::class)
+        ->withDeliveryOptions(factory(DeliveryOptions::class)->withCarrier('POSTNL'))
+        ->make();
+
+    $helper = new CapabilitiesDefaultHelper($order);
+
+    $definition = \Mockery::mock(OrderOptionDefinitionInterface::class);
+    $definition->shouldReceive('getCapabilitiesOptionsKey')->andReturn(null);
+
+    expect($helper->get($definition))->toEqual(TriStateService::INHERIT);
+});

--- a/tests/Unit/App/Options/Helper/CarrierSettingsDefinitionHelperTest.php
+++ b/tests/Unit/App/Options/Helper/CarrierSettingsDefinitionHelperTest.php
@@ -14,10 +14,11 @@ use MyParcelNL\Pdk\Tests\Uses\UsesSettingsMock;
 use MyParcelNL\Pdk\Types\Service\TriStateService;
 use function MyParcelNL\Pdk\Tests\factory;
 use function MyParcelNL\Pdk\Tests\usesShared;
+use MyParcelNL\Pdk\Tests\Uses\UsesAccountMock;
 
 uses()->group('settings', 'tri-state');
 
-usesShared(new UsesMockPdkInstance(), new UsesSettingsMock());
+usesShared(new UsesMockPdkInstance(), new UsesSettingsMock(), new UsesAccountMock());
 
 it('gets value with all settings disabled', function (string $carrierName, OrderOptionDefinitionInterface $definition) {
     $factory = factory(Settings::class)

--- a/tests/Unit/App/Options/Helper/ShipmentOptionsDefinitionHelperTest.php
+++ b/tests/Unit/App/Options/Helper/ShipmentOptionsDefinitionHelperTest.php
@@ -11,10 +11,11 @@ use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
 use MyParcelNL\Pdk\Types\Service\TriStateService;
 use function MyParcelNL\Pdk\Tests\factory;
 use function MyParcelNL\Pdk\Tests\usesShared;
+use MyParcelNL\Pdk\Tests\Uses\UsesAccountMock;
 
 uses()->group('settings', 'tri-state');
 
-usesShared(new UsesMockPdkInstance());
+usesShared(new UsesMockPdkInstance(), new UsesAccountMock());
 
 it('gets value from order', function (OrderOptionDefinitionInterface $definition) {
     $order = factory(PdkOrder::class)->make();

--- a/tests/Unit/App/Options/OptionDefinitionConsistencyTest.php
+++ b/tests/Unit/App/Options/OptionDefinitionConsistencyTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\App\Options;
+
+use MyParcelNL\Pdk\App\Order\Collection\PdkOrderLineCollection;
+use MyParcelNL\Pdk\App\Order\Contract\PdkOrderOptionsServiceInterface;
+use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\App\Order\Model\PdkOrderLine;
+use MyParcelNL\Pdk\Carrier\Model\Carrier;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Fulfilment\Model\ShipmentOptions as FulfilmentShipmentOptions;
+use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
+use MyParcelNL\Pdk\Settings\Model\ProductSettings;
+use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
+use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
+use MyParcelNL\Pdk\Tests\Uses\UsesAccountMock;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Pdk\Types\Service\TriStateService;
+
+use function MyParcelNL\Pdk\Tests\factory;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+/**
+ * Proves all real registered definitions are correctly wired into the real models.
+ * Unlike the flow test (which uses a fake definition to test the mechanism), this test
+ * iterates all 17+ production definitions and verifies each one produces valid attributes
+ * with correct defaults on CarrierSettings, ProductSettings, ShipmentOptions, and
+ * Fulfilment\ShipmentOptions.
+ */
+
+usesShared(new UsesMockPdkInstance(), new UsesAccountMock());
+
+it('registers all definition-derived attributes on CarrierSettings', function () {
+    $definitions     = Pdk::get('orderOptionDefinitions');
+    $carrierSettings = new CarrierSettings();
+    $attributes      = $carrierSettings->getAttributes();
+
+    foreach ($definitions as $definition) {
+        $carrierKey = $definition->getCarrierSettingsKey();
+        if ($carrierKey !== null) {
+            expect(array_key_exists($carrierKey, $attributes))
+                ->toBeTrue("CarrierSettings is missing attribute '{$carrierKey}' for " . get_class($definition));
+        }
+
+        $allowKey = $definition->getAllowSettingsKey();
+        if ($allowKey !== null) {
+            expect(array_key_exists($allowKey, $attributes))
+                ->toBeTrue("CarrierSettings is missing allow attribute '{$allowKey}' for " . get_class($definition));
+        }
+
+        $priceKey = $definition->getPriceSettingsKey();
+        if ($priceKey !== null) {
+            expect(array_key_exists($priceKey, $attributes))
+                ->toBeTrue("CarrierSettings is missing price attribute '{$priceKey}' for " . get_class($definition));
+        }
+    }
+});
+
+it('registers all definition-derived attributes on ProductSettings', function () {
+    $definitions     = Pdk::get('orderOptionDefinitions');
+    $productSettings = new ProductSettings();
+    $attributes      = $productSettings->getAttributes();
+
+    foreach ($definitions as $definition) {
+        $productKey = $definition->getProductSettingsKey();
+        if ($productKey !== null) {
+            expect(array_key_exists($productKey, $attributes))
+                ->toBeTrue("ProductSettings is missing attribute '{$productKey}' for " . get_class($definition));
+        }
+    }
+});
+
+it('registers all definition-derived attributes on ShipmentOptions', function () {
+    $definitions     = Pdk::get('orderOptionDefinitions');
+    $shipmentOptions = new ShipmentOptions();
+
+    foreach ($definitions as $definition) {
+        $key = $definition->getShipmentOptionsKey();
+        if ($key !== null) {
+            expect($shipmentOptions->getAttribute($key))->toBe(
+                $definition->getShipmentOptionsDefault(),
+                "ShipmentOptions attribute '{$key}' has wrong default for " . get_class($definition)
+            );
+        }
+    }
+});
+
+it('registers all definition-derived attributes on Fulfilment ShipmentOptions', function () {
+    $definitions        = Pdk::get('orderOptionDefinitions');
+    $fulfilmentOptions  = new FulfilmentShipmentOptions();
+
+    foreach ($definitions as $definition) {
+        $key = $definition->getShipmentOptionsKey();
+        if ($key !== null) {
+            expect($fulfilmentOptions->getAttribute($key))->toBeNull(
+                "Fulfilment ShipmentOptions attribute '{$key}' should default to null for " . get_class($definition)
+            );
+        }
+    }
+});
+
+it('flows product settings through calculateShipmentOptions for all definitions with both product and shipment option keys', function () {
+    $definitions = Pdk::get('orderOptionDefinitions');
+
+    factory(Carrier::class)
+        ->withAllCapabilities()
+        ->store();
+
+    foreach ($definitions as $definition) {
+        $productKey  = $definition->getProductSettingsKey();
+        $shipmentKey = $definition->getShipmentOptionsKey();
+
+        if ($productKey === null || $shipmentKey === null) {
+            continue;
+        }
+
+        $order = factory(PdkOrder::class)
+            ->withDeliveryOptions(
+                factory(DeliveryOptions::class)->withCarrier('POSTNL')
+            )
+            ->withLines(
+                factory(PdkOrderLineCollection::class)->push(
+                    factory(PdkOrderLine::class)->withProduct(
+                        factory(\MyParcelNL\Pdk\App\Order\Model\PdkProduct::class)
+                            ->withSettings(factory(ProductSettings::class)->with([$productKey => TriStateService::ENABLED]))
+                    )
+                )
+            )
+            ->make();
+
+        /** @var PdkOrderOptionsServiceInterface $service */
+        $service = Pdk::get(PdkOrderOptionsServiceInterface::class);
+        $flags   = PdkOrderOptionsServiceInterface::EXCLUDE_SHIPMENT_OPTIONS | PdkOrderOptionsServiceInterface::EXCLUDE_CARRIER_SETTINGS;
+
+        $newOrder = $service->calculateShipmentOptions($order, $flags);
+
+        expect($newOrder->deliveryOptions->shipmentOptions->getAttribute($shipmentKey))->toBe(
+            TriStateService::ENABLED,
+            "Definition " . get_class($definition) . " with productKey='{$productKey}' should flow through to shipmentOptions['{$shipmentKey}'] as ENABLED"
+        );
+    }
+});

--- a/tests/Unit/App/Options/ShipmentOptionDefinitionFlowTest.php
+++ b/tests/Unit/App/Options/ShipmentOptionDefinitionFlowTest.php
@@ -1,0 +1,225 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection,PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\App\Options;
+
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
+use MyParcelNL\Pdk\App\Options\Definition\AbstractOrderOptionDefinition;
+use MyParcelNL\Pdk\App\Order\Contract\PdkOrderOptionsServiceInterface;
+use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\Carrier\Model\Carrier;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Fulfilment\Model\ShipmentOptions as FulfilmentShipmentOptions;
+use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
+use MyParcelNL\Pdk\Settings\Model\ProductSettings;
+use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
+use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
+use MyParcelNL\Pdk\Tests\Uses\UsesAccountMock;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Pdk\Types\Service\TriStateService;
+use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
+
+use function DI\value;
+use function MyParcelNL\Pdk\Tests\factory;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+/**
+ * Proves the option definition mechanism works end-to-end with a fake option.
+ * Registers a TestFlowOptionDefinition as the only definition (isolating from real ones)
+ * and verifies the entire pipeline: settings registration on all models, option calculation
+ * through the priority chain, carrier validation via capabilities key, and the V2 API
+ * export/import roundtrip (shipment options key ↔ capabilities key conversion).
+ *
+ * Uses distinct PDK and capabilities keys to match the real definition convention,
+ * where the shipment option key (legacy V1 naming) differs from the capabilities key (V2 naming).
+ */
+final class TestFlowOptionDefinition extends AbstractOrderOptionDefinition
+{
+    public function getShipmentOptionsKey(): ?string
+    {
+        return 'testFlowOption';
+    }
+
+    public function getCapabilitiesOptionsKey(): ?string
+    {
+        return 'testFlowCapability';
+    }
+}
+
+uses()->group('options', 'flow');
+
+usesShared(
+    new UsesMockPdkInstance([
+        'orderOptionDefinitions' => value([new TestFlowOptionDefinition()]),
+    ]),
+    new UsesAccountMock()
+);
+
+it('registers exportTestFlowOption on CarrierSettings with TriState INHERIT default', function () {
+    $settings = new CarrierSettings();
+
+    expect($settings->getAttribute('exportTestFlowOption'))->toBe(TriStateService::INHERIT);
+});
+
+it('registers allowTestFlowOption on CarrierSettings with false default', function () {
+    $settings = new CarrierSettings();
+
+    expect($settings->getAttribute('allowTestFlowOption'))->toBe(false);
+});
+
+it('registers priceTestFlowOption on CarrierSettings with 0 default', function () {
+    $settings = new CarrierSettings();
+
+    // Price settings are cast as 'float', so the default 0 is stored as 0.0
+    expect($settings->getAttribute('priceTestFlowOption'))->toBe(0.0);
+});
+
+it('registers exportTestFlowOption on ProductSettings with TriState INHERIT default', function () {
+    $settings = new ProductSettings();
+
+    expect($settings->getAttribute('exportTestFlowOption'))->toBe(TriStateService::INHERIT);
+});
+
+it('registers testFlowOption on ShipmentOptions with TriState INHERIT default', function () {
+    $options = new ShipmentOptions();
+
+    expect($options->getAttribute('testFlowOption'))->toBe(TriStateService::INHERIT);
+});
+
+it('registers testFlowOption on Fulfilment ShipmentOptions with null default', function () {
+    $options = new FulfilmentShipmentOptions();
+
+    expect($options->getAttribute('testFlowOption'))->toBeNull();
+});
+
+it('casts testFlowOption to bool on Fulfilment ShipmentOptions', function () {
+    $options = new FulfilmentShipmentOptions(['testFlowOption' => true]);
+
+    expect($options->testFlowOption)->toBe(true);
+});
+
+it('resolves testFlowOption through priority chain via calculateShipmentOptions', function () {
+    factory(Carrier::class)
+        ->withAllCapabilities()
+        ->store();
+
+    $order = factory(PdkOrder::class)
+        ->withDeliveryOptions(
+            factory(DeliveryOptions::class)
+                ->withCarrier('POSTNL')
+                ->withShipmentOptions(new ShipmentOptions(['testFlowOption' => TriStateService::ENABLED]))
+        )
+        ->make();
+
+    /** @var PdkOrderOptionsServiceInterface $service */
+    $service  = Pdk::get(PdkOrderOptionsServiceInterface::class);
+    $newOrder = $service->calculateShipmentOptions($order);
+
+    expect($newOrder->deliveryOptions->shipmentOptions->testFlowOption)->toBe(TriStateService::ENABLED);
+});
+
+it('resolves testFlowOption to DISABLED when no source sets a value', function () {
+    factory(Carrier::class)
+        ->withAllCapabilities()
+        ->store();
+
+    $order = factory(PdkOrder::class)
+        ->withDeliveryOptions(
+            factory(DeliveryOptions::class)->withCarrier('POSTNL')
+        )
+        ->make();
+
+    /** @var PdkOrderOptionsServiceInterface $service */
+    $service  = Pdk::get(PdkOrderOptionsServiceInterface::class);
+    $newOrder = $service->calculateShipmentOptions($order);
+
+    // When all sources are INHERIT, TriStateService::resolve() returns DISABLED (0) as the final value.
+    expect($newOrder->deliveryOptions->shipmentOptions->testFlowOption)->toBe(TriStateService::DISABLED);
+});
+
+it('canHaveShipmentOption checks the capabilities key against carrier options', function () {
+    // The definition's getCapabilitiesOptionsKey() is 'testFlowCapability'.
+    // canHaveShipmentOption() uses that key to look up availability in the carrier schema.
+    // Since 'testFlowCapability' is not a real SDK capabilities key, it will not appear
+    // in any carrier's options, so the result is always false for this fake definition.
+    $carrier = factory(Carrier::class)
+        ->withAllCapabilities()
+        ->make();
+
+    /** @var CarrierSchema $carrierSchema */
+    $carrierSchema = Pdk::get(CarrierSchema::class);
+    $carrierSchema->setCarrier($carrier);
+
+    $definition = new TestFlowOptionDefinition();
+
+    // The key 'testFlowCapability' is not in the SDK capabilities model, so it is never available.
+    expect($carrierSchema->canHaveShipmentOption($definition))->toBeFalse();
+});
+
+it('canHaveShipmentOption uses the definition capabilities key, not the shipment options key', function () {
+    // Verify that canHaveShipmentOption() checks getCapabilitiesOptionsKey(), not getShipmentOptionsKey().
+    // A carrier with NO options should return false for any definition.
+    $carrier = factory(Carrier::class)
+        ->withMinimalCapabilities()
+        ->make();
+
+    /** @var CarrierSchema $carrierSchema */
+    $carrierSchema = Pdk::get(CarrierSchema::class);
+    $carrierSchema->setCarrier($carrier);
+
+    $definition = new TestFlowOptionDefinition();
+
+    expect($carrierSchema->canHaveShipmentOption($definition))->toBeFalse();
+});
+
+it('toCapabilitiesDefinitions maps the shipment option key to the capabilities key', function () {
+    // The definition maps: testFlowOption (shipment) -> testFlowCapability (capabilities).
+    $options = new ShipmentOptions(['testFlowOption' => TriStateService::ENABLED]);
+
+    $result = ShipmentOptions::toCapabilitiesDefinitions($options);
+
+    // The result should use the capabilities key 'testFlowCapability', not 'testFlowOption'
+    expect($result)->toHaveKey('testFlowCapability');
+    expect($result['testFlowCapability'])->toBe(TriStateService::ENABLED);
+});
+
+it('fromCapabilitiesDefinitions maps the capabilities key back to the shipment options key', function () {
+    // Input uses capabilities key 'testFlowCapability', output should be under shipment options key 'testFlowOption'.
+    $data = ['testFlowCapability' => TriStateService::ENABLED];
+
+    $options = ShipmentOptions::fromCapabilitiesDefinitions($data);
+
+    expect($options->getAttribute('testFlowOption'))->toBe(TriStateService::ENABLED);
+});
+
+it('roundtrips through toCapabilitiesDefinitions and fromCapabilitiesDefinitions', function () {
+    // Start with a ShipmentOptions model, export to capabilities format, then import back.
+    $original = new ShipmentOptions(['testFlowOption' => TriStateService::DISABLED]);
+
+    $exported = ShipmentOptions::toCapabilitiesDefinitions($original);
+
+    // After export, the value should be under the capabilities key
+    expect($exported)->toHaveKey('testFlowCapability');
+    expect($exported['testFlowCapability'])->toBe(TriStateService::DISABLED);
+
+    $imported = ShipmentOptions::fromCapabilitiesDefinitions($exported);
+
+    // After import, the value should be back under the shipment options key
+    expect($imported->getAttribute('testFlowOption'))->toBe(TriStateService::DISABLED);
+});
+
+it('definition derives correct key values for the full pipeline', function () {
+    $definition = new TestFlowOptionDefinition();
+
+    expect($definition->getShipmentOptionsKey())->toBe('testFlowOption');
+    expect($definition->getCapabilitiesOptionsKey())->toBe('testFlowCapability');
+    expect($definition->getCarrierSettingsKey())->toBe('exportTestFlowOption');
+    expect($definition->getProductSettingsKey())->toBe('exportTestFlowOption');
+    expect($definition->getAllowSettingsKey())->toBe('allowTestFlowOption');
+    expect($definition->getPriceSettingsKey())->toBe('priceTestFlowOption');
+    expect($definition->getShipmentOptionsCast())->toBe(TriStateService::TYPE_STRICT);
+    expect($definition->getShipmentOptionsDefault())->toBe(TriStateService::INHERIT);
+});

--- a/tests/Unit/Fulfilment/Model/ShipmentOptionsTest.php
+++ b/tests/Unit/Fulfilment/Model/ShipmentOptionsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection PhpUnhandledExceptionInspection,StaticClosureCanBeUsedInspection */
 
 declare(strict_types=1);
@@ -9,11 +10,13 @@ use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
 use function MyParcelNL\Pdk\Tests\factory;
 use function MyParcelNL\Pdk\Tests\usesShared;
+use MyParcelNL\Pdk\Tests\Uses\UsesAccountMock;
 
-usesShared(new UsesMockPdkInstance());
+usesShared(new UsesMockPdkInstance(), new UsesAccountMock());
 
 it('can create instance from pdk delivery options', function () {
     $deliveryOptions = factory(DeliveryOptions::class)
+        ->withCarrier('POSTNL')
         ->withDeliveryType(DeliveryOptions::DELIVERY_TYPE_MORNING_NAME)
         ->withPackageType(DeliveryOptions::PACKAGE_TYPE_MAILBOX_NAME)
         ->withAllShipmentOptions()
@@ -28,15 +31,20 @@ it('can create instance from pdk delivery options', function () {
         'insurance'        => 100,
         'labelDescription' => 'test',
         'ageCheck'         => true,
-        'collect'          => null,
-        'cooledDelivery'   => null,
+        'collect'          => false,
+        'cooledDelivery'   => false,
         'hideSender'       => true,
         'largeFormat'      => true,
         'onlyRecipient'    => true,
         'priorityDelivery' => true,
         'return'           => true,
         'sameDayDelivery'  => true,
-        'saturdayDelivery' => null,
+        'saturdayDelivery' => false,
         'signature'        => true,
+        'receiptCode'      => true,
+        'tracked'          => false,
+        'excludeParcelLockers' => false,
+        'freshFood'        => false,
+        'frozen'           => false,
     ]);
 });

--- a/tests/Unit/Shipment/Model/Options/ShipmentOptionsTest.php
+++ b/tests/Unit/Shipment/Model/Options/ShipmentOptionsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection,PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Shipment\Model;
+
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Pdk\Types\Service\TriStateService;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPdkInstance());
+
+it('fromCapabilitiesDefinitions preserves values when capabilities key matches model key', function () {
+    // When the capabilities key and model key are the same (e.g. 'tracked', 'insurance'),
+    // fromCapabilitiesDefinitions must not lose the value.
+    $result = ShipmentOptions::fromCapabilitiesDefinitions([
+        'tracked'   => TriStateService::DISABLED,
+        'insurance' => TriStateService::DISABLED,
+    ]);
+
+    expect($result->tracked)->toBe(TriStateService::DISABLED)
+        ->and($result->insurance)->toBe(TriStateService::DISABLED);
+});
+
+it('fromCapabilitiesDefinitions maps capability keys to model keys', function () {
+    // When the capabilities key differs from the model key (e.g. requiresSignature → signature),
+    // the value should be mapped correctly.
+    $result = ShipmentOptions::fromCapabilitiesDefinitions([
+        'requiresSignature' => TriStateService::DISABLED,
+    ]);
+
+    expect($result->signature)->toBe(TriStateService::DISABLED);
+});
+
+it('fromCapabilitiesDefinitions preserves all values in export-like merge scenario', function () {
+    // Simulate merge of existing order shipmentOptions (model keys) with request data (capability keys)
+    $existingOptions = [
+        'signature' => TriStateService::ENABLED,
+        'tracked'   => TriStateService::INHERIT,
+    ];
+
+    $requestOptions = [
+        'requiresSignature' => TriStateService::DISABLED,
+        'tracked'           => TriStateService::DISABLED,
+        'insurance'         => TriStateService::INHERIT,
+    ];
+
+    // After array_replace_recursive, both model and capability keys coexist
+    $merged = \array_replace_recursive($existingOptions, $requestOptions);
+    $result = ShipmentOptions::fromCapabilitiesDefinitions($merged);
+
+    // requiresSignature:0 → mapped to signature, overwriting existing 1
+    expect($result->signature)->toBe(TriStateService::DISABLED)
+        // tracked:0 → same key as model, must not be lost
+        ->and($result->tracked)->toBe(TriStateService::DISABLED)
+        // insurance:-1 → same key as model, must not be lost
+        ->and($result->insurance)->toBe(TriStateService::INHERIT);
+});

--- a/tests/Unit/Validation/Validator/CarrierSchemaTest.php
+++ b/tests/Unit/Validation/Validator/CarrierSchemaTest.php
@@ -10,7 +10,6 @@ use BadMethodCallException;
 use MyParcelNL\Pdk\Carrier\Model\Carrier;
 use MyParcelNL\Pdk\Carrier\Model\CarrierCapabilities;
 use MyParcelNL\Pdk\Facade\Pdk;
-use MyParcelNL\Pdk\Proposition\Model\PropositionCarrierFeatures;
 use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
 
 use function MyParcelNL\Pdk\Tests\factory;
@@ -22,7 +21,7 @@ function createSchema(): CarrierSchema
 {
     $carrier = factory(Carrier::class)
         ->withName('fake')
-        ->withOutboundFeatures(factory(PropositionCarrierFeatures::class)->withEverything())
+        ->withAllCapabilities()
         ->make();
 
     $carrierSchema = Pdk::get(CarrierSchema::class);


### PR DESCRIPTION
Depends on: #441

Option definitions are now the single source of truth for all key mappings,
reducing the files touched when adding a new shipment option from 9+ to 2-3.
AbstractOrderOptionDefinition derives settings keys by convention (export,
allow, price). ResolvesOptionAttributes trait lets models build attributes
dynamically from registered definitions. CapabilitiesDefaultHelper enforces
isRequired and isSelectedByDefault from the capabilities API.

- Add AbstractOrderOptionDefinition with convention-based defaults
- Add ResolvesOptionAttributes trait for dynamic attribute building
- Add CooledDeliveryDefinition
- Migrate all definition classes to extend AbstractOrderOptionDefinition
- Add CapabilitiesDefaultHelper for isRequired/isSelectedByDefault resolution
- Integrate dynamic attribute resolution into ShipmentOptions, CarrierSettings,
  ProductSettings, and Fulfilment\ShipmentOptions
- Replace CarrierSchema individual canHave*() methods with __call() proxy
- Filter Carrier capability options to registered definitions only
- Remove internal ShipmentOptions constant usage across PDK
- Make CarrierSettingsItemView, ProductSettingsView, and DeliveryOptionsService
  definition-driven (Phase 2: dynamic frontend views)
- Add flow, consistency, and frontend definition tests

BREAKING CHANGE: OrderOptionDefinitionInterface has new required methods:
getCapabilitiesOptionsKey(), getAllowSettingsKey(), getPriceSettingsKey(),
getShipmentOptionsCast(), getShipmentOptionsDefault().
Removed: getPropositionKey().
Migration: extend AbstractOrderOptionDefinition for defaults.

DeliveryOptionsValidatorInterface: removed canHaveAgeCheck(),
canHaveDirectReturn(), canHaveHideSender(), canHaveInsurance(),
canHaveLargeFormat(), canHaveOnlyRecipient(), canHaveSameDayDelivery(),
canHaveSignature(). These are now proxied via CarrierSchema::__call().

CarrierSettings::fromCarrier() now requires a Carrier instance (was string|Carrier).

CarrierSettings export option attributes changed from bool to tri-state.

Renamed CarrierSettings constants:
PRICE_DELIVERY_TYPE_EVENING → PRICE_DELIVERY_TYPE_EVENING_DELIVERY
PRICE_DELIVERY_TYPE_MORNING → PRICE_DELIVERY_TYPE_MORNING_DELIVERY
PRICE_DELIVERY_TYPE_MONDAY → PRICE_DELIVERY_TYPE_MONDAY_DELIVERY
PRICE_DELIVERY_TYPE_SAME_DAY → PRICE_DELIVERY_TYPE_SAME_DAY_DELIVERY
PRICE_DELIVERY_TYPE_SATURDAY → PRICE_DELIVERY_TYPE_SATURDAY_DELIVERY
PRICE_DELIVERY_TYPE_STANDARD → PRICE_DELIVERY_TYPE_STANDARD_DELIVERY

ShipmentOptions, CarrierSettings, and ProductSettings option constants are
deprecated. Use OrderOptionDefinitionInterface methods instead.

Carrier capability options are now filtered to only include options with a
registered OrderOptionDefinition. Unregistered API options are stripped.

FIxes INT-1261