### PR TITLE
fix(INT-1261): combine Presta export compat and age-check toggle fixes

### DIFF
--- a/src/Api/Response/JsonResponse.php
+++ b/src/Api/Response/JsonResponse.php
@@ -12,15 +12,16 @@ class JsonResponse extends Response
     /**
      * Factory method for fluent creation. Uses a Symfony-compatible signature
      * when Response::create() exists and normalizes content to the array payload
-     * expected by this response class.
+     * expected by this response class. Parameters stay untyped because the PDK
+     * supports multiple Symfony parent signatures.
      *
      * @param  mixed $content
-     * @param  int   $status
-     * @param  array $headers
+     * @param  mixed $status
+     * @param  mixed $headers
      *
-     * @return self
+     * @return static
      */
-    public static function create($content = '', int $status = 200, array $headers = [])
+    public static function create($content = '', $status = 200, $headers = [])
     {
         if (is_array($content)) {
             $data = $content;

--- a/src/App/Action/Backend/Settings/UpdatePluginSettingsAction.php
+++ b/src/App/Action/Backend/Settings/UpdatePluginSettingsAction.php
@@ -7,10 +7,21 @@ namespace MyParcelNL\Pdk\App\Action\Backend\Settings;
 use InvalidArgumentException;
 use MyParcelNL\Pdk\Api\Response\JsonResponse;
 use MyParcelNL\Pdk\App\Action\Contract\ActionInterface;
+use MyParcelNL\Pdk\App\Order\Calculator\General\CarrierSpecificCalculator;
+use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
+use MyParcelNL\Pdk\App\Order\Model\ShippingAddress;
+use MyParcelNL\Pdk\App\Options\Contract\OrderOptionDefinitionInterface;
 use MyParcelNL\Pdk\App\Service\DeliveryOptionsResetService;
+use MyParcelNL\Pdk\Base\Service\CountryCodes;
+use MyParcelNL\Pdk\Carrier\Contract\CarrierRepositoryInterface;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Proposition\Service\PropositionService;
 use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
+use MyParcelNL\Pdk\Settings\SettingsManager;
 use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
 use MyParcelNL\Pdk\Settings\Model\Settings;
+use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
+use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -56,6 +67,7 @@ class UpdatePluginSettingsAction implements ActionInterface
 
         // Reset underlying delivery options settings when DELIVERY_OPTIONS_ENABLED is disabled
         $this->resetDeliveryOptionsWhenDisabled($settings);
+        $this->normalizeCarrierSettings($settings);
 
         foreach (array_keys($pluginSettings) as $editedSettingsId) {
             $this->settingsRepository->storeSettings($settings->getAttribute($editedSettingsId));
@@ -88,6 +100,131 @@ class UpdatePluginSettingsAction implements ActionInterface
             if ($carrierSettings->deliveryOptionsEnabled === false) {
                 $this->deliveryOptionsResetService->resetDeliveryOptions($carrierSettings);
             }
+        }
+    }
+
+    /**
+     * Normalize carrier export settings through the existing carrier calculators so the
+     * saved defaults cannot drift away from the effective shipment rules used elsewhere.
+     *
+     * Example: PostNL age check requires signature + only recipient, while UPS age check
+     * only requires signature. The settings page should persist those same rules.
+     *
+     * @param  \MyParcelNL\Pdk\Settings\Model\Settings $settings
+     *
+     * @return void
+     */
+    private function normalizeCarrierSettings(Settings $settings): void
+    {
+        if ($settings->carrier === null) {
+            return;
+        }
+
+        /** @var CarrierRepositoryInterface $carrierRepository */
+        $carrierRepository = Pdk::get(CarrierRepositoryInterface::class);
+
+        /** @var OrderOptionDefinitionInterface[] $definitions */
+        $definitions = Pdk::get('orderOptionDefinitions');
+
+        $localCountryCode = Pdk::get(PropositionService::class)->getPropositionConfig()->countryCode
+            ?: CountryCodes::CC_NL;
+
+        foreach ($settings->carrier as $carrierName => $carrierSettings) {
+            if (
+                ! $carrierSettings instanceof CarrierSettings
+                || ! is_string($carrierName)
+                || CarrierSettings::ID === $carrierName
+                || SettingsManager::KEY_ALL === $carrierName
+            ) {
+                continue;
+            }
+
+            $carrier = $carrierRepository->find($carrierName);
+
+            if (! $carrier) {
+                try {
+                    $carrier = $carrierRepository->findByLegacyName(strtolower($carrierName));
+                } catch (InvalidArgumentException $e) {
+                    continue;
+                }
+            }
+
+            if (! $carrier) {
+                continue;
+            }
+
+            $order = new PdkOrder([
+                'deliveryOptions' => new DeliveryOptions([
+                    'carrier'         => $carrier,
+                    'shipmentOptions' => new ShipmentOptions(
+                        $this->mapCarrierSettingsToShipmentOptions($carrierSettings, $definitions)
+                    ),
+                ]),
+                'shippingAddress' => new ShippingAddress([
+                    'cc' => $localCountryCode,
+                ]),
+            ]);
+
+            (new CarrierSpecificCalculator($order))->calculate();
+
+            $this->mapShipmentOptionsBackToCarrierSettings(
+                $carrierSettings,
+                $order->deliveryOptions->shipmentOptions,
+                $definitions
+            );
+        }
+    }
+
+    /**
+     * @param  \MyParcelNL\Pdk\Settings\Model\CarrierSettings                      $carrierSettings
+     * @param  array<array-key, OrderOptionDefinitionInterface>                    $definitions
+     *
+     * @return array<string, mixed>
+     */
+    private function mapCarrierSettingsToShipmentOptions(
+        CarrierSettings $carrierSettings,
+        array $definitions
+    ): array {
+        $shipmentOptions = [];
+
+        foreach ($definitions as $definition) {
+            $carrierSettingsKey = $definition->getCarrierSettingsKey();
+            $shipmentOptionsKey = $definition->getShipmentOptionsKey();
+
+            if (! $carrierSettingsKey || ! $shipmentOptionsKey) {
+                continue;
+            }
+
+            $shipmentOptions[$shipmentOptionsKey] = $carrierSettings->getAttribute($carrierSettingsKey);
+        }
+
+        return $shipmentOptions;
+    }
+
+    /**
+     * @param  \MyParcelNL\Pdk\Settings\Model\CarrierSettings                      $carrierSettings
+     * @param  \MyParcelNL\Pdk\Shipment\Model\ShipmentOptions                      $shipmentOptions
+     * @param  array<array-key, OrderOptionDefinitionInterface>                    $definitions
+     *
+     * @return void
+     */
+    private function mapShipmentOptionsBackToCarrierSettings(
+        CarrierSettings $carrierSettings,
+        ShipmentOptions $shipmentOptions,
+        array $definitions
+    ): void {
+        foreach ($definitions as $definition) {
+            $carrierSettingsKey = $definition->getCarrierSettingsKey();
+            $shipmentOptionsKey = $definition->getShipmentOptionsKey();
+
+            if (! $carrierSettingsKey || ! $shipmentOptionsKey) {
+                continue;
+            }
+
+            $carrierSettings->setAttribute(
+                $carrierSettingsKey,
+                $shipmentOptions->getAttribute($shipmentOptionsKey)
+            );
         }
     }
 }

--- a/src/App/DeliveryOptions/Service/DeliveryOptionsService.php
+++ b/src/App/DeliveryOptions/Service/DeliveryOptionsService.php
@@ -25,6 +25,7 @@ use MyParcelNL\Pdk\Frontend\Contract\FrontendDataAdapterInterface;
 use MyParcelNL\Pdk\Proposition\Service\PropositionService;
 use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
 use MyParcelNL\Pdk\Settings\Model\CheckoutSettings;
+use MyParcelNL\Pdk\Settings\SettingsManager;
 use MyParcelNL\Pdk\Shipment\Contract\DropOffServiceInterface;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Pdk\Shipment\Model\PackageType;
@@ -163,7 +164,7 @@ class DeliveryOptionsService implements DeliveryOptionsServiceInterface
      */
     private function createCarrierSettings(Carrier $carrier, PdkCart $cart, string $packageType): array
     {
-        $carrierSettings = CarrierSettings::fromCarrier($carrier);
+        $carrierSettings = $this->getCarrierSettings($carrier);
 
         $dropOff           = $this->dropOffService->getForDate($carrierSettings);
         $dropOffCollection = $this->dropOffService->getPossibleDropOffDays($carrierSettings);
@@ -202,6 +203,30 @@ class DeliveryOptionsService implements DeliveryOptionsServiceInterface
                 'dropOffDays'          => $dropOffDays,
             ]
         );
+    }
+
+    /**
+     * @param  \MyParcelNL\Pdk\Carrier\Model\Carrier $carrier
+     *
+     * @return \MyParcelNL\Pdk\Settings\Model\CarrierSettings
+     */
+    private function getCarrierSettings(Carrier $carrier): CarrierSettings
+    {
+        $allCarrierSettings = Settings::all()->carrier;
+        $carrierSettings    = $allCarrierSettings->get($carrier->carrier);
+        $storedSettings     = Settings::get($carrier->carrier, CarrierSettings::ID);
+
+        if (null !== $storedSettings && $carrierSettings) {
+            return clone $carrierSettings;
+        }
+
+        $globalSettings = $allCarrierSettings->get(SettingsManager::KEY_ALL);
+
+        if ($globalSettings) {
+            return (clone $globalSettings)->fill(['id' => $carrier->carrier]);
+        }
+
+        return new CarrierSettings(['id' => $carrier->carrier]);
     }
 
     /**

--- a/src/Context/Model/OrderDataContext.php
+++ b/src/Context/Model/OrderDataContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\Context\Model;
 
+use MyParcelNL\Pdk\App\Order\Calculator\General\CarrierSpecificCalculator;
 use MyParcelNL\Pdk\App\Order\Contract\PdkOrderOptionsServiceInterface;
 use MyParcelNL\Pdk\App\Order\Model\PdkOrder;
 use MyParcelNL\Pdk\Base\Support\Collection;
@@ -118,6 +119,7 @@ class OrderDataContext extends PdkOrder
             $clonedOrder = new PdkOrder([
                 'deliveryOptions' => $this->attributes['deliveryOptions'],
                 'lines'           => $this->attributes['lines'],
+                'shippingAddress' => $this->attributes['shippingAddress'],
             ]);
             $newCarrier  = $this->carrierRepository->find($carrier->carrier);
 
@@ -127,6 +129,10 @@ class OrderDataContext extends PdkOrder
                 $clonedOrder,
                 PdkOrderOptionsServiceInterface::EXCLUDE_SHIPMENT_OPTIONS
             );
+
+            // Apply carrier-specific cascades (for example 18+ => signature + only recipient)
+            // so the admin context reflects the same effective defaults as export calculations.
+            (new CarrierSpecificCalculator($calculatedOrder))->calculate();
 
             $calculatedOrder->deliveryOptions->offsetUnset('carrier');
 

--- a/src/Frontend/View/CarrierSettingsItemView.php
+++ b/src/Frontend/View/CarrierSettingsItemView.php
@@ -25,7 +25,6 @@ use MyParcelNL\Pdk\Frontend\Form\InteractiveElement;
 use MyParcelNL\Pdk\Frontend\Form\SettingsDivider;
 use MyParcelNL\Pdk\Proposition\Service\PropositionService;
 use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
-use MyParcelNL\Pdk\Types\Service\TriStateService;
 use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageTypeV2;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesDeliveryTypeV2;
@@ -269,11 +268,14 @@ class CarrierSettingsItemView extends AbstractSettingsView
             $ageCheckElement = (new InteractiveElement($ageCheckDefinition->getCarrierSettingsKey(), Components::INPUT_TOGGLE))
                 ->builder(function (FormOperationBuilder $builder) use ($signatureKey, $onlyRecipientKey) {
                     $builder->afterUpdate(function (FormAfterUpdateBuilder $afterUpdate) use ($signatureKey, $onlyRecipientKey) {
+                        // Toggle-typed fields on the JS side emit/receive booleans, so
+                        // operand literals must be true/false — not TriStateService::ENABLED
+                        // (int 1), which fails the frontend's strict `$eq` check.
                         if ($signatureKey) {
-                            $afterUpdate->setValue(TriStateService::ENABLED)->on($signatureKey)->if->eq(TriStateService::ENABLED);
+                            $afterUpdate->setValue(true)->on($signatureKey)->if->eq(true);
                         }
                         if ($onlyRecipientKey) {
-                            $afterUpdate->setValue(TriStateService::ENABLED)->on($onlyRecipientKey)->if->eq(TriStateService::ENABLED);
+                            $afterUpdate->setValue(true)->on($onlyRecipientKey)->if->eq(true);
                         }
                     });
                 });

--- a/tests/Unit/Api/Response/JsonResponseTest.php
+++ b/tests/Unit/Api/Response/JsonResponseTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Api\Response;
+
+use ReflectionMethod;
+
+it('creates a pdk json response through the factory method', function () {
+    $response = JsonResponse::create([
+        'success' => true,
+    ], 201, [
+        'X-Test' => '1',
+    ]);
+
+    expect($response->getStatusCode())->toBe(201);
+    expect($response->headers->get('X-Test'))->toBe('1');
+    expect(json_decode($response->getContent(), true))->toBe([
+        'data' => [
+            'success' => true,
+        ],
+    ]);
+});
+
+it('keeps the create factory parameters untyped for symfony compatibility', function () {
+    $method = new ReflectionMethod(JsonResponse::class, 'create');
+
+    foreach ($method->getParameters() as $parameter) {
+        expect($parameter->hasType())->toBeFalse();
+    }
+});

--- a/tests/Unit/App/Action/Backend/Order/ExportOrderActionTest.php
+++ b/tests/Unit/App/Action/Backend/Order/ExportOrderActionTest.php
@@ -243,6 +243,60 @@ it('exports order with age check setting enabled', function (bool $orderMode) {
 })
     ->with('order mode toggle');
 
+it('exports order with age check setting enabled when checkout stored disabled dependents', function (bool $orderMode) {
+    $fakeCarrier = factory(Carrier::class)
+        ->withCarrier(RefCapabilitiesSharedCarrierV2::POSTNL)
+        ->withAllCapabilities()
+        ->make();
+
+    factory(Settings::class)
+        ->withOrder(factory(OrderSettings::class)->withOrderMode($orderMode))
+        ->withCarrier(
+            $fakeCarrier->carrier,
+            factory(CarrierSettings::class)
+                ->withExportAgeCheck(true)
+                ->withExportOnlyRecipient(true)
+                ->withExportSignature(true)
+        )
+        ->store();
+
+    $collection = factory(PdkOrderCollection::class)
+        ->push(
+            factory(PdkOrder::class)
+                ->withDeliveryOptions(
+                    factory(DeliveryOptions::class)
+                        ->withCarrier($fakeCarrier)
+                        ->withShipmentOptions(
+                            factory(ShipmentOptions::class)
+                                ->withAgeCheck(TriStateService::INHERIT)
+                                ->withOnlyRecipient(TriStateService::DISABLED)
+                                ->withSignature(TriStateService::DISABLED)
+                        )
+                )
+        )
+        ->store()
+        ->make();
+
+    MockApi::enqueue(
+        ...$orderMode
+            ? [new ExamplePostOrdersResponse(), new ExamplePostOrderNotesResponse()]
+            : [new ExamplePostShipmentsResponse()]
+    );
+
+    Actions::execute(PdkBackendActions::EXPORT_ORDERS, [
+        'orderIds' => Arr::pluck($collection->toArray(), 'externalIdentifier'),
+    ]);
+
+    $lastRequest = MockApi::ensureLastRequest();
+    $body        = json_decode($lastRequest->getBody()->getContents(), true);
+    $options     = getRequestOptions($body, $orderMode);
+
+    expect($options['age_check'])->toBe(1)
+        ->and($options['only_recipient'])->toBe(1)
+        ->and($options['signature'])->toBe(1);
+})
+    ->with('order mode toggle');
+
 it('exports order with return setting enabled', function (bool $orderMode) {
     $body    = exportWithSetting($orderMode, factory(CarrierSettings::class)->withExportReturn(true));
     $options = getRequestOptions($body, $orderMode);

--- a/tests/Unit/App/Action/Backend/Settings/UpdatePluginSettingsActionTest.php
+++ b/tests/Unit/App/Action/Backend/Settings/UpdatePluginSettingsActionTest.php
@@ -7,13 +7,17 @@ namespace MyParcelNL\Pdk\App\Action\Backend\Settings;
 
 use MyParcelNL\Pdk\App\Api\Backend\PdkBackendActions;
 use MyParcelNL\Pdk\Base\Support\Arr;
+use MyParcelNL\Pdk\Carrier\Model\Carrier;
 use MyParcelNL\Pdk\Facade\Actions;
+use MyParcelNL\Pdk\Tests\Uses\UsesAccountMock;
 use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesSharedCarrierV2;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use function MyParcelNL\Pdk\Tests\factory;
 use function MyParcelNL\Pdk\Tests\usesShared;
 
-usesShared(new UsesMockPdkInstance());
+usesShared(new UsesMockPdkInstance(), new UsesAccountMock());
 
 it('saves settings', function (array $data) {
     $content = json_encode([
@@ -93,5 +97,114 @@ it('resets delivery options when disabled', function () {
             'allowPriorityDelivery'    => false,
             'allowPickupLocations'     => false,
             'allowDeliveryTypeExpress' => false,
+        ]);
+});
+
+it('normalizes carrier-specific shipment option dependencies when saving carrier settings', function (
+    string $carrierName,
+    array $carrierSettings,
+    array $expected
+) {
+    factory(Carrier::class)
+        ->withAllCapabilities($carrierName)
+        ->store();
+
+    $content = json_encode([
+        'data' => [
+            'plugin_settings' => [
+                'carrier' => [
+                    $carrierName => array_merge(
+                        ['id' => $carrierName],
+                        $carrierSettings
+                    ),
+                ],
+            ],
+        ],
+    ]);
+
+    $request  = new Request(['action' => PdkBackendActions::UPDATE_PLUGIN_SETTINGS], [], [], [], [], [], $content);
+    $response = Actions::execute($request);
+    $content  = json_decode($response->getContent(), true);
+
+    expect($response)
+        ->toBeInstanceOf(Response::class)
+        ->and($response->getStatusCode())
+        ->toBe(200)
+        ->and($content['data']['plugin_settings']['carrier'][$carrierName])
+        ->toHaveKeysAndValues($expected);
+})->with([
+    'postnl: age check also enables signature and only recipient' => [
+        RefCapabilitiesSharedCarrierV2::POSTNL,
+        [
+            'exportAgeCheck'      => 1,
+            'exportSignature'     => 0,
+            'exportOnlyRecipient' => 0,
+        ],
+        [
+            'exportAgeCheck'      => 1,
+            'exportSignature'     => 1,
+            'exportOnlyRecipient' => 1,
+        ],
+    ],
+    'ups standard: age check enables signature only' => [
+        RefCapabilitiesSharedCarrierV2::UPS_STANDARD,
+        [
+            'exportAgeCheck'      => 1,
+            'exportSignature'     => 0,
+            'exportOnlyRecipient' => 0,
+        ],
+        [
+            'exportAgeCheck'      => 1,
+            'exportSignature'     => 1,
+            'exportOnlyRecipient' => 0,
+        ],
+    ],
+    'dhl for you: age check disables only recipient' => [
+        RefCapabilitiesSharedCarrierV2::DHL_FOR_YOU,
+        [
+            'exportAgeCheck'      => 1,
+            'exportOnlyRecipient' => 1,
+        ],
+        [
+            'exportAgeCheck'      => 1,
+            'exportOnlyRecipient' => 0,
+        ],
+    ],
+]);
+
+it('normalizes carrier settings when the payload uses carrier collection keys as identifiers', function () {
+    factory(Carrier::class)
+        ->withAllCapabilities(RefCapabilitiesSharedCarrierV2::POSTNL)
+        ->store();
+
+    $content = json_encode([
+        'data' => [
+            'plugin_settings' => [
+                'carrier' => [
+                    'id'     => 'carrier',
+                    'POSTNL' => [
+                        'id'                  => 'carrier',
+                        'exportAgeCheck'      => 1,
+                        'exportSignature'     => 0,
+                        'exportOnlyRecipient' => 0,
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    $request  = new Request(['action' => PdkBackendActions::UPDATE_PLUGIN_SETTINGS], [], [], [], [], [], $content);
+    $response = Actions::execute($request);
+    $content  = json_decode($response->getContent(), true);
+
+    expect($response)
+        ->toBeInstanceOf(Response::class)
+        ->and($response->getStatusCode())
+        ->toBe(200)
+        ->and($content['data']['plugin_settings']['carrier']['POSTNL'])
+        ->toHaveKeysAndValues([
+            'exportAgeCheck'      => 1,
+            'exportSignature'     => 1,
+            'exportOnlyRecipient' => 1,
         ]);
 });

--- a/tests/Unit/App/DeliveryOptions/Service/DeliveryOptionsServiceTest.php
+++ b/tests/Unit/App/DeliveryOptions/Service/DeliveryOptionsServiceTest.php
@@ -15,16 +15,18 @@ use MyParcelNL\Pdk\Carrier\Model\Carrier;
 use MyParcelNL\Pdk\Carrier\Model\CarrierFactory;
 use MyParcelNL\Pdk\Facade\FrontendData;
 use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
 use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
 use MyParcelNL\Pdk\Settings\Model\ProductSettings;
+use MyParcelNL\Pdk\Settings\SettingsManager;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Pdk\Tests\Uses\UsesAccountMock;
 use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesSharedCarrierV2;
 
 use function MyParcelNL\Pdk\Tests\factory;
 use function MyParcelNL\Pdk\Tests\usesShared;
 use function Spatie\Snapshots\assertMatchesJsonSnapshot;
-use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesSharedCarrierV2;
 
 uses()->group('checkout');
 
@@ -242,4 +244,52 @@ it('uses international mailbox price when shipping address is non-local', functi
 
     $carrierId   = FrontendData::getLegacyCarrierIdentifier($fakeCarrier->carrier);
     expect($result['carrierSettings'][$carrierId]['pricePackageTypeMailbox'])->toBe(1.05);
+});
+
+it('uses global carrier settings when a carrier-specific row is missing', function () {
+    $carrierFactory = factory(Carrier::class)->withCarrier(RefCapabilitiesSharedCarrierV2::POSTNL);
+    $fakeCarrier    = $carrierFactory->make();
+
+    $globalCarrierSettings = new CarrierSettings([
+        'id'                                      => SettingsManager::KEY_ALL,
+        CarrierSettings::DELIVERY_OPTIONS_ENABLED => true,
+        CarrierSettings::ALLOW_DELIVERY_OPTIONS   => true,
+        CarrierSettings::ALLOW_STANDARD_DELIVERY  => true,
+        CarrierSettings::ALLOW_MORNING_DELIVERY   => true,
+        CarrierSettings::ALLOW_PICKUP_DELIVERY    => true,
+    ]);
+
+    Pdk::get(PdkSettingsRepositoryInterface::class)
+        ->store(Pdk::get('createSettingsKey')(CarrierSettings::ID), [
+            SettingsManager::KEY_ALL => $globalCarrierSettings->toStorableArray(),
+        ]);
+
+    factory(Shop::class)
+        ->withCarriers(factory(CarrierCollection::class)->push($carrierFactory))
+        ->store();
+
+    /** @var \MyParcelNL\Pdk\App\DeliveryOptions\Contract\DeliveryOptionsServiceInterface $service */
+    $service = Pdk::get(DeliveryOptionsServiceInterface::class);
+
+    $result = $service->createAllCarrierSettings(new PdkCart([
+        'lines' => [
+            [
+                'quantity' => 1,
+                'product'  => [
+                    'weight'        => 1,
+                    'isDeliverable' => true,
+                ],
+            ],
+        ],
+    ]));
+
+    $carrierId = FrontendData::getLegacyCarrierIdentifier($fakeCarrier->carrier);
+
+    expect($result['carrierSettings'][$carrierId])
+        ->toMatchArray([
+            'allowDeliveryOptions'   => true,
+            'allowStandardDelivery'  => true,
+            'allowMorningDelivery'   => true,
+            'allowPickupLocations'   => true,
+        ]);
 });

--- a/tests/Unit/Context/Model/OrderDataContextCapabilitiesTest.php
+++ b/tests/Unit/Context/Model/OrderDataContextCapabilitiesTest.php
@@ -147,3 +147,36 @@ it('isRequired overrides even explicit carrier settings in inherited delivery op
     expect($inherited['POSTNL']['shipmentOptions']['requiresSignature'])
         ->toBe(TriStateService::ENABLED);
 });
+
+it('applies carrier-specific cascades in inherited delivery options', function () {
+    factory(Carrier::class)
+        ->withAllCapabilities()
+        ->store();
+
+    $storage = Pdk::get(StorageInterface::class);
+    $storage->delete('carrier:POSTNL');
+    $storage->delete('carrier:all');
+
+    factory(Settings::class)
+        ->withCarrier('POSTNL', [CarrierSettings::EXPORT_AGE_CHECK => 1])
+        ->store();
+
+    $order = factory(PdkOrder::class)
+        ->withDeliveryOptions(
+            factory(DeliveryOptions::class)->withCarrier('POSTNL')
+        )
+        ->make();
+
+    $context = factory(OrderDataContext::class)
+        ->with($order->getAttributes())
+        ->make();
+
+    $inherited = $context->inheritedDeliveryOptions->toArrayWithoutNull();
+
+    expect($inherited['POSTNL']['shipmentOptions'])
+        ->toMatchArray([
+            'requiresAgeVerification' => TriStateService::ENABLED,
+            'requiresSignature'       => TriStateService::ENABLED,
+            'recipientOnlyDelivery'   => TriStateService::ENABLED,
+        ]);
+});

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_plugin_settings__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_plugin_settings__1.json
@@ -1807,22 +1807,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -3417,22 +3417,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -5027,22 +5027,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -6637,22 +6637,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -8247,22 +8247,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -9857,22 +9857,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -11467,22 +11467,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -13077,22 +13077,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -14687,22 +14687,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -16297,22 +16297,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -17907,22 +17907,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -19568,22 +19568,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -21178,22 +21178,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
@@ -22788,22 +22788,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": 1,
+                                                "$value": true,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": 1
+                                                        "$eq": true
                                                     }
                                                 ]
                                             }

--- a/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_carrier_settings__1.json
+++ b/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_carrier_settings__1.json
@@ -24,22 +24,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -1634,22 +1634,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -3244,22 +3244,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -4854,22 +4854,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -6464,22 +6464,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -8074,22 +8074,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -9684,22 +9684,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -11294,22 +11294,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -12904,22 +12904,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -14514,22 +14514,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -16124,22 +16124,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -17785,22 +17785,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -19395,22 +19395,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
@@ -21005,22 +21005,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": 1,
+                                        "$value": true,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": 1
+                                                "$eq": true
                                             }
                                         ]
                                     }


### PR DESCRIPTION
## Summary
- keep `JsonResponse::create()` compatible with the Presta runtime
- apply carrier option cascades for age-check export
- fall back to global `*` carrier settings when a carrier-specific settings row is missing
- add regression coverage for Delivery Options settings fallback and age-check export

