### PR TITLE
fix: prevent old carrier info from crashing plugin

### DIFF
--- a/src/App/DeliveryOptions/Service/DeliveryOptionsService.php
+++ b/src/App/DeliveryOptions/Service/DeliveryOptionsService.php
@@ -146,6 +146,7 @@ class DeliveryOptionsService implements DeliveryOptionsServiceInterface
         ];
 
         foreach ($carriers as $carrier) {
+            if (null === $carrier) { continue; }
             // Use the legacy identifier for the delivery options, as that endpoint does not yet support the new identifiers.
             $identifier = FrontendData::getLegacyCarrierIdentifier($carrier->carrier);
             $settings['carrierSettings'][$identifier] = $this->createCarrierSettings($carrier, $cart, $packageType);

--- a/src/App/DeliveryOptions/Service/DeliveryOptionsService.php
+++ b/src/App/DeliveryOptions/Service/DeliveryOptionsService.php
@@ -146,7 +146,7 @@ class DeliveryOptionsService implements DeliveryOptionsServiceInterface
         ];
 
         foreach ($carriers as $carrier) {
-            if (null === $carrier) { continue; }
+            if (null === $carrier->carrier) { continue; }
             // Use the legacy identifier for the delivery options, as that endpoint does not yet support the new identifiers.
             $identifier = FrontendData::getLegacyCarrierIdentifier($carrier->carrier);
             $settings['carrierSettings'][$identifier] = $this->createCarrierSettings($carrier, $cart, $packageType);


### PR DESCRIPTION
Fixes an issue that arises especially during development and continuously switching between capabilities and non-capabilities versions. It does no harm in production and it prevents the, however unlikely, case with a customer as well.