### PR TITLE
fix: add JsonResponse::create() for Symfony 6+ IDE helper compatibility

### DIFF
--- a/src/Api/Response/JsonResponse.php
+++ b/src/Api/Response/JsonResponse.php
@@ -10,17 +10,25 @@ use Symfony\Component\HttpFoundation\Response;
 class JsonResponse extends Response
 {
     /**
-     * Factory method for fluent creation. Restores compatibility with Symfony 6+
-     * which removed Response::create().
+     * Factory method for fluent creation. Uses a Symfony-compatible signature
+     * when Response::create() exists and normalizes content to the array payload
+     * expected by this response class.
      *
-     * @param  array $data
+     * @param  mixed $content
      * @param  int   $status
      * @param  array $headers
      *
      * @return static
      */
-    public static function create(array $data = [], int $status = 200, array $headers = []): self
+    public static function create($content = '', int $status = 200, array $headers = [])
     {
+        if (is_array($content)) {
+            $data = $content;
+        } elseif (null === $content || '' === $content) {
+            $data = [];
+        } else {
+            $data = ['content' => $content];
+        }
         return new static($data, $status, $headers);
     }
 

--- a/src/Api/Response/JsonResponse.php
+++ b/src/Api/Response/JsonResponse.php
@@ -18,7 +18,7 @@ class JsonResponse extends Response
      * @param  int   $status
      * @param  array $headers
      *
-     * @return static
+     * @return self
      */
     public static function create($content = '', int $status = 200, array $headers = [])
     {

--- a/src/Api/Response/JsonResponse.php
+++ b/src/Api/Response/JsonResponse.php
@@ -10,6 +10,21 @@ use Symfony\Component\HttpFoundation\Response;
 class JsonResponse extends Response
 {
     /**
+     * Factory method for fluent creation. Restores compatibility with Symfony 6+
+     * which removed Response::create().
+     *
+     * @param  array $data
+     * @param  int   $status
+     * @param  array $headers
+     *
+     * @return static
+     */
+    public static function create(array $data = [], int $status = 200, array $headers = []): self
+    {
+        return new static($data, $status, $headers);
+    }
+
+    /**
      * @param  array $data
      * @param  int   $status
      * @param  array $headers


### PR DESCRIPTION
## Summary

- Adds `create()` static factory method to `JsonResponse` for Symfony 6+ compatibility
- The IDE helper generator (`composer console generate:ide-helper`) fails on PHP 8.1+ because Symfony 6 removed `Response::create()` and the generator tries to reflect it

## Test plan

- [x] `PHP_VERSION=8.1 docker compose run php composer console generate:ide-helper` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)