### PR TITLE
build: add claude skill to find and add translations for dynamic strings (capabilities-based)

### DIFF
--- a/.claude/skills/check-pdk-translations/SKILL.md
+++ b/.claude/skills/check-pdk-translations/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: check-pdk-translations
+description: Check for or translate missing PDK translation keys for shipment options, delivery types, package types, and carriers. Use whenever the user asks about missing translations, untranslated keys, or wants translation suggestions for the PDK — including phrases like "check translations", "find missing translations", "translate keys", "shipment options translations", "carrier translations". Always invoke this skill before doing manual grep-based translation key searches in the PDK.
+---
+
+# Check PDK Translations
+
+This skill finds translation keys referenced in the PDK source/SDK that are missing from a plugin's generated translation files, and optionally translates them into all 5 supported languages (en, nl, fr, de, it).
+
+The PDK does not store translation values directly — values only exist in plugin builds (e.g. `docker-prestashop/modules/myparcelnl/config/pdk/translations/{en,nl,fr,de,it}.json`). This skill therefore requires a plugin path to compare against.
+
+## Sheet location
+
+The Google Sheet that drives all translations:
+- **Document:** "PDK Vertalingen"
+- **Sheet:** "Vertalingen"
+- **URL:** https://docs.google.com/spreadsheets/d/1TPE7gwG2GXtX7vlKIaskwMy0Xr4o_ir-lsedWB86xyc/edit?gid=0#gid=0
+
+Whenever you tell the user to paste the TSV into the sheet, include this URL and run `open <url>` (macOS) to launch it in their browser, so they don't have to hunt for the tab.
+
+## When to use
+
+Trigger on any of: "check translations", "find missing translations", "untranslated keys", "translate PDK keys", "missing shipment options/carrier/delivery type translations", or any request to audit or fill in PDK translations.
+
+## Terminology — be explicit about keys vs values
+
+Two distinct things get called "translations" in this codebase:
+
+- **Translation key** (a.k.a. "key") — the identifier like `shipment_options_signature`. Keys are derived deterministically from PDK source, the SDK, or the helper script. There is no guesswork about which keys exist or are needed.
+- **Translation value** (a.k.a. "value", "copy", or the language name e.g. "English copy", "Dutch translation") — the actual user-facing string like "Signature" or "Handtekening".
+
+When narrating any decision or observation to the user, always say "key" or "value" (or a more specific synonym) explicitly. Don't write "patterns" or "style" or "newer additions" without clarifying whether you mean key naming or value wording — the user has to pause and re-read to figure out which you mean.
+
+Examples:
+- ✅ "Sibling **values** for `settings_carrier_export_*` use a mix of 'Activate X' / 'Enable X' / just 'X'. I'll follow the dominant 'Activate X' pattern for these new entries."
+- ✅ "The **key** `shipment_options_oversized_package` is the capability-key form of the legacy **key** `shipment_options_large_format`. I'll reuse the legacy **value** 'Extra large format' verbatim under the new **key**."
+- ❌ "settings_carrier_export_* has mixed patterns in legacy ('Activate X' / 'Enable X' / just 'X'). Newer additions (fresh_food, frozen) drop the verb, so I'll do the same." → ambiguous: are we talking about keys or values? Always clarify.
+
+## Modes
+
+- **check** — diagnostic only. Lists missing keys, grouped by category, with the legacy key (if any) whose value can be reused.
+- **translate** — same as check, plus interactive translation flow that produces a TSV ready to paste into the sheet. Optionally re-imports translations into plugins/PDK and rebuilds.
+
+## Required input
+
+- **Plugin path** — absolute path to a plugin's translations directory (e.g. `/Users/freek.vanrijt/projects/docker-prestashop/modules/myparcelnl`). If the user did not provide one, ask. Do not invent a default.
+
+## Workflow
+
+### Step 1 — refresh translations (always)
+
+Before either mode, refresh the plugin's translation files so the comparison reflects the current state of the Google Sheet:
+
+```bash
+cd <plugin-path> && yarn translations:import
+```
+
+If the plugin uses a different command (older repos), check `package.json` for a translation-related script and use that. Don't skip this step — stale local files will produce false positives.
+
+### Step 2 — enumerate expected keys
+
+Use `scripts/find_missing_keys.sh <plugin-path>`. The script reads PDK Definition classes and SDK constants, computes expected keys by category, diffs against the plugin's `en.json`, and prints missing keys grouped per category.
+
+If you need to understand or extend what the script enumerates, read `references/key-patterns.md` — it documents every key pattern and where it comes from.
+
+The output is grouped per category:
+```
+== shipment_options ==                    (label + _description from Definition classes)
+== settings_carrier (per-option) ==        (allow/price/export keys per Definition)
+== settings_product (per-option) ==        (per-option product settings)
+== settings_carrier (static dividers) ==   (export, delivery_options, etc. grep'd from views)
+== delivery_type ==                        (SDK ShipmentDefsDeliveryOptionsDeliveryNameV2)
+== package_type ==                         (SDK RefShipmentPackageTypeV2)
+== carrier ==                              (SDK RefCapabilitiesSharedCarrierV2)
+```
+
+Each missing key is shown on its own line, annotated with which of the 5 languages it is missing from. Renamed keys also include a legacy hint:
+
+- Fully missing: `carrier_brt	(missing: en,nl,fr,de,it)` — needs translation in every language.
+- Partial gap: `carrier_trunkrs	(missing: it)` — translated in en/nl/fr/de but not it. Generate only the missing language(s) when filling these.
+- Renamed: `shipment_options_oversized_package	(missing: en,nl,fr,de,it)	(legacy: shipment_options_large_format)` — copy from the legacy key into the new key for any language where the new key is missing.
+
+The "legacy" column lets you reuse existing translations when a key was renamed (e.g. PDK option `large_format` → capability key `oversized_package`). When present, the legacy key's value is good copy already approved by the translation owner.
+
+### Step 3 — (check mode) report and stop
+
+Present the grouped missing keys to the user. For each missing key, mention if a legacy key with reusable copy exists. End the turn.
+
+### Step 3 — (translate mode) interactive flow
+
+1. **Confirm scope** — show the user the missing keys grouped by category and ask which to translate. They may want all of them, only one category, or a subset.
+
+2. **Per-category description toggle** — descriptions are optional and not auto-flagged by the diff script. For each category in scope, ask whether `_description` rows should also be drafted. Default: include description if a `_description` legacy key already exists for the option being renamed, otherwise label-only. Ask once per category, not per key, unless the user wants finer control. The same applies to divider `_description` keys — only generate them when the user opts in.
+
+3. **Draft English first** — for each key, draft an English value. Sources to draw on, in order:
+   - The legacy key's existing translation (verbatim if the option semantics are identical).
+   - The PDK Definition class's docblock and class name.
+   - The SDK class's docblock for the corresponding constant or attribute.
+   - The capability/option key's name itself, used carefully.
+
+4. **Verify uncertain English** — for any key where you are not confident the English is right (semantics unclear, no legacy reference, ambiguous capability name, marketing phrasing matters), present your draft and ask the user to confirm or supply an alternative. Do this before translating to other languages — translating bad English wastes the user's time. Batch the verifications: list all uncertain drafts at once, not one by one.
+
+5. **Translate the missing languages** — for fully missing keys, draft all 5 languages from English. For partial gaps (e.g. `(missing: it)`), only draft the languages listed in the `(missing: …)` annotation — pull the existing values for the other languages from the plugin's translation JSON files so the TSV row is complete. Reuse existing translations of the same word/phrase where they appear elsewhere in the same JSON file (grep `nl.json` for "Signature" equivalents to match style). Match the tone and length of nearby legacy translations.
+
+6. **Output the TSV** — write to `<pdk-root>/missing_pdk_translations.tsv` (the PDK repo root, not the plugin dir — the TSV is a working artifact for this skill, not part of any plugin). Format: tab-separated, **no header row**, columns in this order: `key, en, nl, fr, de, it`. Sort alphabetically by key. Then:
+   - Tell the user the file path.
+   - Run `open <pdk-root>/missing_pdk_translations.tsv` so the file opens in the user's default editor for review.
+   - Print the sheet URL: https://docs.google.com/spreadsheets/d/1TPE7gwG2GXtX7vlKIaskwMy0Xr4o_ir-lsedWB86xyc/edit?gid=0#gid=0
+   - Run `open 'https://docs.google.com/spreadsheets/d/1TPE7gwG2GXtX7vlKIaskwMy0Xr4o_ir-lsedWB86xyc/edit?gid=0#gid=0'` so the sheet opens in their browser.
+   - Remind them: "Append to the bottom of the 'Vertalingen' sheet."
+
+7. **Offer post-translation rebuild** — after the user confirms the TSV is in the sheet, ask whether they want to:
+   - Re-run `yarn translations:import` in this plugin.
+   - Run the same in any sibling plugin/module the user mentions (e.g. WooCommerce).
+   - Trigger a JS rebuild (`yarn build:js:dev --skip-nx-cache` or equivalent).
+   - Apply equivalent steps for the PDK itself if relevant.
+
+   Only run what the user confirms. Do not blanket-rebuild all plugins.
+
+## Output rules
+
+- **TSV format:** no header, tab-separated, 6 columns (`key`, `en`, `nl`, `fr`, `de`, `it`), alphabetical by key.
+- **TSV location:** `<pdk-root>/missing_pdk_translations.tsv` (the PDK repo root, overwrite if exists). The file is `.gitignore`-eligible — it's a working artifact, not source.
+- **Auto-open:** always `open` the TSV file and the sheet URL after writing, so the user can review and paste without hunting for either.
+- **`_subtext` rows:** skip them. The codebase has no generic `_subtext` translations — fields silently omit subtext when the key is missing, so writing empty rows just clutters the sheet. Only include `_subtext` if the user explicitly asks.
+
+## Useful patterns
+
+- "I want to translate PDK keys but only signature stuff" → check mode first, then translate scoped to keys containing `signature` or its capability variant.
+- "Just tell me what's missing" → check mode.
+- "Update everything" → translate mode with rebuild step at the end across all plugin paths the user names.

--- a/.claude/skills/check-pdk-translations/SKILL.md
+++ b/.claude/skills/check-pdk-translations/SKILL.md
@@ -45,7 +45,7 @@ Examples:
 
 ## Required input
 
-- **Plugin path** — absolute path to a plugin's translations directory (e.g. `/Users/freek.vanrijt/projects/docker-prestashop/modules/myparcelnl`). If the user did not provide one, ask. Do not invent a default.
+- **Plugin path** — absolute path to a plugin's translations directory (e.g. `/Users/user-name/projects/docker-prestashop/modules/myparcelnl`). If the user did not provide one, ask. Do not invent a default.
 
 ## Workflow
 

--- a/.claude/skills/check-pdk-translations/SKILL.md
+++ b/.claude/skills/check-pdk-translations/SKILL.md
@@ -12,6 +12,7 @@ The PDK does not store translation values directly — values only exist in plug
 ## Sheet location
 
 The Google Sheet that drives all translations:
+
 - **Document:** "PDK Vertalingen"
 - **Sheet:** "Vertalingen"
 - **URL:** https://docs.google.com/spreadsheets/d/1TPE7gwG2GXtX7vlKIaskwMy0Xr4o_ir-lsedWB86xyc/edit?gid=0#gid=0
@@ -32,9 +33,10 @@ Two distinct things get called "translations" in this codebase:
 When narrating any decision or observation to the user, always say "key" or "value" (or a more specific synonym) explicitly. Don't write "patterns" or "style" or "newer additions" without clarifying whether you mean key naming or value wording — the user has to pause and re-read to figure out which you mean.
 
 Examples:
+
 - ✅ "Sibling **values** for `settings_carrier_export_*` use a mix of 'Activate X' / 'Enable X' / just 'X'. I'll follow the dominant 'Activate X' pattern for these new entries."
 - ✅ "The **key** `shipment_options_oversized_package` is the capability-key form of the legacy **key** `shipment_options_large_format`. I'll reuse the legacy **value** 'Extra large format' verbatim under the new **key**."
-- ❌ "settings_carrier_export_* has mixed patterns in legacy ('Activate X' / 'Enable X' / just 'X'). Newer additions (fresh_food, frozen) drop the verb, so I'll do the same." → ambiguous: are we talking about keys or values? Always clarify.
+- ❌ "settings*carrier_export*\* has mixed patterns in legacy ('Activate X' / 'Enable X' / just 'X'). Newer additions (fresh_food, frozen) drop the verb, so I'll do the same." → ambiguous: are we talking about keys or values? Always clarify.
 
 ## Modes
 
@@ -59,16 +61,17 @@ If the plugin uses a different command (older repos), check `package.json` for a
 
 ### Step 2 — enumerate expected keys
 
-Use `scripts/find_missing_keys.sh <plugin-path>`. The script reads PDK Definition classes and SDK constants, computes expected keys by category, diffs against the plugin's `en.json`, and prints missing keys grouped per category.
+Use `scripts/find_missing_keys.sh <plugin-path>`. The script introspects PDK Definition classes and SDK constant classes via PHP reflection (run inside the PDK's docker `php` service), computes expected keys by category, checks each of the plugin's 5 language translation files, and prints missing keys grouped per category with per-language gaps.
 
 If you need to understand or extend what the script enumerates, read `references/key-patterns.md` — it documents every key pattern and where it comes from.
 
 The output is grouped per category:
+
 ```
-== shipment_options ==                    (label + _description from Definition classes)
+== shipment_options ==                    (label keys from Definition::getCapabilitiesOptionsKey)
 == settings_carrier (per-option) ==        (allow/price/export keys per Definition)
 == settings_product (per-option) ==        (per-option product settings)
-== settings_carrier (static dividers) ==   (export, delivery_options, etc. grep'd from views)
+== settings_carrier (static dividers) ==   (export, delivery_options, etc. from CarrierSettingsItemView)
 == delivery_type ==                        (SDK ShipmentDefsDeliveryOptionsDeliveryNameV2)
 == package_type ==                         (SDK RefShipmentPackageTypeV2)
 == carrier ==                              (SDK RefCapabilitiesSharedCarrierV2)
@@ -93,6 +96,7 @@ Present the grouped missing keys to the user. For each missing key, mention if a
 2. **Per-category description toggle** — descriptions are optional and not auto-flagged by the diff script. For each category in scope, ask whether `_description` rows should also be drafted. Default: include description if a `_description` legacy key already exists for the option being renamed, otherwise label-only. Ask once per category, not per key, unless the user wants finer control. The same applies to divider `_description` keys — only generate them when the user opts in.
 
 3. **Draft English first** — for each key, draft an English value. Sources to draw on, in order:
+
    - The legacy key's existing translation (verbatim if the option semantics are identical).
    - The PDK Definition class's docblock and class name.
    - The SDK class's docblock for the corresponding constant or attribute.
@@ -103,6 +107,7 @@ Present the grouped missing keys to the user. For each missing key, mention if a
 5. **Translate the missing languages** — for fully missing keys, draft all 5 languages from English. For partial gaps (e.g. `(missing: it)`), only draft the languages listed in the `(missing: …)` annotation — pull the existing values for the other languages from the plugin's translation JSON files so the TSV row is complete. Reuse existing translations of the same word/phrase where they appear elsewhere in the same JSON file (grep `nl.json` for "Signature" equivalents to match style). Match the tone and length of nearby legacy translations.
 
 6. **Output the TSV** — write to `<pdk-root>/missing_pdk_translations.tsv` (the PDK repo root, not the plugin dir — the TSV is a working artifact for this skill, not part of any plugin). Format: tab-separated, **no header row**, columns in this order: `key, en, nl, fr, de, it`. Sort alphabetically by key. Then:
+
    - Tell the user the file path.
    - Run `open <pdk-root>/missing_pdk_translations.tsv` so the file opens in the user's default editor for review.
    - Print the sheet URL: https://docs.google.com/spreadsheets/d/1TPE7gwG2GXtX7vlKIaskwMy0Xr4o_ir-lsedWB86xyc/edit?gid=0#gid=0
@@ -110,6 +115,7 @@ Present the grouped missing keys to the user. For each missing key, mention if a
    - Remind them: "Append to the bottom of the 'Vertalingen' sheet."
 
 7. **Offer post-translation rebuild** — after the user confirms the TSV is in the sheet, ask whether they want to:
+
    - Re-run `yarn translations:import` in this plugin.
    - Run the same in any sibling plugin/module the user mentions (e.g. WooCommerce).
    - Trigger a JS rebuild (`yarn build:js:dev --skip-nx-cache` or equivalent).

--- a/.claude/skills/check-pdk-translations/references/key-patterns.md
+++ b/.claude/skills/check-pdk-translations/references/key-patterns.md
@@ -1,0 +1,68 @@
+# PDK translation key patterns
+
+Reference for what generates each translation key the skill audits. Read this when extending `find_missing_keys.sh` or when the user asks about a category beyond the defaults.
+
+## shipment_options_*
+
+**Pattern:** `shipment_options_<snake_case_capability_key>` (label) plus `_description` and `_subtext` siblings.
+
+**Source of truth:** PDK `*Definition` classes in `src/App/Options/Definition/`. Each definition's `getCapabilitiesOptionsKey()` returns the camelCase capability key from `RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()`. The form (`createShipmentOptionField.ts` in JS-PDK) iterates `Object.keys(carrier.options)` (those camelCase keys) and feeds each through `getFieldLabel(name) = snakeCase('shipmentOptions_' + name)`.
+
+**Why Definitions rather than just SDK:** Definitions are PDK's source of truth for which options are exposed. They also expose `getShipmentOptionsKey()`, which is the *legacy* PDK key — useful for finding a reusable existing translation when an option was renamed (`signature` → `requires_signature`, `large_format` → `oversized_package`).
+
+**Description and subtext are optional.** `defineFormField` in `js-pdk/apps/admin/src/forms/helpers/defineFormField.ts` auto-attaches `description` and `subtext` translation lookups to every shipment-option field. For each label `shipment_options_X`, the form will also try `shipment_options_X_description` and `shipment_options_X_subtext`, but missing keys silently fall through (key returned, nothing rendered). The script therefore only flags missing **labels** — auto-flagging every description sibling produced false-positive noise during the skill's first iteration. The translate-mode workflow opts in to descriptions per category instead.
+
+## settings_carrier_*  (per-option)
+
+**Pattern:** `settings_carrier_<snake_case>` (+ `_description`).
+
+**Source:** PDK Definition classes via three methods:
+- `getAllowSettingsKey()` — e.g. `'allowSaturdayDelivery'` → `settings_carrier_allow_saturday_delivery`.
+- `getPriceSettingsKey()` — e.g. `'priceSaturdayDelivery'` → `settings_carrier_price_saturday_delivery`.
+- `getCarrierSettingsKey()` — defaults to `'export' . ucfirst(getShipmentOptionsKey())`, so e.g. `'exportSignature'` → `settings_carrier_export_signature`. Some definitions override this to return null or a custom value.
+
+The script walks every Definition and emits all three keys (when non-null) plus their `_description` siblings. Where the carrier-settings key is the abstract default, the script synthesises it from `getShipmentOptionsKey()`.
+
+## settings_product_*  (per-option)
+
+**Pattern:** `settings_product_<snake_case>` (+ `_description`).
+
+**Source:** Definition `getProductSettingsKey()` — e.g. `'fitInDigitalStamp'` → `settings_product_fit_in_digital_stamp`. The default in the abstract class is to return `getCarrierSettingsKey()`, but the script only emits explicit non-null returns to avoid double-counting and false positives.
+
+## settings_carrier_*  (static dividers)
+
+**Pattern:** `settings_carrier_<divider_name>_title` (visible header). `_description` is optional and not auto-flagged.
+
+**Source:** `createGenericLabel('X')` calls inside `src/Frontend/View/CarrierSettingsItemView.php`. The view's `getLabelPrefix()` returns `'carrier'` and `KEY_PREFIX` is `'settings'`, so each call produces a base of `settings_carrier_<X>`. The renderer then looks up `<base>_title` (and optionally `<base>_description`). The bare key is not used directly. Examples grep-found: `export`, `export_returns`, `delivery_options`, `delivery_options_delivery`, `delivery_options_pickup`, `delivery_moments`, `shipment_options`.
+
+Adding a new divider in PHP means the next run picks it up automatically; renaming or moving the view requires updating the script.
+
+## delivery_type_*
+
+**Pattern:** `delivery_type_<lowercase_name>`.
+
+**Source:** SDK `ShipmentDefsDeliveryOptionsDeliveryNameV2` in `vendor/myparcelnl/sdk/src/Client/Generated/CoreApi/Model/`. Constants are already lowercase string values (`'morning'`, `'standard'`, etc.). `getDynamicTranslation('delivery_type', name)` in `js-pdk/apps/admin/src/utils/translations/getDynamicTranslation.ts` does `${prefix}_${input.toLowerCase()}`.
+
+**Note on enums:** there are several delivery-type-shaped classes in the SDK (`RefTypesDeliveryTypeV2`, `RefShipmentOptionsDeliveryTypeAll`, etc.). `ShipmentDefsDeliveryOptionsDeliveryNameV2` is the one whose values match the runtime translation keys. If a future SDK regen moves these constants, update the script.
+
+## package_type_*
+
+**Pattern:** `package_type_<lowercase_name>`.
+
+**Source:** SDK `RefShipmentPackageTypeV2`. Constants are UPPER_SNAKE values like `'PACKAGE'`, `'MAILBOX'`. `getPackageTypeTranslation` calls `getDynamicTranslation('package_type', name)`, which lowercases. Result: `package_type_package`, `package_type_mailbox`, etc.
+
+## carrier_*
+
+**Pattern:** `carrier_<lowercase_carrier_name>` (with original underscores preserved, e.g. `carrier_dhl_for_you`).
+
+**Source:** SDK `RefCapabilitiesSharedCarrierV2`. Constants like `DHL_FOR_YOU = 'DHL_FOR_YOU'`. `createCarrierField.ts` falls back to `translate('carrier_' + snakeCase(carrier.carrier))` when the API doesn't return a `human` label. The translation is therefore a fallback — useful when a carrier is added before its translation row exists.
+
+## What the skill does NOT cover
+
+- **Hardcoded translation keys** scattered through PHP (`Language::translate('return_shipment_created_title')` etc.) — too many ad-hoc keys to enumerate reliably without static analysis. Add to the script if a stable pattern emerges.
+- **Plugin-specific translation keys** (e.g. PrestaShop or WooCommerce admin labels) — those are owned by the plugin, not the PDK.
+- **JS-PDK app-only keys** that don't trace back to PDK definitions or SDK constants. The user mostly cares about the form fields the PDK drives, which is what this skill targets.
+
+## Why English-first translation matters
+
+When drafting translations for new keys, get English right before generating the other four languages. The Dutch/French/German/Italian drafts will be derived from the English source. A mistranslation at the English step propagates to four languages and is usually caught only when someone notices an odd label in production. The "verify uncertain English" step in the skill workflow exists specifically to avoid this.

--- a/.claude/skills/check-pdk-translations/references/key-patterns.md
+++ b/.claude/skills/check-pdk-translations/references/key-patterns.md
@@ -34,7 +34,7 @@ Reference for what generates each translation key the skill audits. Read this wh
 - explicit `null` overrides suppress the key,
 - unoverridden methods inherit the abstract delegate (typical for shipment-option definitions like `SignatureDefinition` → `settings_product_export_signature`).
 
-## settings*carrier*\* (static dividers)
+## `settings_carrier_*` (static dividers)
 
 **Pattern:** `settings_carrier_<divider_name>_title` (visible header). `_description` is optional and not auto-flagged.
 

--- a/.claude/skills/check-pdk-translations/references/key-patterns.md
+++ b/.claude/skills/check-pdk-translations/references/key-patterns.md
@@ -2,34 +2,39 @@
 
 Reference for what generates each translation key the skill audits. Read this when extending `find_missing_keys.sh` or when the user asks about a category beyond the defaults.
 
-## shipment_options_*
+## shipment*options*\*
 
-**Pattern:** `shipment_options_<snake_case_capability_key>` (label) plus `_description` and `_subtext` siblings.
+**Pattern:** `shipment_options_<snake_case_capability_key>` (label, audited by the script). `_description` and `_subtext` siblings exist at runtime but are not auto-emitted (see "Description and subtext are optional" below).
 
 **Source of truth:** PDK `*Definition` classes in `src/App/Options/Definition/`. Each definition's `getCapabilitiesOptionsKey()` returns the camelCase capability key from `RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::attributeMap()`. The form (`createShipmentOptionField.ts` in JS-PDK) iterates `Object.keys(carrier.options)` (those camelCase keys) and feeds each through `getFieldLabel(name) = snakeCase('shipmentOptions_' + name)`.
 
-**Why Definitions rather than just SDK:** Definitions are PDK's source of truth for which options are exposed. They also expose `getShipmentOptionsKey()`, which is the *legacy* PDK key — useful for finding a reusable existing translation when an option was renamed (`signature` → `requires_signature`, `large_format` → `oversized_package`).
+**Why Definitions rather than just SDK:** Definitions are PDK's source of truth for which options are exposed. They also expose `getShipmentOptionsKey()`, which is the _legacy_ PDK key — useful for finding a reusable existing translation when an option was renamed (`signature` → `requires_signature`, `large_format` → `oversized_package`).
 
 **Description and subtext are optional.** `defineFormField` in `js-pdk/apps/admin/src/forms/helpers/defineFormField.ts` auto-attaches `description` and `subtext` translation lookups to every shipment-option field. For each label `shipment_options_X`, the form will also try `shipment_options_X_description` and `shipment_options_X_subtext`, but missing keys silently fall through (key returned, nothing rendered). The script therefore only flags missing **labels** — auto-flagging every description sibling produced false-positive noise during the skill's first iteration. The translate-mode workflow opts in to descriptions per category instead.
 
-## settings_carrier_*  (per-option)
+## settings*carrier*\* (per-option)
 
-**Pattern:** `settings_carrier_<snake_case>` (+ `_description`).
+**Pattern:** `settings_carrier_<snake_case>` (base key, audited by the script). `_description` may exist at runtime but is not auto-emitted.
 
-**Source:** PDK Definition classes via three methods:
-- `getAllowSettingsKey()` — e.g. `'allowSaturdayDelivery'` → `settings_carrier_allow_saturday_delivery`.
-- `getPriceSettingsKey()` — e.g. `'priceSaturdayDelivery'` → `settings_carrier_price_saturday_delivery`.
-- `getCarrierSettingsKey()` — defaults to `'export' . ucfirst(getShipmentOptionsKey())`, so e.g. `'exportSignature'` → `settings_carrier_export_signature`. Some definitions override this to return null or a custom value.
+**Source:** PDK Definition classes via three methods on `AbstractOrderOptionDefinition`:
 
-The script walks every Definition and emits all three keys (when non-null) plus their `_description` siblings. Where the carrier-settings key is the abstract default, the script synthesises it from `getShipmentOptionsKey()`.
+- `getAllowSettingsKey()` — defaults to `'allow' . ucfirst(getShipmentOptionsKey())`, e.g. `'allowSaturdayDelivery'` → `settings_carrier_allow_saturday_delivery`.
+- `getPriceSettingsKey()` — defaults to `'price' . ucfirst(getShipmentOptionsKey())`, e.g. `'priceSaturdayDelivery'` → `settings_carrier_price_saturday_delivery`.
+- `getCarrierSettingsKey()` — defaults to `'export' . ucfirst(getShipmentOptionsKey())`, e.g. `'exportSignature'` → `settings_carrier_export_signature`. Definitions may override any of these to return `null` or a custom value.
 
-## settings_product_*  (per-option)
+`introspect_keys.php` invokes each method via PHP reflection, so inherited defaults from the abstract class are resolved natively. It emits the three base keys whenever the method returns non-null. Explicit `null` overrides correctly suppress the key (no false positives for definitions like `ExcludeParcelLockersDefinition`/`SaturdayDeliveryDefinition` that return `null` from one or more of these methods).
 
-**Pattern:** `settings_product_<snake_case>` (+ `_description`).
+## settings*product*\* (per-option)
 
-**Source:** Definition `getProductSettingsKey()` — e.g. `'fitInDigitalStamp'` → `settings_product_fit_in_digital_stamp`. The default in the abstract class is to return `getCarrierSettingsKey()`, but the script only emits explicit non-null returns to avoid double-counting and false positives.
+**Pattern:** `settings_product_<snake_case>` (base key, audited by the script). `_description` may exist at runtime but is not auto-emitted.
 
-## settings_carrier_*  (static dividers)
+**Source:** Definition `getProductSettingsKey()` — e.g. `'fitInDigitalStamp'` → `settings_product_fit_in_digital_stamp`. The default in the abstract class delegates to `getCarrierSettingsKey()`, so most options yield a `settings_product_export_*` key via that delegation. PHP reflection invokes the method directly, so:
+
+- explicit non-null overrides yield their own key (e.g. `FitInDigitalStampDefinition` → `settings_product_fit_in_digital_stamp`),
+- explicit `null` overrides suppress the key,
+- unoverridden methods inherit the abstract delegate (typical for shipment-option definitions like `SignatureDefinition` → `settings_product_export_signature`).
+
+## settings*carrier*\* (static dividers)
 
 **Pattern:** `settings_carrier_<divider_name>_title` (visible header). `_description` is optional and not auto-flagged.
 
@@ -37,7 +42,7 @@ The script walks every Definition and emits all three keys (when non-null) plus 
 
 Adding a new divider in PHP means the next run picks it up automatically; renaming or moving the view requires updating the script.
 
-## delivery_type_*
+## delivery*type*\*
 
 **Pattern:** `delivery_type_<lowercase_name>`.
 
@@ -45,13 +50,13 @@ Adding a new divider in PHP means the next run picks it up automatically; renami
 
 **Note on enums:** there are several delivery-type-shaped classes in the SDK (`RefTypesDeliveryTypeV2`, `RefShipmentOptionsDeliveryTypeAll`, etc.). `ShipmentDefsDeliveryOptionsDeliveryNameV2` is the one whose values match the runtime translation keys. If a future SDK regen moves these constants, update the script.
 
-## package_type_*
+## package*type*\*
 
 **Pattern:** `package_type_<lowercase_name>`.
 
 **Source:** SDK `RefShipmentPackageTypeV2`. Constants are UPPER_SNAKE values like `'PACKAGE'`, `'MAILBOX'`. `getPackageTypeTranslation` calls `getDynamicTranslation('package_type', name)`, which lowercases. Result: `package_type_package`, `package_type_mailbox`, etc.
 
-## carrier_*
+## carrier\_\*
 
 **Pattern:** `carrier_<lowercase_carrier_name>` (with original underscores preserved, e.g. `carrier_dhl_for_you`).
 

--- a/.claude/skills/check-pdk-translations/references/key-patterns.md
+++ b/.claude/skills/check-pdk-translations/references/key-patterns.md
@@ -50,7 +50,7 @@ Adding a new divider in PHP means the next run picks it up automatically; renami
 
 **Note on enums:** there are several delivery-type-shaped classes in the SDK (`RefTypesDeliveryTypeV2`, `RefShipmentOptionsDeliveryTypeAll`, etc.). `ShipmentDefsDeliveryOptionsDeliveryNameV2` is the one whose values match the runtime translation keys. If a future SDK regen moves these constants, update the script.
 
-## package*type*\*
+## `package_type_*`
 
 **Pattern:** `package_type_<lowercase_name>`.
 

--- a/.claude/skills/check-pdk-translations/references/key-patterns.md
+++ b/.claude/skills/check-pdk-translations/references/key-patterns.md
@@ -24,7 +24,7 @@ Reference for what generates each translation key the skill audits. Read this wh
 
 `introspect_keys.php` invokes each method via PHP reflection, so inherited defaults from the abstract class are resolved natively. It emits the three base keys whenever the method returns non-null. Explicit `null` overrides correctly suppress the key (no false positives for definitions like `ExcludeParcelLockersDefinition`/`SaturdayDeliveryDefinition` that return `null` from one or more of these methods).
 
-## settings*product*\* (per-option)
+## `settings_product_*` (per-option)
 
 **Pattern:** `settings_product_<snake_case>` (base key, audited by the script). `_description` may exist at runtime but is not auto-emitted.
 

--- a/.claude/skills/check-pdk-translations/references/key-patterns.md
+++ b/.claude/skills/check-pdk-translations/references/key-patterns.md
@@ -2,7 +2,7 @@
 
 Reference for what generates each translation key the skill audits. Read this when extending `find_missing_keys.sh` or when the user asks about a category beyond the defaults.
 
-## shipment*options*\*
+## `shipment_options_*`
 
 **Pattern:** `shipment_options_<snake_case_capability_key>` (label, audited by the script). `_description` and `_subtext` siblings exist at runtime but are not auto-emitted (see "Description and subtext are optional" below).
 
@@ -12,7 +12,7 @@ Reference for what generates each translation key the skill audits. Read this wh
 
 **Description and subtext are optional.** `defineFormField` in `js-pdk/apps/admin/src/forms/helpers/defineFormField.ts` auto-attaches `description` and `subtext` translation lookups to every shipment-option field. For each label `shipment_options_X`, the form will also try `shipment_options_X_description` and `shipment_options_X_subtext`, but missing keys silently fall through (key returned, nothing rendered). The script therefore only flags missing **labels** — auto-flagging every description sibling produced false-positive noise during the skill's first iteration. The translate-mode workflow opts in to descriptions per category instead.
 
-## settings*carrier*\* (per-option)
+## `settings_carrier_*` (per-option)
 
 **Pattern:** `settings_carrier_<snake_case>` (base key, audited by the script). `_description` may exist at runtime but is not auto-emitted.
 
@@ -42,7 +42,7 @@ Reference for what generates each translation key the skill audits. Read this wh
 
 Adding a new divider in PHP means the next run picks it up automatically; renaming or moving the view requires updating the script.
 
-## delivery*type*\*
+## `delivery_type_*`
 
 **Pattern:** `delivery_type_<lowercase_name>`.
 

--- a/.claude/skills/check-pdk-translations/scripts/find_missing_keys.sh
+++ b/.claude/skills/check-pdk-translations/scripts/find_missing_keys.sh
@@ -53,7 +53,7 @@ if [[ ! -f "$PDK_ROOT/vendor/autoload.php" ]]; then
   exit 1
 fi
 
-KEYS_TMPDIR=$(mktemp -d -t pdk_translations_keys.XXXXXX)
+KEYS_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/pdk_translations_keys.XXXXXX")
 trap 'rm -rf "${KEYS_TMPDIR:-}"' EXIT
 
 for lang in "${LANGS[@]}"; do

--- a/.claude/skills/check-pdk-translations/scripts/find_missing_keys.sh
+++ b/.claude/skills/check-pdk-translations/scripts/find_missing_keys.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Enumerate expected PDK translation keys and diff them against a plugin's en.json.
+#
+# Categories covered:
+#   - shipment_options_*       (label + _description) from Definition classes
+#   - settings_carrier_*       allow/price/export keys from Definition classes,
+#                              plus static dividers grep'd from view files
+#   - settings_product_*       per-option product settings from Definition classes
+#   - delivery_type_*          from SDK ShipmentDefsDeliveryOptionsDeliveryNameV2
+#   - package_type_*           from SDK RefShipmentPackageTypeV2
+#   - carrier_*                from SDK RefCapabilitiesSharedCarrierV2
+#
+# Usage: find_missing_keys.sh <plugin-path>
+#   <plugin-path> must contain config/pdk/translations/en.json
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <plugin-path>" >&2
+  exit 2
+fi
+
+PLUGIN_PATH="$1"
+TRANSLATIONS_DIR="$PLUGIN_PATH/config/pdk/translations"
+LANGS=(en nl fr de it)
+
+for lang in "${LANGS[@]}"; do
+  if [[ ! -f "$TRANSLATIONS_DIR/$lang.json" ]]; then
+    echo "ERROR: $TRANSLATIONS_DIR/$lang.json not found. Run 'yarn translations:import' in $PLUGIN_PATH first." >&2
+    exit 1
+  fi
+done
+
+# Resolve PDK root from this script's location: <pdk>/.claude/skills/<name>/scripts/this.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PDK_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+DEFINITIONS_DIR="$PDK_ROOT/src/App/Options/Definition"
+SDK_MODELS="$PDK_ROOT/vendor/myparcelnl/sdk/src/Client/Generated/CoreApi/Model"
+VIEWS_DIR="$PDK_ROOT/src/Frontend/View"
+
+if [[ ! -d "$DEFINITIONS_DIR" ]]; then
+  echo "ERROR: $DEFINITIONS_DIR not found. Is this script inside the PDK repo?" >&2
+  exit 1
+fi
+if [[ ! -d "$SDK_MODELS" ]]; then
+  echo "ERROR: SDK models not found at $SDK_MODELS. Run 'composer install'." >&2
+  exit 1
+fi
+
+KEYS_TMPDIR=$(mktemp -d -t pdk_translations_keys.XXXXXX)
+trap 'rm -rf "$KEYS_TMPDIR"' EXIT
+
+for lang in "${LANGS[@]}"; do
+  jq -r 'keys[]' "$TRANSLATIONS_DIR/$lang.json" > "$KEYS_TMPDIR/$lang.txt"
+done
+
+# True if the key exists in the en.json key set (used for legacy-hint lookup).
+key_exists() { grep -Fxq "$1" "$KEYS_TMPDIR/en.txt"; }
+
+# Echo a comma-separated list of langs where the key is missing, or empty if present in all.
+languages_missing_for() {
+  local key="$1" lang
+  local missing=""
+  for lang in "${LANGS[@]}"; do
+    if ! grep -Fxq "$key" "$KEYS_TMPDIR/$lang.txt"; then
+      missing+="${missing:+,}$lang"
+    fi
+  done
+  echo "$missing"
+}
+
+# Convert camelCase → snake_case (portable: macOS BSD sed has no \L)
+to_snake() {
+  echo "$1" | sed -E 's/([A-Z])/_\1/g; s/^_//' | tr '[:upper:]' '[:lower:]'
+}
+
+# Extract a method's first return value from a Definition file.
+# Returns the snake_case literal arg if the method is `attributeMap()['snake']`,
+# otherwise the camelCase string literal returned directly.
+extract_return() {
+  local file="$1" method="$2"
+  local cap=""
+  cap=$(awk -v m="$method" '$0 ~ "function " m {flag=1} flag && /return/{print; exit}' "$file" \
+    | sed -nE "s/.*attributeMap\(\)\['([a-zA-Z_]+)'\].*/\1/p")
+  if [[ -z "$cap" ]]; then
+    cap=$(awk -v m="$method" '$0 ~ "function " m {flag=1} flag && /return/{print; exit}' "$file" \
+      | sed -nE "s/.*return '([a-zA-Z_]+)'.*/\1/p")
+  fi
+  # Edge: AbstractOrderOptionDefinition's getCarrierSettingsKey builds 'export' . ucfirst($key)
+  # — we synthesise the same value below in the shipment-options loop, not here.
+  echo "$cap"
+}
+
+# Emit a row when the key is missing from any of the 5 languages.
+# Format: "<key>\t(missing: <comma-separated-langs>)[\t(legacy: <legacy_key>)]"
+# When all 5 are missing the missing-list reads "en,nl,fr,de,it" — that's the same
+# signal the previous version surfaced, just explicit. Partial gaps (e.g. "(missing: it)")
+# are now visible too.
+emit_if_missing() {
+  local key="$1" legacy="${2:-}"
+  local missing
+  missing=$(languages_missing_for "$key")
+  [[ -z "$missing" ]] && return
+
+  local out="$key	(missing: $missing)"
+  if [[ -n "$legacy" ]] && key_exists "$legacy"; then
+    out="$out	(legacy: $legacy)"
+  fi
+  echo "$out"
+}
+
+# ---- shipment_options_* and settings_carrier_*/settings_product_* per-option ----
+
+# Build a cache file with one line per Definition:
+#   <basename>|<cap>|<legacy_camel>|<allow>|<price>|<carrier>|<product>
+build_definition_cache() {
+  local cache="$1"
+  : > "$cache"
+  local f basename cap legacy_camel allow price carrier product first rest
+  for f in "$DEFINITIONS_DIR"/*Definition.php; do
+    basename="$(basename "$f")"
+    [[ "$basename" == "AbstractOrderOptionDefinition.php" ]] && continue
+
+    cap=$(extract_return "$f" "getCapabilitiesOptionsKey")
+    legacy_camel=$(extract_return "$f" "getShipmentOptionsKey")
+    allow=$(extract_return "$f" "getAllowSettingsKey")
+    price=$(extract_return "$f" "getPriceSettingsKey")
+    carrier=$(extract_return "$f" "getCarrierSettingsKey")
+    product=$(extract_return "$f" "getProductSettingsKey")
+
+    # Apply abstract default for getCarrierSettingsKey: 'export' . ucfirst($shipmentOptionsKey).
+    if [[ -z "$carrier" && -n "$legacy_camel" ]]; then
+      first=${legacy_camel:0:1}
+      rest=${legacy_camel:1}
+      carrier="export$(echo "$first" | tr '[:lower:]' '[:upper:]')${rest}"
+    fi
+
+    printf '%s|%s|%s|%s|%s|%s|%s\n' \
+      "$basename" "$cap" "$legacy_camel" "$allow" "$price" "$carrier" "$product" >> "$cache"
+  done
+}
+
+# Description (`_description`) and subtext siblings are intentionally NOT emitted —
+# they are optional in this codebase. Missing descriptions silently render nothing
+# in the UI, so flagging them here as "missing" produces noise. Translate mode asks
+# the user per category whether to draft descriptions.
+
+print_shipment_options_from_cache() {
+  echo "== shipment_options =="
+  local cap legacy_camel legacy_snake key legacy
+  while IFS='|' read -r _ cap legacy_camel _ _ _ _; do
+    [[ -z "$cap" ]] && continue
+    legacy_snake=$(to_snake "$legacy_camel")
+    key="shipment_options_${cap}"
+    legacy=""
+    [[ -n "$legacy_snake" && "$legacy_snake" != "$cap" ]] && legacy="shipment_options_${legacy_snake}"
+    emit_if_missing "$key" "$legacy"
+  done < "$1"
+}
+
+print_settings_carrier_per_option_from_cache() {
+  echo "== settings_carrier (per-option) =="
+  local allow price carrier camel snake
+  while IFS='|' read -r _ _ _ allow price carrier _; do
+    for camel in "$allow" "$price" "$carrier"; do
+      [[ -z "$camel" ]] && continue
+      snake=$(to_snake "$camel")
+      emit_if_missing "settings_carrier_${snake}"
+    done
+  done < "$1"
+}
+
+print_settings_product_per_option_from_cache() {
+  echo "== settings_product (per-option) =="
+  local product snake
+  while IFS='|' read -r _ _ _ _ _ _ product; do
+    [[ -z "$product" ]] && continue
+    snake=$(to_snake "$product")
+    emit_if_missing "settings_product_${snake}"
+  done < "$1"
+}
+
+# ---- static settings dividers grep'd from views ----
+# createGenericLabel('foo') in a view with labelPrefix=$prefix produces
+# settings_<prefix>_<foo>. Default prefix in CarrierSettingsItemView is 'carrier'.
+# We only include matches we can attribute to a known prefix.
+
+print_static_dividers() {
+  echo "== settings_carrier (static dividers) =="
+  # CarrierSettingsItemView always uses prefix 'carrier' (CarrierSettings::ID).
+  # Dividers are rendered with `_title` (visible header) — not the bare key.
+  # `_description` exists for some dividers but is optional, so we don't emit it.
+  local view="$VIEWS_DIR/CarrierSettingsItemView.php"
+  if [[ -f "$view" ]]; then
+    grep -oE "createGenericLabel\(['\"][a-z_]+['\"]\)" "$view" \
+      | sed -E "s/createGenericLabel\(['\"]([a-z_]+)['\"]\)/\1/" \
+      | sort -u \
+      | while read -r divider; do
+          emit_if_missing "settings_carrier_${divider}_title"
+        done
+  fi
+}
+
+# ---- delivery_type_* ----
+
+print_delivery_types() {
+  echo "== delivery_type =="
+  local sdk_file="$SDK_MODELS/ShipmentDefsDeliveryOptionsDeliveryNameV2.php"
+  [[ ! -f "$sdk_file" ]] && { echo "(SDK class not found: $sdk_file)"; return; }
+  grep -E "public const [A-Z_]+ = '" "$sdk_file" \
+    | sed -E "s/.*= '([a-z_]+)'.*/\1/" \
+    | while read -r name; do
+        emit_if_missing "delivery_type_${name}"
+      done
+}
+
+# ---- package_type_* ----
+
+print_package_types() {
+  echo "== package_type =="
+  local sdk_file="$SDK_MODELS/RefShipmentPackageTypeV2.php"
+  [[ ! -f "$sdk_file" ]] && { echo "(SDK class not found: $sdk_file)"; return; }
+  grep -E "public const [A-Z_]+ = '[A-Z_]+'" "$sdk_file" \
+    | sed -E "s/.*= '([A-Z_]+)'.*/\1/" \
+    | tr '[:upper:]' '[:lower:]' \
+    | while read -r name; do
+        emit_if_missing "package_type_${name}"
+      done
+}
+
+# ---- carrier_* ----
+
+print_carriers() {
+  echo "== carrier =="
+  local sdk_file="$SDK_MODELS/RefCapabilitiesSharedCarrierV2.php"
+  [[ ! -f "$sdk_file" ]] && { echo "(SDK class not found: $sdk_file)"; return; }
+  grep -E "public const [A-Z_]+ = '[A-Z_]+'" "$sdk_file" \
+    | sed -E "s/.*= '([A-Z_]+)'.*/\1/" \
+    | tr '[:upper:]' '[:lower:]' \
+    | while read -r name; do
+        emit_if_missing "carrier_${name}"
+      done
+}
+
+DEF_CACHE=$(mktemp -t pdk_translations_definitions.XXXXXX)
+trap 'rm -f "$DEF_CACHE"' EXIT
+build_definition_cache "$DEF_CACHE"
+
+print_shipment_options_from_cache "$DEF_CACHE"
+echo
+print_settings_carrier_per_option_from_cache "$DEF_CACHE"
+echo
+print_settings_product_per_option_from_cache "$DEF_CACHE"
+echo
+print_static_dividers
+echo
+print_delivery_types
+echo
+print_package_types
+echo
+print_carriers

--- a/.claude/skills/check-pdk-translations/scripts/find_missing_keys.sh
+++ b/.claude/skills/check-pdk-translations/scripts/find_missing_keys.sh
@@ -1,17 +1,26 @@
 #!/usr/bin/env bash
-# Enumerate expected PDK translation keys and diff them against a plugin's en.json.
+# Diff the PDK's expected translation keys against a plugin's generated translation files.
+#
+# Expected keys are determined by introspect_keys.php (run via the PDK's php docker service).
+# That script reflects PDK Definition classes and SDK constant classes to derive the keys
+# the runtime expects, eliminating brittle text-based parsing of PHP source.
 #
 # Categories covered:
-#   - shipment_options_*       (label + _description) from Definition classes
+#   - shipment_options_*       label keys from Definition::getCapabilitiesOptionsKey()
 #   - settings_carrier_*       allow/price/export keys from Definition classes,
-#                              plus static dividers grep'd from view files
-#   - settings_product_*       per-option product settings from Definition classes
+#                              plus static dividers from CarrierSettingsItemView (label only, `_title`)
+#   - settings_product_*       per-option product settings from Definition::getProductSettingsKey()
 #   - delivery_type_*          from SDK ShipmentDefsDeliveryOptionsDeliveryNameV2
 #   - package_type_*           from SDK RefShipmentPackageTypeV2
 #   - carrier_*                from SDK RefCapabilitiesSharedCarrierV2
 #
+# Description (`_description`) and subtext siblings are intentionally NOT emitted —
+# they are optional in this codebase. Missing descriptions silently render nothing
+# in the UI, so flagging them here as "missing" produces noise. Translate mode asks
+# the user per category whether to draft descriptions.
+#
 # Usage: find_missing_keys.sh <plugin-path>
-#   <plugin-path> must contain config/pdk/translations/en.json
+#   <plugin-path> must contain config/pdk/translations/{en,nl,fr,de,it}.json
 
 set -euo pipefail
 
@@ -34,28 +43,25 @@ done
 # Resolve PDK root from this script's location: <pdk>/.claude/skills/<name>/scripts/this.sh
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PDK_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
-DEFINITIONS_DIR="$PDK_ROOT/src/App/Options/Definition"
-SDK_MODELS="$PDK_ROOT/vendor/myparcelnl/sdk/src/Client/Generated/CoreApi/Model"
-VIEWS_DIR="$PDK_ROOT/src/Frontend/View"
 
-if [[ ! -d "$DEFINITIONS_DIR" ]]; then
-  echo "ERROR: $DEFINITIONS_DIR not found. Is this script inside the PDK repo?" >&2
+if [[ ! -f "$PDK_ROOT/docker-compose.yml" ]]; then
+  echo "ERROR: $PDK_ROOT/docker-compose.yml not found. Is this script inside the PDK repo?" >&2
   exit 1
 fi
-if [[ ! -d "$SDK_MODELS" ]]; then
-  echo "ERROR: SDK models not found at $SDK_MODELS. Run 'composer install'." >&2
+if [[ ! -f "$PDK_ROOT/vendor/autoload.php" ]]; then
+  echo "ERROR: $PDK_ROOT/vendor/autoload.php missing. Run 'composer install' in the PDK." >&2
   exit 1
 fi
 
 KEYS_TMPDIR=$(mktemp -d -t pdk_translations_keys.XXXXXX)
-trap 'rm -rf "$KEYS_TMPDIR"' EXIT
+trap 'rm -rf "${KEYS_TMPDIR:-}"' EXIT
 
 for lang in "${LANGS[@]}"; do
   jq -r 'keys[]' "$TRANSLATIONS_DIR/$lang.json" > "$KEYS_TMPDIR/$lang.txt"
 done
 
-# True if the key exists in the en.json key set (used for legacy-hint lookup).
-key_exists() { grep -Fxq "$1" "$KEYS_TMPDIR/en.txt"; }
+# True if the key exists in en.json (used for legacy-hint lookup).
+key_exists_en() { grep -Fxq "$1" "$KEYS_TMPDIR/en.txt"; }
 
 # Echo a comma-separated list of langs where the key is missing, or empty if present in all.
 languages_missing_for() {
@@ -69,33 +75,8 @@ languages_missing_for() {
   echo "$missing"
 }
 
-# Convert camelCase → snake_case (portable: macOS BSD sed has no \L)
-to_snake() {
-  echo "$1" | sed -E 's/([A-Z])/_\1/g; s/^_//' | tr '[:upper:]' '[:lower:]'
-}
-
-# Extract a method's first return value from a Definition file.
-# Returns the snake_case literal arg if the method is `attributeMap()['snake']`,
-# otherwise the camelCase string literal returned directly.
-extract_return() {
-  local file="$1" method="$2"
-  local cap=""
-  cap=$(awk -v m="$method" '$0 ~ "function " m {flag=1} flag && /return/{print; exit}' "$file" \
-    | sed -nE "s/.*attributeMap\(\)\['([a-zA-Z_]+)'\].*/\1/p")
-  if [[ -z "$cap" ]]; then
-    cap=$(awk -v m="$method" '$0 ~ "function " m {flag=1} flag && /return/{print; exit}' "$file" \
-      | sed -nE "s/.*return '([a-zA-Z_]+)'.*/\1/p")
-  fi
-  # Edge: AbstractOrderOptionDefinition's getCarrierSettingsKey builds 'export' . ucfirst($key)
-  # — we synthesise the same value below in the shipment-options loop, not here.
-  echo "$cap"
-}
-
 # Emit a row when the key is missing from any of the 5 languages.
 # Format: "<key>\t(missing: <comma-separated-langs>)[\t(legacy: <legacy_key>)]"
-# When all 5 are missing the missing-list reads "en,nl,fr,de,it" — that's the same
-# signal the previous version surfaced, just explicit. Partial gaps (e.g. "(missing: it)")
-# are now visible too.
 emit_if_missing() {
   local key="$1" legacy="${2:-}"
   local missing
@@ -103,159 +84,54 @@ emit_if_missing() {
   [[ -z "$missing" ]] && return
 
   local out="$key	(missing: $missing)"
-  if [[ -n "$legacy" ]] && key_exists "$legacy"; then
+  if [[ -n "$legacy" ]] && key_exists_en "$legacy"; then
     out="$out	(legacy: $legacy)"
   fi
   echo "$out"
 }
 
-# ---- shipment_options_* and settings_carrier_*/settings_product_* per-option ----
+# Run the PHP introspection inside the PDK's docker php service.
+INTROSPECT_JSON="$KEYS_TMPDIR/expected_keys.json"
+(
+  cd "$PDK_ROOT"
+  docker compose run --rm -T php php .claude/skills/check-pdk-translations/scripts/introspect_keys.php
+) > "$INTROSPECT_JSON"
 
-# Build a cache file with one line per Definition:
-#   <basename>|<cap>|<legacy_camel>|<allow>|<price>|<carrier>|<product>
-build_definition_cache() {
-  local cache="$1"
-  : > "$cache"
-  local f basename cap legacy_camel allow price carrier product first rest
-  for f in "$DEFINITIONS_DIR"/*Definition.php; do
-    basename="$(basename "$f")"
-    [[ "$basename" == "AbstractOrderOptionDefinition.php" ]] && continue
+if [[ ! -s "$INTROSPECT_JSON" ]]; then
+  echo "ERROR: PHP introspection produced no output." >&2
+  exit 1
+fi
 
-    cap=$(extract_return "$f" "getCapabilitiesOptionsKey")
-    legacy_camel=$(extract_return "$f" "getShipmentOptionsKey")
-    allow=$(extract_return "$f" "getAllowSettingsKey")
-    price=$(extract_return "$f" "getPriceSettingsKey")
-    carrier=$(extract_return "$f" "getCarrierSettingsKey")
-    product=$(extract_return "$f" "getProductSettingsKey")
-
-    # Apply abstract default for getCarrierSettingsKey: 'export' . ucfirst($shipmentOptionsKey).
-    if [[ -z "$carrier" && -n "$legacy_camel" ]]; then
-      first=${legacy_camel:0:1}
-      rest=${legacy_camel:1}
-      carrier="export$(echo "$first" | tr '[:lower:]' '[:upper:]')${rest}"
-    fi
-
-    printf '%s|%s|%s|%s|%s|%s|%s\n' \
-      "$basename" "$cap" "$legacy_camel" "$allow" "$price" "$carrier" "$product" >> "$cache"
-  done
-}
-
-# Description (`_description`) and subtext siblings are intentionally NOT emitted —
-# they are optional in this codebase. Missing descriptions silently render nothing
-# in the UI, so flagging them here as "missing" produces noise. Translate mode asks
-# the user per category whether to draft descriptions.
-
-print_shipment_options_from_cache() {
-  echo "== shipment_options =="
-  local cap legacy_camel legacy_snake key legacy
-  while IFS='|' read -r _ cap legacy_camel _ _ _ _; do
-    [[ -z "$cap" ]] && continue
-    legacy_snake=$(to_snake "$legacy_camel")
-    key="shipment_options_${cap}"
-    legacy=""
-    [[ -n "$legacy_snake" && "$legacy_snake" != "$cap" ]] && legacy="shipment_options_${legacy_snake}"
-    emit_if_missing "$key" "$legacy"
-  done < "$1"
-}
-
-print_settings_carrier_per_option_from_cache() {
-  echo "== settings_carrier (per-option) =="
-  local allow price carrier camel snake
-  while IFS='|' read -r _ _ _ allow price carrier _; do
-    for camel in "$allow" "$price" "$carrier"; do
-      [[ -z "$camel" ]] && continue
-      snake=$(to_snake "$camel")
-      emit_if_missing "settings_carrier_${snake}"
-    done
-  done < "$1"
-}
-
-print_settings_product_per_option_from_cache() {
-  echo "== settings_product (per-option) =="
-  local product snake
-  while IFS='|' read -r _ _ _ _ _ _ product; do
-    [[ -z "$product" ]] && continue
-    snake=$(to_snake "$product")
-    emit_if_missing "settings_product_${snake}"
-  done < "$1"
-}
-
-# ---- static settings dividers grep'd from views ----
-# createGenericLabel('foo') in a view with labelPrefix=$prefix produces
-# settings_<prefix>_<foo>. Default prefix in CarrierSettingsItemView is 'carrier'.
-# We only include matches we can attribute to a known prefix.
-
-print_static_dividers() {
-  echo "== settings_carrier (static dividers) =="
-  # CarrierSettingsItemView always uses prefix 'carrier' (CarrierSettings::ID).
-  # Dividers are rendered with `_title` (visible header) — not the bare key.
-  # `_description` exists for some dividers but is optional, so we don't emit it.
-  local view="$VIEWS_DIR/CarrierSettingsItemView.php"
-  if [[ -f "$view" ]]; then
-    grep -oE "createGenericLabel\(['\"][a-z_]+['\"]\)" "$view" \
-      | sed -E "s/createGenericLabel\(['\"]([a-z_]+)['\"]\)/\1/" \
-      | sort -u \
-      | while read -r divider; do
-          emit_if_missing "settings_carrier_${divider}_title"
-        done
-  fi
-}
-
-# ---- delivery_type_* ----
-
-print_delivery_types() {
-  echo "== delivery_type =="
-  local sdk_file="$SDK_MODELS/ShipmentDefsDeliveryOptionsDeliveryNameV2.php"
-  [[ ! -f "$sdk_file" ]] && { echo "(SDK class not found: $sdk_file)"; return; }
-  grep -E "public const [A-Z_]+ = '" "$sdk_file" \
-    | sed -E "s/.*= '([a-z_]+)'.*/\1/" \
-    | while read -r name; do
-        emit_if_missing "delivery_type_${name}"
+# Print a section heading and emit missing keys for every entry under the given jq path.
+# Usage: print_section "== heading ==" '<jq expression yielding {key,legacy?} or string>'
+print_section() {
+  local heading="$1" jq_expr="$2"
+  echo "$heading"
+  jq -r "$jq_expr" "$INTROSPECT_JSON" \
+    | while IFS=$'\t' read -r key legacy; do
+        [[ -z "$key" ]] && continue
+        emit_if_missing "$key" "$legacy"
       done
 }
 
-# ---- package_type_* ----
-
-print_package_types() {
-  echo "== package_type =="
-  local sdk_file="$SDK_MODELS/RefShipmentPackageTypeV2.php"
-  [[ ! -f "$sdk_file" ]] && { echo "(SDK class not found: $sdk_file)"; return; }
-  grep -E "public const [A-Z_]+ = '[A-Z_]+'" "$sdk_file" \
-    | sed -E "s/.*= '([A-Z_]+)'.*/\1/" \
-    | tr '[:upper:]' '[:lower:]' \
-    | while read -r name; do
-        emit_if_missing "package_type_${name}"
-      done
-}
-
-# ---- carrier_* ----
-
-print_carriers() {
-  echo "== carrier =="
-  local sdk_file="$SDK_MODELS/RefCapabilitiesSharedCarrierV2.php"
-  [[ ! -f "$sdk_file" ]] && { echo "(SDK class not found: $sdk_file)"; return; }
-  grep -E "public const [A-Z_]+ = '[A-Z_]+'" "$sdk_file" \
-    | sed -E "s/.*= '([A-Z_]+)'.*/\1/" \
-    | tr '[:upper:]' '[:lower:]' \
-    | while read -r name; do
-        emit_if_missing "carrier_${name}"
-      done
-}
-
-DEF_CACHE=$(mktemp -t pdk_translations_definitions.XXXXXX)
-trap 'rm -f "$DEF_CACHE"' EXIT
-build_definition_cache "$DEF_CACHE"
-
-print_shipment_options_from_cache "$DEF_CACHE"
+# `// ""` keeps an empty legacy field when null, so the bash read still gets two columns.
+print_section "== shipment_options ==" \
+  '.shipment_options[] | "\(.key)\t\(.legacy // "")"'
 echo
-print_settings_carrier_per_option_from_cache "$DEF_CACHE"
+print_section "== settings_carrier (per-option) ==" \
+  '.settings_carrier[] | "\(.)\t"'
 echo
-print_settings_product_per_option_from_cache "$DEF_CACHE"
+print_section "== settings_product (per-option) ==" \
+  '.settings_product[] | "\(.)\t"'
 echo
-print_static_dividers
+print_section "== settings_carrier (static dividers) ==" \
+  '.settings_carrier_dividers[] | "\(.)\t"'
 echo
-print_delivery_types
+print_section "== delivery_type ==" \
+  '.delivery_type[] | "\(.)\t"'
 echo
-print_package_types
+print_section "== package_type ==" \
+  '.package_type[] | "\(.)\t"'
 echo
-print_carriers
+print_section "== carrier ==" \
+  '.carrier[] | "\(.)\t"'

--- a/.claude/skills/check-pdk-translations/scripts/introspect_keys.php
+++ b/.claude/skills/check-pdk-translations/scripts/introspect_keys.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Enumerate the translation keys the PDK runtime expects, based on:
+ *   - PDK Definition classes in src/App/Options/Definition (allow/price/carrier/product/shipment-options/capabilities keys)
+ *   - SDK constant classes (delivery types, package types, carriers)
+ *   - createGenericLabel('foo') calls in CarrierSettingsItemView (static dividers)
+ *
+ * Output: a single JSON document on stdout. The bash wrapper diffs it against
+ * the plugin's generated translation files for each supported language.
+ *
+ * Designed to be run via `docker compose run --rm -T php php <this>` from PDK root.
+ */
+
+$pdkRoot = realpath(__DIR__ . '/../../../..');
+require $pdkRoot . '/vendor/autoload.php';
+
+$snake = static function (string $camel): string {
+    return strtolower((string) preg_replace('/([A-Z])/', '_$1', lcfirst($camel)));
+};
+
+$definitionsDir   = $pdkRoot . '/src/App/Options/Definition';
+$shipmentOptions  = [];
+$settingsCarrier  = [];
+$settingsProduct  = [];
+
+foreach (glob($definitionsDir . '/*Definition.php') ?: [] as $file) {
+    $basename = basename($file, '.php');
+    if ($basename === 'AbstractOrderOptionDefinition') {
+        continue;
+    }
+    $fqcn = "MyParcelNL\\Pdk\\App\\Options\\Definition\\{$basename}";
+    if (! class_exists($fqcn)) {
+        continue;
+    }
+    $reflection = new ReflectionClass($fqcn);
+    if ($reflection->isAbstract()) {
+        continue;
+    }
+    $definition = $reflection->newInstance();
+
+    $cap                = $definition->getCapabilitiesOptionsKey();
+    $shipmentOptionsKey = $definition->getShipmentOptionsKey();
+
+    if ($cap !== null && $cap !== '') {
+        $key            = "shipment_options_{$cap}";
+        $legacy         = null;
+        if ($shipmentOptionsKey !== null && $shipmentOptionsKey !== '') {
+            $legacyCandidate = "shipment_options_{$snake($shipmentOptionsKey)}";
+            if ($legacyCandidate !== $key) {
+                $legacy = $legacyCandidate;
+            }
+        }
+        $shipmentOptions[] = ['key' => $key, 'legacy' => $legacy];
+    }
+
+    $perOptionCarrierKeys = [
+        $definition->getAllowSettingsKey(),
+        $definition->getPriceSettingsKey(),
+        $definition->getCarrierSettingsKey(),
+    ];
+    foreach ($perOptionCarrierKeys as $camel) {
+        if ($camel === null || $camel === '') {
+            continue;
+        }
+        $settingsCarrier[] = "settings_carrier_{$snake($camel)}";
+    }
+
+    $product = $definition->getProductSettingsKey();
+    if ($product !== null && $product !== '') {
+        $settingsProduct[] = "settings_product_{$snake($product)}";
+    }
+}
+
+// Static dividers from CarrierSettingsItemView (createGenericLabel('foo') -> settings_carrier_<foo>_title).
+// CarrierSettingsItemView always uses the 'carrier' label prefix (CarrierSettings::ID).
+// Dividers render with `_title`; `_description` exists for some but is optional.
+$staticDividers = [];
+$viewFile       = $pdkRoot . '/src/Frontend/View/CarrierSettingsItemView.php';
+if (is_file($viewFile)) {
+    $contents = (string) file_get_contents($viewFile);
+    if (preg_match_all("/createGenericLabel\\(['\"]([a-z_]+)['\"]\\)/", $contents, $matches) > 0) {
+        foreach (array_unique($matches[1]) as $divider) {
+            $staticDividers[] = "settings_carrier_{$divider}_title";
+        }
+    }
+}
+
+$constantsAsKeys = static function (string $fqcn, string $prefix): array {
+    if (! class_exists($fqcn)) {
+        return [];
+    }
+    $r    = new ReflectionClass($fqcn);
+    $keys = [];
+    foreach ($r->getConstants() as $value) {
+        if (! is_string($value) || $value === '') {
+            continue;
+        }
+        $keys[] = $prefix . '_' . strtolower($value);
+    }
+    return array_values(array_unique($keys));
+};
+
+echo json_encode([
+    'shipment_options'         => $shipmentOptions,
+    'settings_carrier'         => array_values(array_unique($settingsCarrier)),
+    'settings_product'         => array_values(array_unique($settingsProduct)),
+    'settings_carrier_dividers'=> $staticDividers,
+    'delivery_type'            => $constantsAsKeys('MyParcelNL\\Sdk\\Client\\Generated\\CoreApi\\Model\\ShipmentDefsDeliveryOptionsDeliveryNameV2', 'delivery_type'),
+    'package_type'             => $constantsAsKeys('MyParcelNL\\Sdk\\Client\\Generated\\CoreApi\\Model\\RefShipmentPackageTypeV2', 'package_type'),
+    'carrier'                  => $constantsAsKeys('MyParcelNL\\Sdk\\Client\\Generated\\CoreApi\\Model\\RefCapabilitiesSharedCarrierV2', 'carrier'),
+], JSON_THROW_ON_ERROR);


### PR DESCRIPTION
adds a claude skill to find and translate dynamic translation keys that are missing: delivery types, shipment options, carrier names and package types - and their various prefixed versions in the PDK.

it is NOT a catch-all: doesn't do a full code scan for any other (custom) translations