### PR TITLE
fix(settings): preserve falsy $value in $setValue serialization

### DIFF
--- a/src/Frontend/Form/Builder/Operation/AbstractFormOperation.php
+++ b/src/Frontend/Form/Builder/Operation/AbstractFormOperation.php
@@ -75,7 +75,7 @@ abstract class AbstractFormOperation extends AbstractFormBuilderCore implements 
     final public function toArray(?int $flags = null): array
     {
         return [
-            $this->getOperationKey() => Utils::filterNull(array_filter($this->createArray())),
+            $this->getOperationKey() => Utils::filterNull($this->createArray()),
         ];
     }
 }

--- a/tests/Unit/Frontend/Form/Builder/Operation/FormSetValueOperationTest.php
+++ b/tests/Unit/Frontend/Form/Builder/Operation/FormSetValueOperationTest.php
@@ -18,6 +18,20 @@ it('can be converted to array', function () {
     ]);
 });
 
+it('preserves a falsy $value when converted to array', function ($falsyValue) {
+    $operation = new FormSetValueOperation(new FormOperationBuilder(), $falsyValue);
+
+    expect($operation->toArray())->toBe([
+        '$setValue' => [
+            '$value' => $falsyValue,
+        ],
+    ]);
+})->with([
+    'false'        => [false],
+    'integer zero' => [0],
+    'empty string' => [''],
+]);
+
 it('throws error when a non-scalar value is passed', function () {
     new FormSetValueOperation(new FormOperationBuilder(), (object) ['something' => 1]);
 })->throws(InvalidArgumentException::class);

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_plugin_settings__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_plugin_settings__1.json
@@ -16,7 +16,9 @@
                     "name": "orderMode",
                     "$builders": [
                         {
-                            "$readOnlyWhen": []
+                            "$readOnlyWhen": {
+                                "$if": []
+                            }
                         }
                     ],
                     "$component": "ToggleInput",
@@ -2292,6 +2294,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -2302,6 +2305,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -2312,6 +2316,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -2322,6 +2327,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -2332,6 +2338,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -2342,6 +2349,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -2352,6 +2360,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -2362,6 +2371,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -2372,6 +2382,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -2382,6 +2393,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -2392,6 +2404,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -2402,6 +2415,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -3902,6 +3916,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -3912,6 +3927,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -3922,6 +3938,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -3932,6 +3949,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -3942,6 +3960,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -3952,6 +3971,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -3962,6 +3982,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -3972,6 +3993,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -3982,6 +4004,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -3992,6 +4015,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -4002,6 +4026,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -4012,6 +4037,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -5512,6 +5538,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -5522,6 +5549,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -5532,6 +5560,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -5542,6 +5571,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -5552,6 +5582,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -5562,6 +5593,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -5572,6 +5604,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -5582,6 +5615,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -5592,6 +5626,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -5602,6 +5637,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -5612,6 +5648,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -5622,6 +5659,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -7122,6 +7160,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -7132,6 +7171,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -7142,6 +7182,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -7152,6 +7193,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -7162,6 +7204,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -7172,6 +7215,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -7182,6 +7226,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -7192,6 +7237,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -7202,6 +7248,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -7212,6 +7259,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -7222,6 +7270,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -7232,6 +7281,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -8732,6 +8782,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -8742,6 +8793,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -8752,6 +8804,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -8762,6 +8815,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -8772,6 +8826,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -8782,6 +8837,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -8792,6 +8848,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -8802,6 +8859,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -8812,6 +8870,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -8822,6 +8881,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -8832,6 +8892,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -8842,6 +8903,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -10342,6 +10404,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -10352,6 +10415,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -10362,6 +10426,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -10372,6 +10437,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -10382,6 +10448,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -10392,6 +10459,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -10402,6 +10470,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -10412,6 +10481,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -10422,6 +10492,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -10432,6 +10503,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -10442,6 +10514,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -10452,6 +10525,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -11952,6 +12026,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -11962,6 +12037,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -11972,6 +12048,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -11982,6 +12059,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -11992,6 +12070,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -12002,6 +12081,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -12012,6 +12092,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -12022,6 +12103,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -12032,6 +12114,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -12042,6 +12125,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -12052,6 +12136,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -12062,6 +12147,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -13562,6 +13648,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -13572,6 +13659,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -13582,6 +13670,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -13592,6 +13681,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -13602,6 +13692,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -13612,6 +13703,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -13622,6 +13714,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -13632,6 +13725,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -13642,6 +13736,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -13652,6 +13747,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -13662,6 +13758,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -13672,6 +13769,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -15172,6 +15270,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -15182,6 +15281,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -15192,6 +15292,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -15202,6 +15303,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -15212,6 +15314,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -15222,6 +15325,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -15232,6 +15336,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -15242,6 +15347,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -15252,6 +15358,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -15262,6 +15369,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -15272,6 +15380,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -15282,6 +15391,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -16782,6 +16892,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -16792,6 +16903,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -16802,6 +16914,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -16812,6 +16925,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -16822,6 +16936,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -16832,6 +16947,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -16842,6 +16958,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -16852,6 +16969,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -16862,6 +16980,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -16872,6 +16991,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -16882,6 +17002,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -16892,6 +17013,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -18392,6 +18514,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -18402,6 +18525,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -18412,6 +18536,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -18422,6 +18547,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -18432,6 +18558,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -18442,6 +18569,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -18452,6 +18580,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -18462,6 +18591,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -18472,6 +18602,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -18482,6 +18613,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -18492,6 +18624,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -18502,6 +18635,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -20053,6 +20187,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -20063,6 +20198,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -20073,6 +20209,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -20083,6 +20220,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -20093,6 +20231,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -20103,6 +20242,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -20113,6 +20253,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -20123,6 +20264,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -20133,6 +20275,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -20143,6 +20286,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -20153,6 +20297,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -20163,6 +20308,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -21663,6 +21809,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -21673,6 +21820,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -21683,6 +21831,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -21693,6 +21842,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -21703,6 +21853,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -21713,6 +21864,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -21723,6 +21875,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -21733,6 +21886,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -21743,6 +21897,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -21753,6 +21908,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -21763,6 +21919,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -21773,6 +21930,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
@@ -23273,6 +23431,7 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
@@ -23283,6 +23442,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
@@ -23293,6 +23453,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
@@ -23303,6 +23464,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
@@ -23313,6 +23475,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
@@ -23323,6 +23486,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
@@ -23333,6 +23497,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
@@ -23343,6 +23508,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
@@ -23353,6 +23519,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
@@ -23363,6 +23530,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
@@ -23373,6 +23541,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
@@ -23383,6 +23552,7 @@
                                         },
                                         {
                                             "$setValue": {
+                                                "$value": false,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {

--- a/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_carrier_settings__1.json
+++ b/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_carrier_settings__1.json
@@ -509,6 +509,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -519,6 +520,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -529,6 +531,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -539,6 +542,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -549,6 +553,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -559,6 +564,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -569,6 +575,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -579,6 +586,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -589,6 +597,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -599,6 +608,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -609,6 +619,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -619,6 +630,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -2119,6 +2131,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -2129,6 +2142,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -2139,6 +2153,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -2149,6 +2164,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -2159,6 +2175,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -2169,6 +2186,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -2179,6 +2197,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -2189,6 +2208,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -2199,6 +2219,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -2209,6 +2230,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -2219,6 +2241,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -2229,6 +2252,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -3729,6 +3753,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -3739,6 +3764,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -3749,6 +3775,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -3759,6 +3786,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -3769,6 +3797,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -3779,6 +3808,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -3789,6 +3819,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -3799,6 +3830,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -3809,6 +3841,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -3819,6 +3852,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -3829,6 +3863,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -3839,6 +3874,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -5339,6 +5375,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -5349,6 +5386,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -5359,6 +5397,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -5369,6 +5408,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -5379,6 +5419,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -5389,6 +5430,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -5399,6 +5441,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -5409,6 +5452,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -5419,6 +5463,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -5429,6 +5474,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -5439,6 +5485,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -5449,6 +5496,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -6949,6 +6997,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -6959,6 +7008,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -6969,6 +7019,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -6979,6 +7030,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -6989,6 +7041,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -6999,6 +7052,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -7009,6 +7063,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -7019,6 +7074,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -7029,6 +7085,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -7039,6 +7096,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -7049,6 +7107,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -7059,6 +7118,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -8559,6 +8619,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -8569,6 +8630,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -8579,6 +8641,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -8589,6 +8652,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -8599,6 +8663,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -8609,6 +8674,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -8619,6 +8685,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -8629,6 +8696,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -8639,6 +8707,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -8649,6 +8718,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -8659,6 +8729,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -8669,6 +8740,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -10169,6 +10241,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -10179,6 +10252,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -10189,6 +10263,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -10199,6 +10274,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -10209,6 +10285,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -10219,6 +10296,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -10229,6 +10307,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -10239,6 +10318,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -10249,6 +10329,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -10259,6 +10340,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -10269,6 +10351,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -10279,6 +10362,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -11779,6 +11863,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -11789,6 +11874,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -11799,6 +11885,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -11809,6 +11896,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -11819,6 +11907,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -11829,6 +11918,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -11839,6 +11929,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -11849,6 +11940,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -11859,6 +11951,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -11869,6 +11962,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -11879,6 +11973,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -11889,6 +11984,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -13389,6 +13485,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -13399,6 +13496,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -13409,6 +13507,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -13419,6 +13518,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -13429,6 +13529,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -13439,6 +13540,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -13449,6 +13551,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -13459,6 +13562,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -13469,6 +13573,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -13479,6 +13584,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -13489,6 +13595,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -13499,6 +13606,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -14999,6 +15107,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -15009,6 +15118,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -15019,6 +15129,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -15029,6 +15140,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -15039,6 +15151,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -15049,6 +15162,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -15059,6 +15173,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -15069,6 +15184,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -15079,6 +15195,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -15089,6 +15206,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -15099,6 +15217,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -15109,6 +15228,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -16609,6 +16729,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -16619,6 +16740,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -16629,6 +16751,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -16639,6 +16762,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -16649,6 +16773,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -16659,6 +16784,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -16669,6 +16795,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -16679,6 +16806,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -16689,6 +16817,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -16699,6 +16828,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -16709,6 +16839,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -16719,6 +16850,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -18270,6 +18402,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -18280,6 +18413,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -18290,6 +18424,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -18300,6 +18435,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -18310,6 +18446,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -18320,6 +18457,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -18330,6 +18468,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -18340,6 +18479,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -18350,6 +18490,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -18360,6 +18501,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -18370,6 +18512,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -18380,6 +18523,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -19880,6 +20024,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -19890,6 +20035,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -19900,6 +20046,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -19910,6 +20057,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -19920,6 +20068,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -19930,6 +20079,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -19940,6 +20090,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -19950,6 +20101,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -19960,6 +20112,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -19970,6 +20123,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -19980,6 +20134,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -19990,6 +20145,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
@@ -21490,6 +21646,7 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
@@ -21500,6 +21657,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
@@ -21510,6 +21668,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
@@ -21520,6 +21679,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
@@ -21530,6 +21690,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
@@ -21540,6 +21701,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
@@ -21550,6 +21712,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
@@ -21560,6 +21723,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
@@ -21570,6 +21734,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
@@ -21580,6 +21745,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
@@ -21590,6 +21756,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
@@ -21600,6 +21767,7 @@
                                 },
                                 {
                                     "$setValue": {
+                                        "$value": false,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {

--- a/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_order_settings__1.json
+++ b/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_order_settings__1.json
@@ -1,347 +1,349 @@
 {
-  "id": "order",
-  "title": "settings_order_title",
-  "description": "settings_order_description",
-  "elements": [
-    {
-      "$component": "SettingsDivider",
-      "$wrapper": false,
-      "level": 2,
-      "content": "settings_order_general_description",
-      "heading": "settings_order_general_title"
-    },
-    {
-      "name": "orderMode",
-      "$builders": [
+    "id": "order",
+    "title": "settings_order_title",
+    "description": "settings_order_description",
+    "elements": [
         {
-          "$readOnlyWhen": []
+            "$component": "SettingsDivider",
+            "$wrapper": false,
+            "level": 2,
+            "content": "settings_order_general_description",
+            "heading": "settings_order_general_title"
+        },
+        {
+            "name": "orderMode",
+            "$builders": [
+                {
+                    "$readOnlyWhen": {
+                        "$if": []
+                    }
+                }
+            ],
+            "$component": "ToggleInput",
+            "subtext": "hint_enable_order_mode_backoffice",
+            "label": "settings_order_order_mode",
+            "description": "settings_order_order_mode_description"
+        },
+        {
+            "name": "conceptShipments",
+            "$builders": [
+                {
+                    "$visibleWhen": {
+                        "$if": [
+                            {
+                                "$target": "orderMode",
+                                "$eq": false
+                            }
+                        ]
+                    }
+                }
+            ],
+            "$component": "ToggleInput",
+            "label": "settings_order_concept_shipments",
+            "description": "settings_order_concept_shipments_description"
+        },
+        {
+            "name": "processDirectly",
+            "$component": "SelectInput",
+            "label": "settings_order_process_directly",
+            "description": "settings_order_process_directly_description",
+            "options": [
+                {
+                    "value": -1,
+                    "label": "settings_none"
+                },
+                {
+                    "plainLabel": "Pending",
+                    "value": "pending"
+                },
+                {
+                    "plainLabel": "Paid",
+                    "value": "paid"
+                },
+                {
+                    "plainLabel": "Shipped",
+                    "value": "shipped"
+                },
+                {
+                    "plainLabel": "Completed",
+                    "value": "completed"
+                },
+                {
+                    "plainLabel": "Cancelled",
+                    "value": "cancelled"
+                },
+                {
+                    "plainLabel": "Refunded",
+                    "value": "refunded"
+                }
+            ],
+            "sort": "desc"
+        },
+        {
+            "name": "sendReturnEmail",
+            "$component": "ToggleInput",
+            "label": "settings_order_send_return_email",
+            "description": "settings_order_send_return_email_description"
+        },
+        {
+            "name": "saveCustomerAddress",
+            "$builders": [
+                {
+                    "$visibleWhen": {
+                        "$if": [
+                            {
+                                "$target": "orderMode",
+                                "$eq": false
+                            }
+                        ]
+                    }
+                }
+            ],
+            "$component": "ToggleInput",
+            "label": "settings_order_save_customer_address",
+            "description": "settings_order_save_customer_address_description"
+        },
+        {
+            "name": "shareCustomerInformation",
+            "$component": "ToggleInput",
+            "label": "settings_order_share_customer_information",
+            "description": "settings_order_share_customer_information_description"
+        },
+        {
+            "$component": "SettingsDivider",
+            "$wrapper": false,
+            "level": 2,
+            "content": "settings_order_status_description",
+            "heading": "settings_order_status_title"
+        },
+        {
+            "name": "statusOnLabelCreate",
+            "$component": "SelectInput",
+            "label": "settings_order_status_on_label_create",
+            "description": "settings_order_status_on_label_create_description",
+            "options": [
+                {
+                    "value": -1,
+                    "label": "settings_none"
+                },
+                {
+                    "plainLabel": "Pending",
+                    "value": "pending"
+                },
+                {
+                    "plainLabel": "Paid",
+                    "value": "paid"
+                },
+                {
+                    "plainLabel": "Shipped",
+                    "value": "shipped"
+                },
+                {
+                    "plainLabel": "Completed",
+                    "value": "completed"
+                },
+                {
+                    "plainLabel": "Cancelled",
+                    "value": "cancelled"
+                },
+                {
+                    "plainLabel": "Refunded",
+                    "value": "refunded"
+                }
+            ],
+            "sort": "desc"
+        },
+        {
+            "name": "statusWhenLabelScanned",
+            "$component": "SelectInput",
+            "label": "settings_order_status_when_label_scanned",
+            "description": "settings_order_status_when_label_scanned_description",
+            "options": [
+                {
+                    "value": -1,
+                    "label": "settings_none"
+                },
+                {
+                    "plainLabel": "Pending",
+                    "value": "pending"
+                },
+                {
+                    "plainLabel": "Paid",
+                    "value": "paid"
+                },
+                {
+                    "plainLabel": "Shipped",
+                    "value": "shipped"
+                },
+                {
+                    "plainLabel": "Completed",
+                    "value": "completed"
+                },
+                {
+                    "plainLabel": "Cancelled",
+                    "value": "cancelled"
+                },
+                {
+                    "plainLabel": "Refunded",
+                    "value": "refunded"
+                }
+            ],
+            "sort": "desc"
+        },
+        {
+            "name": "statusWhenDelivered",
+            "$component": "SelectInput",
+            "label": "settings_order_status_when_delivered",
+            "description": "settings_order_status_when_delivered_description",
+            "options": [
+                {
+                    "value": -1,
+                    "label": "settings_none"
+                },
+                {
+                    "plainLabel": "Pending",
+                    "value": "pending"
+                },
+                {
+                    "plainLabel": "Paid",
+                    "value": "paid"
+                },
+                {
+                    "plainLabel": "Shipped",
+                    "value": "shipped"
+                },
+                {
+                    "plainLabel": "Completed",
+                    "value": "completed"
+                },
+                {
+                    "plainLabel": "Cancelled",
+                    "value": "cancelled"
+                },
+                {
+                    "plainLabel": "Refunded",
+                    "value": "refunded"
+                }
+            ],
+            "sort": "desc"
+        },
+        {
+            "name": "sendNotificationAfter",
+            "$component": "SelectInput",
+            "label": "settings_order_send_notification_after",
+            "description": "settings_order_send_notification_after_description",
+            "options": [
+                {
+                    "value": -1,
+                    "label": "settings_none"
+                },
+                {
+                    "plainLabel": "Pending",
+                    "value": "pending"
+                },
+                {
+                    "plainLabel": "Paid",
+                    "value": "paid"
+                },
+                {
+                    "plainLabel": "Shipped",
+                    "value": "shipped"
+                },
+                {
+                    "plainLabel": "Completed",
+                    "value": "completed"
+                },
+                {
+                    "plainLabel": "Cancelled",
+                    "value": "cancelled"
+                },
+                {
+                    "plainLabel": "Refunded",
+                    "value": "refunded"
+                }
+            ],
+            "sort": "desc"
+        },
+        {
+            "$component": "SettingsDivider",
+            "$wrapper": false,
+            "level": 2,
+            "content": "settings_order_track_trace_description",
+            "heading": "settings_order_track_trace_title"
+        },
+        {
+            "name": "trackTraceInEmail",
+            "$component": "ToggleInput",
+            "label": "settings_order_track_trace_in_email",
+            "description": "settings_order_track_trace_in_email_description"
+        },
+        {
+            "name": "trackTraceInAccount",
+            "$component": "ToggleInput",
+            "label": "settings_order_track_trace_in_account",
+            "description": "settings_order_track_trace_in_account_description"
+        },
+        {
+            "$component": "SettingsDivider",
+            "$wrapper": false,
+            "level": 2,
+            "content": "settings_order_weight_description",
+            "heading": "settings_order_weight_title"
+        },
+        {
+            "name": "emptyParcelWeight",
+            "$component": "NumberInput",
+            "label": "settings_order_empty_parcel_weight",
+            "description": "settings_order_empty_parcel_weight_description"
+        },
+        {
+            "name": "emptyPackageSmallWeight",
+            "$component": "NumberInput",
+            "label": "settings_order_empty_package_small_weight",
+            "description": "settings_order_empty_package_small_weight_description"
+        },
+        {
+            "name": "emptyMailboxWeight",
+            "$component": "NumberInput",
+            "label": "settings_order_empty_mailbox_weight",
+            "description": "settings_order_empty_mailbox_weight_description"
+        },
+        {
+            "name": "emptyDigitalStampWeight",
+            "$component": "NumberInput",
+            "label": "settings_order_empty_digital_stamp_weight",
+            "description": "settings_order_empty_digital_stamp_weight_description"
+        },
+        {
+            "$component": "SettingsDivider",
+            "$wrapper": false,
+            "level": 2,
+            "content": "settings_order_order_notes_description",
+            "heading": "settings_order_order_notes_title"
+        },
+        {
+            "name": "barcodeInNote",
+            "$component": "ToggleInput",
+            "label": "settings_order_barcode_in_note",
+            "description": "settings_order_barcode_in_note_description"
+        },
+        {
+            "name": "barcodeInNoteTitle",
+            "$builders": [
+                {
+                    "$visibleWhen": {
+                        "$if": [
+                            {
+                                "$target": "barcodeInNote"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "$component": "TextInput",
+            "label": "settings_order_barcode_in_note_title",
+            "description": "settings_order_barcode_in_note_title_description"
         }
-      ],
-      "$component": "ToggleInput",
-      "subtext": "hint_enable_order_mode_backoffice",
-      "label": "settings_order_order_mode",
-      "description": "settings_order_order_mode_description"
-    },
-    {
-      "name": "conceptShipments",
-      "$builders": [
-        {
-          "$visibleWhen": {
-            "$if": [
-              {
-                "$target": "orderMode",
-                "$eq": false
-              }
-            ]
-          }
-        }
-      ],
-      "$component": "ToggleInput",
-      "label": "settings_order_concept_shipments",
-      "description": "settings_order_concept_shipments_description"
-    },
-    {
-      "name": "processDirectly",
-      "$component": "SelectInput",
-      "label": "settings_order_process_directly",
-      "description": "settings_order_process_directly_description",
-      "options": [
-        {
-          "value": -1,
-          "label": "settings_none"
-        },
-        {
-          "plainLabel": "Pending",
-          "value": "pending"
-        },
-        {
-          "plainLabel": "Paid",
-          "value": "paid"
-        },
-        {
-          "plainLabel": "Shipped",
-          "value": "shipped"
-        },
-        {
-          "plainLabel": "Completed",
-          "value": "completed"
-        },
-        {
-          "plainLabel": "Cancelled",
-          "value": "cancelled"
-        },
-        {
-          "plainLabel": "Refunded",
-          "value": "refunded"
-        }
-      ],
-      "sort": "desc"
-    },
-    {
-      "name": "sendReturnEmail",
-      "$component": "ToggleInput",
-      "label": "settings_order_send_return_email",
-      "description": "settings_order_send_return_email_description"
-    },
-    {
-      "name": "saveCustomerAddress",
-      "$builders": [
-        {
-          "$visibleWhen": {
-            "$if": [
-              {
-                "$target": "orderMode",
-                "$eq": false
-              }
-            ]
-          }
-        }
-      ],
-      "$component": "ToggleInput",
-      "label": "settings_order_save_customer_address",
-      "description": "settings_order_save_customer_address_description"
-    },
-    {
-      "name": "shareCustomerInformation",
-      "$component": "ToggleInput",
-      "label": "settings_order_share_customer_information",
-      "description": "settings_order_share_customer_information_description"
-    },
-    {
-      "$component": "SettingsDivider",
-      "$wrapper": false,
-      "level": 2,
-      "content": "settings_order_status_description",
-      "heading": "settings_order_status_title"
-    },
-    {
-      "name": "statusOnLabelCreate",
-      "$component": "SelectInput",
-      "label": "settings_order_status_on_label_create",
-      "description": "settings_order_status_on_label_create_description",
-      "options": [
-        {
-          "value": -1,
-          "label": "settings_none"
-        },
-        {
-          "plainLabel": "Pending",
-          "value": "pending"
-        },
-        {
-          "plainLabel": "Paid",
-          "value": "paid"
-        },
-        {
-          "plainLabel": "Shipped",
-          "value": "shipped"
-        },
-        {
-          "plainLabel": "Completed",
-          "value": "completed"
-        },
-        {
-          "plainLabel": "Cancelled",
-          "value": "cancelled"
-        },
-        {
-          "plainLabel": "Refunded",
-          "value": "refunded"
-        }
-      ],
-      "sort": "desc"
-    },
-    {
-      "name": "statusWhenLabelScanned",
-      "$component": "SelectInput",
-      "label": "settings_order_status_when_label_scanned",
-      "description": "settings_order_status_when_label_scanned_description",
-      "options": [
-        {
-          "value": -1,
-          "label": "settings_none"
-        },
-        {
-          "plainLabel": "Pending",
-          "value": "pending"
-        },
-        {
-          "plainLabel": "Paid",
-          "value": "paid"
-        },
-        {
-          "plainLabel": "Shipped",
-          "value": "shipped"
-        },
-        {
-          "plainLabel": "Completed",
-          "value": "completed"
-        },
-        {
-          "plainLabel": "Cancelled",
-          "value": "cancelled"
-        },
-        {
-          "plainLabel": "Refunded",
-          "value": "refunded"
-        }
-      ],
-      "sort": "desc"
-    },
-    {
-      "name": "statusWhenDelivered",
-      "$component": "SelectInput",
-      "label": "settings_order_status_when_delivered",
-      "description": "settings_order_status_when_delivered_description",
-      "options": [
-        {
-          "value": -1,
-          "label": "settings_none"
-        },
-        {
-          "plainLabel": "Pending",
-          "value": "pending"
-        },
-        {
-          "plainLabel": "Paid",
-          "value": "paid"
-        },
-        {
-          "plainLabel": "Shipped",
-          "value": "shipped"
-        },
-        {
-          "plainLabel": "Completed",
-          "value": "completed"
-        },
-        {
-          "plainLabel": "Cancelled",
-          "value": "cancelled"
-        },
-        {
-          "plainLabel": "Refunded",
-          "value": "refunded"
-        }
-      ],
-      "sort": "desc"
-    },
-    {
-      "name": "sendNotificationAfter",
-      "$component": "SelectInput",
-      "label": "settings_order_send_notification_after",
-      "description": "settings_order_send_notification_after_description",
-      "options": [
-        {
-          "value": -1,
-          "label": "settings_none"
-        },
-        {
-          "plainLabel": "Pending",
-          "value": "pending"
-        },
-        {
-          "plainLabel": "Paid",
-          "value": "paid"
-        },
-        {
-          "plainLabel": "Shipped",
-          "value": "shipped"
-        },
-        {
-          "plainLabel": "Completed",
-          "value": "completed"
-        },
-        {
-          "plainLabel": "Cancelled",
-          "value": "cancelled"
-        },
-        {
-          "plainLabel": "Refunded",
-          "value": "refunded"
-        }
-      ],
-      "sort": "desc"
-    },
-    {
-      "$component": "SettingsDivider",
-      "$wrapper": false,
-      "level": 2,
-      "content": "settings_order_track_trace_description",
-      "heading": "settings_order_track_trace_title"
-    },
-    {
-      "name": "trackTraceInEmail",
-      "$component": "ToggleInput",
-      "label": "settings_order_track_trace_in_email",
-      "description": "settings_order_track_trace_in_email_description"
-    },
-    {
-      "name": "trackTraceInAccount",
-      "$component": "ToggleInput",
-      "label": "settings_order_track_trace_in_account",
-      "description": "settings_order_track_trace_in_account_description"
-    },
-    {
-      "$component": "SettingsDivider",
-      "$wrapper": false,
-      "level": 2,
-      "content": "settings_order_weight_description",
-      "heading": "settings_order_weight_title"
-    },
-    {
-      "name": "emptyParcelWeight",
-      "$component": "NumberInput",
-      "label": "settings_order_empty_parcel_weight",
-      "description": "settings_order_empty_parcel_weight_description"
-    },
-    {
-      "name": "emptyPackageSmallWeight",
-      "$component": "NumberInput",
-      "label": "settings_order_empty_package_small_weight",
-      "description": "settings_order_empty_package_small_weight_description"
-    },
-    {
-      "name": "emptyMailboxWeight",
-      "$component": "NumberInput",
-      "label": "settings_order_empty_mailbox_weight",
-      "description": "settings_order_empty_mailbox_weight_description"
-    },
-    {
-      "name": "emptyDigitalStampWeight",
-      "$component": "NumberInput",
-      "label": "settings_order_empty_digital_stamp_weight",
-      "description": "settings_order_empty_digital_stamp_weight_description"
-    },
-    {
-      "$component": "SettingsDivider",
-      "$wrapper": false,
-      "level": 2,
-      "content": "settings_order_order_notes_description",
-      "heading": "settings_order_order_notes_title"
-    },
-    {
-      "name": "barcodeInNote",
-      "$component": "ToggleInput",
-      "label": "settings_order_barcode_in_note",
-      "description": "settings_order_barcode_in_note_description"
-    },
-    {
-      "name": "barcodeInNoteTitle",
-      "$builders": [
-        {
-          "$visibleWhen": {
-            "$if": [
-              {
-                "$target": "barcodeInNote"
-              }
-            ]
-          }
-        }
-      ],
-      "$component": "TextInput",
-      "label": "settings_order_barcode_in_note_title",
-      "description": "settings_order_barcode_in_note_title_description"
-    }
-  ],
-  "children": null
+    ],
+    "children": null
 }


### PR DESCRIPTION
## Summary
Follow-up to #452. The `array_filter` on the operation array was eating `$value: false` from `$setValue`, so on the JS side it ended up as `undefined` and cleared the target field instead of setting it to `false`. Mainly hits the `deliveryOptionsEnabled` reset path which forces 11 siblings to false.

Side effect: empty `$if` arrays survive serialization now (`{"$if": []}` instead of being stripped). I checked `validateIfConditions` in JS-PDK — behaves identically (`Array.every([])` is `true`).

Note: there's still a separate JS-PDK gap where `afterUpdate` is never invoked on field change in plugin-settings forms, so the user-visible symptom won't fully clear until that's fixed too. Tracking that next.

Refs INT-1261.

## Test plan
- [x] `composer run test:unit` — 2389 passed, 19 pre-existing skipped.
- [ ] Manual browser check after JS-PDK fix lands.