### PR TITLE
fix(proposition): enable GLS fakedelivery 

### DIFF
--- a/config/proposition/proposition-1.json
+++ b/config/proposition/proposition-1.json
@@ -29,14 +29,7 @@
           "time": "HH:mm"
         },
         "language": "nl-NL",
-        "supportedLanguages": [
-          "nl-NL",
-          "en-GB",
-          "de-DE",
-          "fr-FR",
-          "es-ES",
-          "it-IT"
-        ],
+        "supportedLanguages": ["nl-NL", "en-GB", "de-DE", "fr-FR", "es-ES", "it-IT"],
         "timezone": "Europe/Amsterdam"
       },
       "url": "https://subdomain.myparcel.me"
@@ -69,17 +62,8 @@
   },
   "billing": {
     "bankMandate": {
-      "flow": [
-        "manual",
-        "automatic"
-      ],
-      "manualBanks": [
-        "bunq",
-        "adyen",
-        "revolut",
-        "knab",
-        "other"
-      ]
+      "flow": ["manual", "automatic"],
+      "manualBanks": ["bunq", "adyen", "revolut", "knab", "other"]
     },
     "newInvoiceDates": {
       "monthly": "2024-06-01",
@@ -269,19 +253,8 @@
         "hasCutoffTime": true,
         "hasPostponedDelivery": true,
         "outboundFeatures": {
-          "packageTypes": [
-            "PACKAGE",
-            "MAILBOX",
-            "LETTER",
-            "DIGITAL_STAMP",
-            "SMALL_PACKAGE"
-          ],
-          "deliveryTypes": [
-            "MORNING_DELIVERY",
-            "STANDARD_DELIVERY",
-            "EVENING_DELIVERY",
-            "PICKUP_DELIVERY"
-          ],
+          "packageTypes": ["PACKAGE", "MAILBOX", "LETTER", "DIGITAL_STAMP", "SMALL_PACKAGE"],
+          "deliveryTypes": ["MORNING_DELIVERY", "STANDARD_DELIVERY", "EVENING_DELIVERY", "PICKUP_DELIVERY"],
           "shipmentOptions": [
             "AGE_CHECK",
             "LARGE_FORMAT",
@@ -293,45 +266,20 @@
             "INSURANCE",
             "TRACKED"
           ],
-          "deliveryCountries": [
-            "NL",
-            "BE"
-          ],
-          "pickupCountries": [
-            "NL",
-            "BE",
-            "DK",
-            "SE",
-            "DE"
-          ],
+          "deliveryCountries": ["NL", "BE"],
+          "pickupCountries": ["NL", "BE", "DK", "SE", "DE"],
           "metadata": {
             "labelDescriptionLength": 45,
             "carrierSmallPackageContract": "FEATURE_CUSTOM_CONTRACT_ONLY",
             "multiCollo": true,
             "insuranceOptions": [
-              0,
-              10000,
-              25000,
-              50000,
-              100000,
-              150000,
-              200000,
-              250000,
-              300000,
-              350000,
-              400000,
-              450000,
-              500000
+              0, 10000, 25000, 50000, 100000, 150000, 200000, 250000, 300000, 350000, 400000, 450000, 500000
             ]
           }
         },
         "inboundFeatures": {
-          "packageTypes": [
-            "PACKAGE"
-          ],
-          "deliveryTypes": [
-            "STANDARD_DELIVERY"
-          ],
+          "packageTypes": ["PACKAGE"],
+          "deliveryTypes": ["STANDARD_DELIVERY"],
           "shipmentOptions": [
             "SIGNATURE",
             "RETURN",
@@ -344,49 +292,20 @@
           "metadata": {
             "labelDescriptionLength": 45,
             "insuranceSteps": [
-              0,
-              10000,
-              25000,
-              50000,
-              100000,
-              150000,
-              200000,
-              250000,
-              300000,
-              350000,
-              400000,
-              450000,
-              500000
+              0, 10000, 25000, 50000, 100000, 150000, 200000, 250000, 300000, 350000, 400000, 450000, 500000
             ]
           }
         },
         "deliveryOptions": {
-          "addressFields": [
-            "postalCode",
-            "street",
-            "city"
-          ],
+          "addressFields": ["postalCode", "street", "city"],
           "unsupportedParameters": null,
-          "availableFeatures": [
-            "deliveryDaysWindow",
-            "dropOffDays",
-            "dropOffDelay",
-            "pickupMapAllowLoadMore"
-          ],
+          "availableFeatures": ["deliveryDaysWindow", "dropOffDays", "dropOffDelay", "pickupMapAllowLoadMore"],
           "shipmentOptionsPerPackageType": {
-            "package": [
-              "only_recipient",
-              "signature"
-            ],
-            "mailbox": [
-              "priority_delivery"
-            ],
+            "package": ["only_recipient", "signature"],
+            "mailbox": ["priority_delivery"],
             "letter": [],
             "digital_stamp": [],
-            "package_small": [
-              "only_recipient",
-              "signature"
-            ]
+            "package_small": ["only_recipient", "signature"]
           },
           "allowFakeDelivery": true
         }
@@ -399,9 +318,7 @@
         "hasCutoffTime": true,
         "hasPostponedDelivery": true,
         "outboundFeatures": {
-          "packageTypes": [
-            "PALLET"
-          ],
+          "packageTypes": ["PALLET"],
           "deliveryCountries": [],
           "pickupCountries": []
         },
@@ -420,14 +337,8 @@
         "hasCutoffTime": true,
         "hasPostponedDelivery": true,
         "outboundFeatures": {
-          "packageTypes": [
-            "PACKAGE",
-            "MAILBOX"
-          ],
-          "deliveryTypes": [
-            "STANDARD_DELIVERY",
-            "PICKUP_DELIVERY"
-          ],
+          "packageTypes": ["PACKAGE", "MAILBOX"],
+          "deliveryTypes": ["STANDARD_DELIVERY", "PICKUP_DELIVERY"],
           "shipmentOptions": [],
           "deliveryCountries": [
             "AT",
@@ -483,16 +394,9 @@
           }
         },
         "deliveryOptions": {
-          "addressFields": [
-            "postalCode",
-            "street",
-            "city"
-          ],
+          "addressFields": ["postalCode", "street", "city"],
           "unsupportedParameters": null,
-          "availableFeatures": [
-            "dropOffDays",
-            "dropOffDelay"
-          ],
+          "availableFeatures": ["dropOffDays", "dropOffDelay"],
           "allowFakeDelivery": false
         }
       },
@@ -522,16 +426,8 @@
         "hasCutoffTime": true,
         "hasPostponedDelivery": true,
         "outboundFeatures": {
-          "packageTypes": [
-            "PACKAGE",
-            "MAILBOX",
-            "SMALL_PACKAGE"
-          ],
-          "deliveryTypes": [
-            "STANDARD_DELIVERY",
-            "EVENING_DELIVERY",
-            "PICKUP_DELIVERY"
-          ],
+          "packageTypes": ["PACKAGE", "MAILBOX", "SMALL_PACKAGE"],
+          "deliveryTypes": ["STANDARD_DELIVERY", "EVENING_DELIVERY", "PICKUP_DELIVERY"],
           "shipmentOptions": [
             "AGE_CHECK",
             "ONLY_RECIPIENT",
@@ -541,38 +437,16 @@
             "HIDE_SENDER",
             "INSURANCE"
           ],
-          "deliveryCountries": [
-            "NL",
-            "BE"
-          ],
-          "pickupCountries": [
-            "NL",
-            "BE"
-          ],
+          "deliveryCountries": ["NL", "BE"],
+          "pickupCountries": ["NL", "BE"],
           "metadata": {
             "labelDescriptionLength": 45,
-            "insuranceOptions": [
-              0,
-              50000,
-              100000,
-              150000,
-              200000,
-              250000,
-              300000,
-              350000,
-              400000,
-              450000,
-              500000
-            ]
+            "insuranceOptions": [0, 50000, 100000, 150000, 200000, 250000, 300000, 350000, 400000, 450000, 500000]
           }
         },
         "inboundFeatures": {
-          "packageTypes": [
-            "PACKAGE"
-          ],
-          "deliveryTypes": [
-            "STANDARD_DELIVERY"
-          ],
+          "packageTypes": ["PACKAGE"],
+          "deliveryTypes": ["STANDARD_DELIVERY"],
           "shipmentOptions": [
             "SIGNATURE",
             "RETURN",
@@ -586,16 +460,9 @@
           }
         },
         "deliveryOptions": {
-          "addressFields": [
-            "city",
-            "postalCode"
-          ],
+          "addressFields": ["city", "postalCode"],
           "unsupportedParameters": null,
-          "availableFeatures": [
-            "deliveryDaysWindow",
-            "dropOffDays",
-            "dropOffDelay"
-          ],
+          "availableFeatures": ["deliveryDaysWindow", "dropOffDays", "dropOffDelay"],
           "allowFakeDelivery": false
         }
       },
@@ -607,49 +474,21 @@
         "hasCutoffTime": true,
         "hasPostponedDelivery": true,
         "outboundFeatures": {
-          "packageTypes": [
-            "PACKAGE"
-          ],
-          "deliveryTypes": [
-            "STANDARD_DELIVERY",
-            "PICKUP_DELIVERY"
-          ],
-          "shipmentOptions": [
-            "SIGNATURE",
-            "INSURANCE"
-          ],
+          "packageTypes": ["PACKAGE"],
+          "deliveryTypes": ["STANDARD_DELIVERY", "PICKUP_DELIVERY"],
+          "shipmentOptions": ["SIGNATURE", "INSURANCE"],
           "metadata": {
             "labelDescriptionLength": 45,
-            "insurance": [
-              0,
-              50000,
-              100000,
-              150000,
-              200000,
-              250000,
-              300000,
-              350000,
-              400000,
-              450000,
-              500000
-            ]
+            "insurance": [0, 50000, 100000, 150000, 200000, 250000, 300000, 350000, 400000, 450000, 500000]
           }
         },
         "inboundFeatures": {
-          "packageTypes": [
-            "PACKAGE"
-          ],
-          "deliveryTypes": [
-            "STANDARD_DELIVERY"
-          ],
-          "shipmentOptions": [
-            "INSURANCE"
-          ],
+          "packageTypes": ["PACKAGE"],
+          "deliveryTypes": ["STANDARD_DELIVERY"],
+          "shipmentOptions": ["INSURANCE"],
           "metadata": {
             "labelDescriptionLength": 45,
-            "insuranceOptions": [
-              50000
-            ]
+            "insuranceOptions": [50000]
           }
         },
         "deliveryOptions": {
@@ -667,33 +506,12 @@
         "hasCutoffTime": false,
         "hasPostponedDelivery": false,
         "outboundFeatures": {
-          "packageTypes": [
-            "PACKAGE"
-          ],
-          "deliveryTypes": [
-            "STANDARD_DELIVERY"
-          ],
-          "shipmentOptions": [
-            "SIGNATURE",
-            "SATURDAY_DELIVERY",
-            "HIDE_SENDER",
-            "INSURANCE"
-          ],
+          "packageTypes": ["PACKAGE"],
+          "deliveryTypes": ["STANDARD_DELIVERY"],
+          "shipmentOptions": ["SIGNATURE", "SATURDAY_DELIVERY", "HIDE_SENDER", "INSURANCE"],
           "metadata": {
             "labelDescriptionLength": 45,
-            "insuranceOptions": [
-              0,
-              50000,
-              100000,
-              150000,
-              200000,
-              250000,
-              300000,
-              350000,
-              400000,
-              450000,
-              500000
-            ]
+            "insuranceOptions": [0, 50000, 100000, 150000, 200000, 250000, 300000, 350000, 400000, 450000, 500000]
           }
         },
         "deliveryOptions": {
@@ -711,46 +529,18 @@
         "hasCutoffTime": true,
         "hasPostponedDelivery": true,
         "outboundFeatures": {
-          "packageTypes": [
-            "PACKAGE"
-          ],
-          "deliveryTypes": [
-            "STANDARD_DELIVERY",
-            "PICKUP_DELIVERY"
-          ],
-          "shipmentOptions": [
-            "AGE_CHECK",
-            "ONLY_RECIPIENT",
-            "RETURN",
-            "SIGNATURE",
-            "COLLECT",
-            "INSURANCE"
-          ],
+          "packageTypes": ["PACKAGE"],
+          "deliveryTypes": ["STANDARD_DELIVERY", "PICKUP_DELIVERY"],
+          "shipmentOptions": ["AGE_CHECK", "ONLY_RECIPIENT", "RETURN", "SIGNATURE", "COLLECT", "INSURANCE"],
           "metadata": {
             "labelDescriptionLength": 45,
             "insuranceOptions": [
-              0,
-              10000,
-              25000,
-              50000,
-              100000,
-              150000,
-              200000,
-              250000,
-              300000,
-              350000,
-              400000,
-              450000,
-              500000
+              0, 10000, 25000, 50000, 100000, 150000, 200000, 250000, 300000, 350000, 400000, 450000, 500000
             ]
           }
         },
         "deliveryOptions": {
-          "addressFields": [
-            "postalCode",
-            "street",
-            "city"
-          ],
+          "addressFields": ["postalCode", "street", "city"],
           "unsupportedParameters": null,
           "availableFeatures": null,
           "allowFakeDelivery": false
@@ -764,47 +554,19 @@
         "hasCutoffTime": true,
         "hasPostponedDelivery": true,
         "outboundFeatures": {
-          "packageTypes": [
-            "PACKAGE"
-          ],
-          "deliveryTypes": [
-            "EXPRESS_DELIVERY",
-            "PICKUP_DELIVERY"
-          ],
-          "shipmentOptions": [
-            "AGE_CHECK",
-            "ONLY_RECIPIENT",
-            "RETURN",
-            "SIGNATURE",
-            "COLLECT"
-          ],
+          "packageTypes": ["PACKAGE"],
+          "deliveryTypes": ["EXPRESS_DELIVERY", "PICKUP_DELIVERY"],
+          "shipmentOptions": ["AGE_CHECK", "ONLY_RECIPIENT", "RETURN", "SIGNATURE", "COLLECT"],
           "metadata": {
             "labelDescriptionLength": 45,
             "insuranceOptions": [
-              10000,
-              25000,
-              50000,
-              100000,
-              150000,
-              200000,
-              250000,
-              300000,
-              350000,
-              400000,
-              450000,
-              500000
+              10000, 25000, 50000, 100000, 150000, 200000, 250000, 300000, 350000, 400000, 450000, 500000
             ]
           }
         },
         "deliveryOptions": {
-          "addressFields": [
-            "postalCode",
-            "street",
-            "city"
-          ],
-          "unsupportedParameters": [
-            "package_type"
-          ],
+          "addressFields": ["postalCode", "street", "city"],
+          "unsupportedParameters": ["package_type"],
           "availableFeatures": null,
           "allowFakeDelivery": false
         }
@@ -861,31 +623,20 @@
         "hasCutoffTime": true,
         "hasPostponedDelivery": true,
         "outboundFeatures": {
-          "packageTypes": [
-            "PACKAGE"
-          ],
-          "deliveryTypes": [
-            "STANDARD_DELIVERY",
-            "PICKUP_DELIVERY"
-          ],
-          "shipmentOptions": [
-            "SIGNATURE",
-            "SATURDAY_DELIVERY",
-            "INSURANCE"
-          ],
+          "packageTypes": ["PACKAGE"],
+          "deliveryTypes": ["STANDARD_DELIVERY", "PICKUP_DELIVERY"],
+          "shipmentOptions": ["SIGNATURE", "SATURDAY_DELIVERY", "INSURANCE"],
           "metadata": {
             "labelDescriptionLength": 45,
             "carrierSmallPackageContract": "FEATURE_CUSTOM_CONTRACT_ONLY",
-            "insuranceOptions": [
-              50000
-            ]
-          },
-          "deliveryOptions": {
-            "addressFields": [],
-            "unsupportedParameters": [],
-            "availableFeatures": [],
-            "allowFakeDelivery": false
+            "insuranceOptions": [50000]
           }
+        },
+        "deliveryOptions": {
+          "addressFields": [],
+          "unsupportedParameters": [],
+          "availableFeatures": [],
+          "allowFakeDelivery": true
         }
       },
       {
@@ -896,12 +647,8 @@
         "hasCutoffTime": true,
         "hasPostponedDelivery": true,
         "outboundFeatures": {
-          "packageTypes": [
-            "PACKAGE"
-          ],
-          "deliveryTypes": [
-            "STANDARD_DELIVERY"
-          ],
+          "packageTypes": ["PACKAGE"],
+          "deliveryTypes": ["STANDARD_DELIVERY"],
           "shipmentOptions": [
             "AGE_CHECK",
             "ONLY_RECIPIENT",
@@ -949,15 +696,7 @@
   },
   "countryCode": "NL",
   "deliveryOptions": {
-    "dropOffDays": [
-      0,
-      1,
-      2,
-      3,
-      4,
-      5,
-      6
-    ],
+    "dropOffDays": [0, 1, 2, 3, 4, 5, 6],
     "mondayDelivery": true
   },
   "enableAcademy": true,
@@ -1009,10 +748,7 @@
       "time": "HH:mm"
     },
     "language": "nl-NL",
-    "supportedLanguages": [
-      "nl-NL",
-      "en-GB"
-    ],
+    "supportedLanguages": ["nl-NL", "en-GB"],
     "timezone": "Europe/Amsterdam"
   },
   "proposition": {
@@ -1025,18 +761,11 @@
     "carrier": {
       "withRecommendedPhoneNumber": [],
       "withRequiredCompany": [],
-      "withRequiredEmail": [
-        "UPS_STANDARD",
-        "UPS_EXPRESS_SAVER",
-        "DPD"
-      ],
+      "withRequiredEmail": ["UPS_STANDARD", "UPS_EXPRESS_SAVER", "DPD"],
       "withRequiredHeight": [],
       "withRequiredLabelDescription": [],
       "withRequiredLength": [],
-      "withRequiredPhoneNumber": [
-        "UPS_STANDARD",
-        "UPS_EXPRESS_SAVER"
-      ],
+      "withRequiredPhoneNumber": ["UPS_STANDARD", "UPS_EXPRESS_SAVER"],
       "withRequiredWidth": []
     },
     "country": {
@@ -1058,9 +787,7 @@
         "CH",
         "US"
       ],
-      "withBoxNumber": [
-        "BE"
-      ],
+      "withBoxNumber": ["BE"],
       "withPartnerLinks": [
         "AT",
         "BE",
@@ -1116,9 +843,7 @@
       ],
       "withRecommendedPhoneNumber": [],
       "withRequiredCompany": [],
-      "withRequiredEmail": [
-        "NO"
-      ],
+      "withRequiredEmail": ["NO"],
       "withRequiredHeight": [],
       "withRequiredLabelDescription": [],
       "withRequiredLength": [],
@@ -1141,15 +866,9 @@
       ]
     },
     "shippingRules": {
-      "countryCodes": [
-        "NL",
-        "BE"
-      ],
+      "countryCodes": ["NL", "BE"],
       "maxAmount": 1,
-      "regionCodes": [
-        "EU",
-        "ROW"
-      ]
+      "regionCodes": ["EU", "ROW"]
     }
   },
   "support": {
@@ -1173,12 +892,7 @@
       {
         "id": 2,
         "name": "System",
-        "subTypes": [
-          "plugin_question",
-          "plugin_help_needed",
-          "shipment_export_help_needed",
-          "other_system_question"
-        ],
+        "subTypes": ["plugin_question", "plugin_help_needed", "shipment_export_help_needed", "other_system_question"],
         "extraField": {
           "name": "webshopSoftware",
           "optional": true
@@ -1187,20 +901,12 @@
       {
         "id": 3,
         "name": "ProductsAndPrices",
-        "subTypes": [
-          "products",
-          "rates",
-          "packaging",
-          "webshop_orders"
-        ]
+        "subTypes": ["products", "rates", "packaging", "webshop_orders"]
       },
       {
         "id": 4,
         "name": "MyInvoice",
-        "subTypes": [
-          "invoice_change_details",
-          "invoice_other_question"
-        ],
+        "subTypes": ["invoice_change_details", "invoice_other_question"],
         "extraField": {
           "name": "invoiceNumber",
           "optional": true

--- a/tests/__snapshots__/CarrierTest__it_instantiates_carriers_from_name_with_(myparcel-nederland)__1.json
+++ b/tests/__snapshots__/CarrierTest__it_instantiates_carriers_from_name_with_(myparcel-nederland)__1.json
@@ -309,7 +309,12 @@
         "insuranceOptions": [50000]
       }
     },
-    "deliveryOptions": []
+    "deliveryOptions": {
+      "addressFields": [],
+      "unsupportedParameters": [],
+      "availableFeatures": [],
+      "allowFakeDelivery": true
+    }
   },
   {
     "externalIdentifier": "TRUNKRS",

--- a/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_delivery_options_config__1.json
+++ b/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_delivery_options_config__1.json
@@ -154,6 +154,7 @@
           "subscription": -1,
           "packageTypes": ["package"],
           "deliveryTypes": ["standard", "pickup"],
+          "fakeDelivery": true,
           "shipmentOptionsPerPackageType": {
             "package": ["signature", "saturday_delivery", "insurance"]
           }

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_delivery_options__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_delivery_options__1.json
@@ -170,6 +170,7 @@
           "subscription": -1,
           "packageTypes": ["package"],
           "deliveryTypes": ["standard", "pickup"],
+          "fakeDelivery": true,
           "shipmentOptionsPerPackageType": {
             "package": ["signature", "saturday_delivery", "insurance"]
           }

--- a/tests/__snapshots__/PlatformManagerTest__it_gets_carriers_with_(myparcel-nederland)__1.json
+++ b/tests/__snapshots__/PlatformManagerTest__it_gets_carriers_with_(myparcel-nederland)__1.json
@@ -309,7 +309,12 @@
         "insuranceOptions": [50000]
       }
     },
-    "deliveryOptions": []
+    "deliveryOptions": {
+      "addressFields": [],
+      "unsupportedParameters": [],
+      "availableFeatures": [],
+      "allowFakeDelivery": true
+    }
   },
   {
     "externalIdentifier": "TRUNKRS",

--- a/tests/__snapshots__/PlatformManagerTest__it_retrieves_config_for_each_platform_with_(myparcel-nederland)__1.json
+++ b/tests/__snapshots__/PlatformManagerTest__it_retrieves_config_for_each_platform_with_(myparcel-nederland)__1.json
@@ -718,7 +718,12 @@
         "packageTypes": [],
         "shipmentOptions": []
       },
-      "deliveryOptions": []
+      "deliveryOptions": {
+        "addressFields": [],
+        "unsupportedParameters": [],
+        "availableFeatures": [],
+        "allowFakeDelivery": true
+      }
     },
     {
       "externalIdentifier": "trunkrs",


### PR DESCRIPTION
INT-1428

- Move deliveryOptions for GLS out of outboundFeatures to the correct top-level position (same as PostNL, TRUNKRS, etc.)
- Set allowFakeDelivery to true for GLS in availableForCustomCredentials