### PR TITLE
fix(settings): align toggle operands with v4 TriState data model

### DIFF
--- a/src/Frontend/View/CarrierSettingsItemView.php
+++ b/src/Frontend/View/CarrierSettingsItemView.php
@@ -387,8 +387,8 @@ class CarrierSettingsItemView extends AbstractSettingsView
         $elements[] = (new InteractiveElement(CarrierSettings::DELIVERY_OPTIONS_ENABLED, Components::INPUT_TOGGLE))
             ->builder(function (FormOperationBuilder $builder) {
                 $builder->afterUpdate(function (FormAfterUpdateBuilder $afterUpdate) {
-                    // Toggle settings are stored as TriState integers (-1/0/1); operands
-                    // must match so the frontend's strict `$eq` check succeeds.
+                    // Use the disabled scalar value here so it matches the toggle input's
+                    // value representation and the frontend's strict `$eq` check succeeds.
                     foreach ($this->deliveryOptionsResetService->getDeliveryOptionSettings() as $setting) {
                         $afterUpdate
                             ->setValue(TriStateService::DISABLED)

--- a/src/Frontend/View/CarrierSettingsItemView.php
+++ b/src/Frontend/View/CarrierSettingsItemView.php
@@ -24,6 +24,7 @@ use MyParcelNL\Pdk\Frontend\Form\Components;
 use MyParcelNL\Pdk\Frontend\Form\InteractiveElement;
 use MyParcelNL\Pdk\Frontend\Form\SettingsDivider;
 use MyParcelNL\Pdk\Proposition\Service\PropositionService;
+use MyParcelNL\Pdk\Types\Service\TriStateService;
 use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
 use MyParcelNL\Pdk\Validation\Validator\CarrierSchema;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageTypeV2;
@@ -268,14 +269,13 @@ class CarrierSettingsItemView extends AbstractSettingsView
             $ageCheckElement = (new InteractiveElement($ageCheckDefinition->getCarrierSettingsKey(), Components::INPUT_TOGGLE))
                 ->builder(function (FormOperationBuilder $builder) use ($signatureKey, $onlyRecipientKey) {
                     $builder->afterUpdate(function (FormAfterUpdateBuilder $afterUpdate) use ($signatureKey, $onlyRecipientKey) {
-                        // Toggle-typed fields on the JS side emit/receive booleans, so
-                        // operand literals must be true/false — not TriStateService::ENABLED
-                        // (int 1), which fails the frontend's strict `$eq` check.
+                        // Toggle settings are stored as TriState integers (-1/0/1); operands
+                        // must match so the frontend's strict `$eq` check succeeds.
                         if ($signatureKey) {
-                            $afterUpdate->setValue(true)->on($signatureKey)->if->eq(true);
+                            $afterUpdate->setValue(TriStateService::ENABLED)->on($signatureKey)->if->eq(TriStateService::ENABLED);
                         }
                         if ($onlyRecipientKey) {
-                            $afterUpdate->setValue(true)->on($onlyRecipientKey)->if->eq(true);
+                            $afterUpdate->setValue(TriStateService::ENABLED)->on($onlyRecipientKey)->if->eq(TriStateService::ENABLED);
                         }
                     });
                 });
@@ -387,11 +387,13 @@ class CarrierSettingsItemView extends AbstractSettingsView
         $elements[] = (new InteractiveElement(CarrierSettings::DELIVERY_OPTIONS_ENABLED, Components::INPUT_TOGGLE))
             ->builder(function (FormOperationBuilder $builder) {
                 $builder->afterUpdate(function (FormAfterUpdateBuilder $afterUpdate) {
+                    // Toggle settings are stored as TriState integers (-1/0/1); operands
+                    // must match so the frontend's strict `$eq` check succeeds.
                     foreach ($this->deliveryOptionsResetService->getDeliveryOptionSettings() as $setting) {
                         $afterUpdate
-                            ->setValue(false)
+                            ->setValue(TriStateService::DISABLED)
                             ->on($setting)
-                            ->if->eq(false);
+                            ->if->eq(TriStateService::DISABLED);
                     }
                 });
             });

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_plugin_settings__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_plugin_settings__1.json
@@ -1809,22 +1809,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -2294,132 +2294,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -3431,22 +3431,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -3916,132 +3916,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -5053,22 +5053,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -5538,132 +5538,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -6675,22 +6675,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -7160,132 +7160,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -8297,22 +8297,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -8782,132 +8782,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -9919,22 +9919,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -10404,132 +10404,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -11541,22 +11541,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -12026,132 +12026,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -13163,22 +13163,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -13648,132 +13648,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -14785,22 +14785,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -15270,132 +15270,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -16407,22 +16407,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -16892,132 +16892,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -18029,22 +18029,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -18514,132 +18514,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -19702,22 +19702,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -20187,132 +20187,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -21324,22 +21324,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -21809,132 +21809,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
@@ -22946,22 +22946,22 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": true,
+                                                "$value": 1,
                                                 "$target": "exportOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": true
+                                                        "$eq": 1
                                                     }
                                                 ]
                                             }
@@ -23431,132 +23431,132 @@
                                     "$afterUpdate": [
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryOptions",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowStandardDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMorningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowEveningDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSameDayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowMondayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSaturdayDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowSignature",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowOnlyRecipient",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPriorityDelivery",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowPickupLocations",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }
                                         },
                                         {
                                             "$setValue": {
-                                                "$value": false,
+                                                "$value": 0,
                                                 "$target": "allowDeliveryTypeExpress",
                                                 "$if": [
                                                     {
-                                                        "$eq": false
+                                                        "$eq": 0
                                                     }
                                                 ]
                                             }

--- a/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_carrier_settings__1.json
+++ b/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_carrier_settings__1.json
@@ -24,22 +24,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -509,132 +509,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -1646,22 +1646,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -2131,132 +2131,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -3268,22 +3268,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -3753,132 +3753,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -4890,22 +4890,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -5375,132 +5375,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -6512,22 +6512,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -6997,132 +6997,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -8134,22 +8134,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -8619,132 +8619,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -9756,22 +9756,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -10241,132 +10241,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -11378,22 +11378,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -11863,132 +11863,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -13000,22 +13000,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -13485,132 +13485,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -14622,22 +14622,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -15107,132 +15107,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -16244,22 +16244,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -16729,132 +16729,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -17917,22 +17917,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -18402,132 +18402,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -19539,22 +19539,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -20024,132 +20024,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
@@ -21161,22 +21161,22 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportSignature",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": true,
+                                        "$value": 1,
                                         "$target": "exportOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": true
+                                                "$eq": 1
                                             }
                                         ]
                                     }
@@ -21646,132 +21646,132 @@
                             "$afterUpdate": [
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryOptions",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowStandardDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMorningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowEveningDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSameDayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowMondayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSaturdayDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowSignature",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowOnlyRecipient",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPriorityDelivery",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowPickupLocations",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }
                                 },
                                 {
                                     "$setValue": {
-                                        "$value": false,
+                                        "$value": 0,
                                         "$target": "allowDeliveryTypeExpress",
                                         "$if": [
                                             {
-                                                "$eq": false
+                                                "$eq": 0
                                             }
                                         ]
                                     }


### PR DESCRIPTION
## Summary
Follow-up to #460. Carrier toggle settings became TriState integers in v4 (commit aaa31a35), but #452 left the form-builder operands as booleans. The frontend's strict \`\$eq\` compared the toggle's stored TriState int against the bool operand and skipped \`setValue\` — enabling 18+ left signature/only-recipient unchecked-but-readonly, and disabling delivery options didn't reset its dependents.

Emit \`TriStateService::ENABLED\` / \`DISABLED\` for the affected operands so the comparison matches end-to-end. Old stored bool values keep working — the TriState cast on the model coerces them on load.

Refs INT-1261.

## Test plan
- [x] \`composer run test:unit\` — 2389 passed, 19 pre-existing skipped.
- [x] Manual browser check: enable 18+ → signature & only-recipient flip ON and become readonly. Disable delivery options → all 11 dependents reset to OFF.