### PR TITLE
feat(capabilities): hide capabilities not mapped to v1 CoreApi or delivery options

### DIFF
--- a/src/Api/Request/Request.php
+++ b/src/Api/Request/Request.php
@@ -12,8 +12,9 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
  * @property string                $method
  * @property array{string, string} $parameters
  * @property string                $path
- * @property string                $property
+ * @property string|null           $property
  * @property string|null           $responseProperty
+ * @property bool                  $useDataEnvelope
  */
 class Request implements RequestInterface
 {
@@ -43,7 +44,7 @@ class Request implements RequestInterface
     protected $path = '';
 
     /**
-     * @var string
+     * @var string|null
      */
     private $property;
 

--- a/src/Api/Request/Request.php
+++ b/src/Api/Request/Request.php
@@ -53,6 +53,11 @@ class Request implements RequestInterface
     private $responseProperty;
 
     /**
+     * @var bool
+     */
+    private $useDataEnvelope = true;
+
+    /**
      * @param  array $config
      */
     public function __construct(array $config = [])
@@ -64,6 +69,7 @@ class Request implements RequestInterface
         $this->path             = $config['path'] ?? $this->path;
         $this->property         = $config['property'] ?? $this->property;
         $this->responseProperty = $config['responseProperty'] ?? $this->responseProperty;
+        $this->useDataEnvelope  = $config['useDataEnvelope'] ?? $this->useDataEnvelope;
     }
 
     /**
@@ -128,6 +134,14 @@ class Request implements RequestInterface
     public function getUniqueKey(): string
     {
         return sprintf('%s?%s:%s', $this->getPath(), $this->getQueryString(), http_build_query($this->getHeaders()));
+    }
+
+    /**
+     * @return bool
+     */
+    public function getUseDataEnvelope(): bool
+    {
+        return $this->useDataEnvelope;
     }
 
     /**

--- a/src/App/Action/Capabilities/CapabilitiesAction.php
+++ b/src/App/Action/Capabilities/CapabilitiesAction.php
@@ -41,12 +41,16 @@ class CapabilitiesAction implements ActionInterface
             return $corsHandler->handlePreflightRequest($request) ?? new Response();
         }
 
-        $body = json_decode($request->getContent(), true);
-        $shouldFilter = $request->query->getBoolean('filterSupported', false);
-
         try {
-            $results  = $this->capabilitiesService->getCapabilities($body, $shouldFilter);
-            $response = $this->createSymfonyResponse($results);
+            $body = json_decode($request->getContent(), true);
+
+            if (! is_array($body)) {
+                throw new \InvalidArgumentException('Request body must be a JSON object', 400);
+            }
+
+            $shouldFilter = $request->query->getBoolean('filterSupported', false);
+            $results      = $this->capabilitiesService->getCapabilities($body, $shouldFilter);
+            $response     = $this->createSymfonyResponse($results);
         } catch (Throwable $e) {
             $response = $this->createErrorResponse($e);
         }
@@ -56,11 +60,8 @@ class CapabilitiesAction implements ActionInterface
 
     /**
      * @param  \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesResponseCapabilityV2[] $results
-     * @param  bool                                                                                $filterOptions
-     *                                                                                                Apply the registered-options allowlist to each capability's options when true. Default false
-     *                                                                                                preserves the unfiltered SDK passthrough for existing callers.
      */
-    private function createSymfonyResponse(array $results, bool $filterOptions = false): Response
+    private function createSymfonyResponse(array $results): Response
     {
         return new Response(
             json_encode(['results' => $results]),

--- a/src/App/Action/Capabilities/CapabilitiesAction.php
+++ b/src/App/Action/Capabilities/CapabilitiesAction.php
@@ -6,7 +6,6 @@ namespace MyParcelNL\Pdk\App\Action\Capabilities;
 
 use MyParcelNL\Pdk\Api\Handler\CorsHandler;
 use MyParcelNL\Pdk\App\Action\Contract\ActionInterface;
-use MyParcelNL\Pdk\Carrier\Model\Carrier;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\ApiException as CoreApiException;
@@ -42,62 +41,17 @@ class CapabilitiesAction implements ActionInterface
             return $corsHandler->handlePreflightRequest($request) ?? new Response();
         }
 
-        $payload                                = $this->getRequestData($request);
-        [$sdkArgs, $shouldFilterOptions]        = $this->prepareSdkArgs($payload);
+        $body = json_decode($request->getContent(), true);
+        $shouldFilter = $request->query->getBoolean('filterSupported', false);
 
         try {
-            $results  = $this->capabilitiesService->getCapabilities($sdkArgs);
-            $response = $this->createSymfonyResponse($results, $shouldFilterOptions);
+            $results  = $this->capabilitiesService->getCapabilities($body, $shouldFilter);
+            $response = $this->createSymfonyResponse($results);
         } catch (Throwable $e) {
             $response = $this->createErrorResponse($e);
         }
 
         return $corsHandler->addCorsHeaders($request, $response);
-    }
-
-    /**
-     * Pull the action's control parameter ($filterOptions) out of the payload. The remaining
-     * payload is passed through unchanged — `CapabilitiesService::getCapabilities` accepts
-     * either API-style camelCase or SDK-input snake_case keys at every nesting level.
-     *
-     * @param  array $payload
-     *
-     * @return array{0: array, 1: bool} [SDK args (control flag stripped), shouldFilterOptions]
-     */
-    private function prepareSdkArgs(array $payload): array
-    {
-        $filterOptions        = $payload['filterOptions'] ?? false;
-        $shouldFilterOptions  = is_bool($filterOptions)
-            ? $filterOptions
-            : filter_var($filterOptions, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false;
-        unset($payload['filterOptions']);
-
-        return [$payload, $shouldFilterOptions];
-    }
-
-    /**
-     * Extract the action's payload. The PDK SDK wraps request bodies as
-     * {"data": {"<property>": <body>}} where <property> matches CapabilitiesEndpointRequest::
-     * getProperty() (i.e. "capabilities"). Older callers may post the body unwrapped — handle
-     * both. Query-string params are merged in for backward compatibility with the original
-     * proxy implementation.
-     */
-    private function getRequestData(Request $request): array
-    {
-        $body = json_decode($request->getContent(), true);
-
-        if (is_array($body)) {
-            $data    = $body['data'] ?? null;
-            $wrapped = is_array($data) ? ($data['capabilities'] ?? null) : null;
-            $bodyData = is_array($wrapped) ? $wrapped : (is_array($data) ? $data : $body);
-        } else {
-            $bodyData = [];
-        }
-
-        $query = $request->query->all();
-        unset($query['action'], $query['pdk_action'], $query['path']);
-
-        return array_replace($bodyData, $query);
     }
 
     /**
@@ -108,34 +62,8 @@ class CapabilitiesAction implements ActionInterface
      */
     private function createSymfonyResponse(array $results, bool $filterOptions = false): Response
     {
-        $body = json_decode(json_encode(['results' => $results]), true);
-
-        if (isset($body['results']) && is_array($body['results'])) {
-            // Drop capabilities for carriers this PDK version does not support so
-            // that a server-side proposition update cannot expose a new carrier
-            // to the checkout widget. @see Carrier::isSupported()
-            $body['results'] = array_values(array_filter(
-                $body['results'],
-                static function ($capability): bool {
-                    return is_array($capability)
-                        && isset($capability['carrier'])
-                        && is_string($capability['carrier'])
-                        && Carrier::isSupported($capability['carrier']);
-                }
-            ));
-
-            if ($filterOptions) {
-                $body['results'] = array_map(static function (array $capability): array {
-                    if (isset($capability['options']) && is_array($capability['options'])) {
-                        $capability['options'] = Carrier::filterRegisteredOptions($capability['options']);
-                    }
-                    return $capability;
-                }, $body['results']);
-            }
-        }
-
         return new Response(
-            json_encode($body),
+            json_encode(['results' => $results]),
             Response::HTTP_OK,
             ['Content-Type' => 'application/json']
         );

--- a/src/App/Order/Calculator/General/CapabilitiesPackageTypeCalculator.php
+++ b/src/App/Order/Calculator/General/CapabilitiesPackageTypeCalculator.php
@@ -119,13 +119,20 @@ final class CapabilitiesPackageTypeCalculator extends AbstractPdkOrderOptionCalc
      * candidate is evaluated against ITS OWN effective weight (raw order weight +
      * the empty-weight setting configured for that type), so capability min/max
      * checks match what the export will actually submit.
+     *
+     * Only iterates types the carrier itself declares support for via its contract
+     * definitions; querying capability data for types the carrier never supports
+     * would be wasted API calls.
      */
     private function fallbackToNextAvailableType(string $cc, Carrier $carrier): void
     {
         $availableByType = [];
+        $v2ToPdkName     = array_flip(DeliveryOptions::PACKAGE_TYPES_V2_MAP);
 
-        foreach (DeliveryOptions::PACKAGE_TYPES_V2_MAP as $pdkName => $v2Name) {
-            if ($this->isInternationalMailboxBlocked($pdkName, $cc, $carrier)) {
+        foreach (($carrier->packageTypes ?? []) as $v2Name) {
+            $pdkName = $v2ToPdkName[$v2Name] ?? null;
+
+            if ($pdkName === null || $this->isInternationalMailboxBlocked($pdkName, $cc, $carrier)) {
                 continue;
             }
 

--- a/src/App/Request/AbstractEndpointRequest.php
+++ b/src/App/Request/AbstractEndpointRequest.php
@@ -24,6 +24,7 @@ abstract class AbstractEndpointRequest extends Request implements Arrayable
             'path'             => $this->getPath(),
             'property'         => $this->getProperty(),
             'responseProperty' => $this->getResponseProperty(),
+            'useDataEnvelope'  => $this->getUseDataEnvelope(),
         ];
     }
 }

--- a/src/App/Request/Capabilities/CapabilitiesEndpointRequest.php
+++ b/src/App/Request/Capabilities/CapabilitiesEndpointRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MyParcelNL\Pdk\App\Request\Capabilities;
 
 use MyParcelNL\Pdk\App\Request\AbstractEndpointRequest;
+use Override;
 
 class CapabilitiesEndpointRequest extends AbstractEndpointRequest
 {
@@ -12,12 +13,8 @@ class CapabilitiesEndpointRequest extends AbstractEndpointRequest
     {
         return 'POST';
     }
-
-    /**
-     * @return string
-     */
-    public function getProperty(): string
+    public function getUseDataEnvelope(): bool
     {
-        return 'capabilities';
+        return false;
     }
 }

--- a/src/App/Request/Capabilities/CapabilitiesEndpointRequest.php
+++ b/src/App/Request/Capabilities/CapabilitiesEndpointRequest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MyParcelNL\Pdk\App\Request\Capabilities;
 
 use MyParcelNL\Pdk\App\Request\AbstractEndpointRequest;
-use Override;
 
 class CapabilitiesEndpointRequest extends AbstractEndpointRequest
 {

--- a/src/Carrier/Model/Carrier.php
+++ b/src/Carrier/Model/Carrier.php
@@ -205,53 +205,16 @@ class Carrier extends SdkBackedModel
     private static $registeredCapabilitiesKeys;
 
     /**
-     * The capabilities API may return options that don't have a corresponding OrderOptionDefinition
-     * in the PDK yet. Without filtering, the frontend would render UI for these unimplemented options,
-     * but the PDK wouldn't know how to calculate, store, or export them — leading to broken behavior.
+     * Allowlist of camelCase option keys that have a registered OrderOptionDefinition in this PDK.
      *
-     * This override ensures only options backed by a registered definition are included in the
-     * serialized output, making the definitions the single gatekeeper for which options are available.
-     *
-     * @param  null|int $flags
-     *
-     * @return array
-     */
-    public function attributesToArray(?int $flags = null): array
-    {
-        $result = parent::attributesToArray($flags);
-
-        if (! isset($result['options']) || ! is_array($result['options'])) {
-            return $result;
-        }
-
-        $result['options'] = self::filterRegisteredOptions($result['options']);
-
-        return $result;
-    }
-
-    /**
-     * Single source of truth for the option allowlist applied across both serialization paths
-     * — this method (used by Carrier::attributesToArray on contract-definition data) and
-     * CapabilitiesAction (on contextual capabilities responses). Keeping the filter in one
-     * place prevents drift between initial render and drill-down responses.
-     *
-     * @param  array<string, mixed> $options camelCase option keys → option metadata
-     *
-     * @return array<string, mixed>
-     */
-    public static function filterRegisteredOptions(array $options): array
-    {
-        return array_intersect_key($options, self::getRegisteredCapabilitiesKeys());
-    }
-
-    /**
-     * Build and cache the allowlist of capabilities keys that have a registered definition.
-     * Cached as a static property because definitions don't change at runtime, and this method
-     * is called on every Carrier serialization (potentially many times per request).
+     * Capabilities responses may carry options the PDK has no calculator/UI label for; those
+     * are stripped at the SDK boundary so they never reach the admin or checkout. Keys are
+     * camelCase to match the SDK options model's attributeMap. Cached because definitions
+     * don't change at runtime.
      *
      * @return array<string, true>
      */
-    private static function getRegisteredCapabilitiesKeys(): array
+    public static function getRegisteredCapabilitiesKeys(): array
     {
         if (self::$registeredCapabilitiesKeys === null) {
             /** @var OrderOptionDefinitionInterface[] $definitions */

--- a/src/Carrier/Repository/CarrierCapabilitiesRepository.php
+++ b/src/Carrier/Repository/CarrierCapabilitiesRepository.php
@@ -42,7 +42,7 @@ class CarrierCapabilitiesRepository extends Repository
         $cacheKey = "contractDefinitions.$carrier";
 
         return $this->retrieve($cacheKey, function () use ($carrier) {
-            $contractDefinitions = $this->apiService->getContractDefinitions($carrier);
+            $contractDefinitions = $this->apiService->getContractDefinitions($carrier, true);
             // Convert contract definitions to an array so they can be cast into Carrier models
             // The SDK models serialize to nested stdClass objects, not associative arrays.
             // We need arrays for the PDK Model casting, so we roundtrip through JSON to deeply convert them.

--- a/src/SdkApi/Service/CoreApi/Shipment/CapabilitiesService.php
+++ b/src/SdkApi/Service/CoreApi/Shipment/CapabilitiesService.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment;
 
 use GuzzleHttp\HandlerStack;
+use MyParcelNL\Pdk\Carrier\Model\Carrier;
+use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesPostCapabilitiesRequestV2;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesPostContractDefinitionsRequestV2;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesResponsesCapabilitiesV2;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ModelInterface;
-use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesResponseCapabilityV2;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesResponseCapabilityV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesResponseOptionsOptionsV2;
+use MyParcelNL\Sdk\Support\Str;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -96,19 +101,101 @@ class CapabilitiesService extends AbstractShipmentApiService
      *                          - direction: string (optional) - Direction (outbound, inbound)
      *                          - pickup: array (optional) - Pickup location details
      *
+     * @param bool $filterSupported Whether to filter out carriers, delivery types, package types and options that are not supported by this PDK version.
+     * Defaults to return capabilities unfiltered.
+     *
      * @return RefCapabilitiesResponseCapabilityV2[] The capabilities response with available options
      * @throws \MyParcelNL\Sdk\Client\Generated\CoreApi\ApiException On API errors
      * @throws \InvalidArgumentException If required parameters are missing
      */
-    public function getCapabilities(array $parameters): array
+    public function getCapabilities(array $parameters, bool $filterSupported = false): array
     {
         /** @var CapabilitiesPostCapabilitiesRequestV2 $request */
         $request = $this->hydrateModel(CapabilitiesPostCapabilitiesRequestV2::class, $parameters);
 
         /** @var CapabilitiesResponsesCapabilitiesV2 $response */
         $response = $this->shipmentApi->postCapabilities($this->getUserAgent(), $request);
+        $results  = $response->getResults();
 
-        return $response->getResults();
+        return $filterSupported ? $this->filterSupportedCapabilities($results) : $results;
+    }
+
+    /**
+     * Drop carriers and capabilities this PDK version does not recognise, and narrow each surviving model's
+     * delivery types, package types and options to the PDK-supported subset.
+     *
+     * Mutates the passed-in SDK models in place. The two response models share an identical
+     * carrier/deliveryTypes/packageTypes/options surface area, so a union typehint avoids
+     * the generated-model template gymnastics phpstan would otherwise need.
+     *
+     * @param  array<int, RefCapabilitiesResponseCapabilityV2|RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2> $models
+     *
+     * @return array<int, RefCapabilitiesResponseCapabilityV2|RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2>
+     */
+    private function filterSupportedCapabilities(array $models): array
+    {
+        $supported = [];
+
+        foreach ($models as $model) {
+            /** @var string $carrierName */
+            $carrierName = $model->getCarrier();
+            if (! Carrier::isSupported($carrierName)) {
+                continue;
+            }
+
+            $model->setDeliveryTypes(array_values(array_filter(
+                // @phpstan-ignore nullCoalesce.expr (attribute can be null if model is manually constructed with missing fields, but API responses always include it as an array)
+                $model->getDeliveryTypes() ?? [],
+                // @phpstan-ignore argument.type (SDK enum values come back as plain strings)
+                static function (string $type): bool {
+                    return DeliveryOptions::isDeliveryTypeSupported($type);
+                }
+            )));
+
+            $model->setPackageTypes(array_values(array_filter(
+                // @phpstan-ignore nullCoalesce.expr (attribute can be null if model is manually constructed with missing fields, but API responses always include it as an array)
+                $model->getPackageTypes() ?? [],
+                // @phpstan-ignore argument.type (SDK enum values come back as plain strings)
+                static function (string $type): bool {
+                    return DeliveryOptions::isPackageTypeSupported($type);
+                }
+            )));
+
+            $options = $model->getOptions();
+            if ($options !== null) {
+                $model->setOptions($this->stripUnregisteredOptions($options));
+            }
+
+            $supported[] = $model;
+        }
+
+        return $supported;
+    }
+
+    /**
+     * Remove options whose camelCase key has no registered OrderOptionDefinition in this PDK.
+     *
+     * Uses {@see \ArrayAccess::offsetUnset()} on the SDK options model rather than the typed
+     * setters: many setters throw on null for non-nullable fields, but offsetUnset cleanly
+     * removes the property from the underlying container so the serializer skips it.
+     *
+     * @param RefCapabilitiesResponseOptionsOptionsV2|RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2 $options
+     * @return RefCapabilitiesResponseOptionsOptionsV2|RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2
+     */
+    private function stripUnregisteredOptions($options): object
+    {
+        $allowed      = Carrier::getRegisteredCapabilitiesKeys();
+
+        foreach ((array) $options->jsonSerialize() as $name => $option) {
+            if (! isset($allowed[$name])) {
+                // Convert name back to snake_case for the offset, as the SDK models store properties in snake_case but expose them as camelCase via attributeMap-driven getters/setters and jsonSerialize.
+                $snakeName = Str::snake($name);
+                // @phpstan-ignore unset.offset
+                unset($options[$snakeName]);
+            }
+        }
+
+        return $options;
     }
 
     /**
@@ -134,7 +221,8 @@ class CapabilitiesService extends AbstractShipmentApiService
             $property    = $camelToSnake[$key] ?? $key;
             $nestedClass = ltrim((string) ($openAPITypes[$property] ?? ''), '\\');
 
-            if (is_array($value)
+            if (
+                is_array($value)
                 && class_exists($nestedClass)
                 && is_subclass_of($nestedClass, ModelInterface::class)
             ) {
@@ -156,11 +244,13 @@ class CapabilitiesService extends AbstractShipmentApiService
      *
      * @param string|null $carrier The carrier identifier (e.g., 'POSTNL', 'DPD', 'DHL_FOR_YOU') to get a
      *                             specific carrier's contract definitions, or null to retrieve all.
+     * @param bool $filterSupported Whether to drop carriers, delivery types, package types and options
+     *                              that are not supported by this PDK version. Defaults to false.
      *
      * @return RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2[] An array of contract definitions per carrier.
      * @throws \MyParcelNL\Sdk\Client\Generated\CoreApi\ApiException On API errors
      */
-    public function getContractDefinitions(?string $carrier): array
+    public function getContractDefinitions(?string $carrier, bool $filterSupported = false): array
     {
         // Set carrier explicitly as it otherwise does not validate via the constructor.
         $request = new CapabilitiesPostContractDefinitionsRequestV2();
@@ -172,7 +262,8 @@ class CapabilitiesService extends AbstractShipmentApiService
             $this->getUserAgent(),
             $request
         );
+        $items = $response->getItems();
 
-        return $response->getItems();
+        return $filterSupported ? $this->filterSupportedCapabilities($items) : $items;
     }
 }

--- a/src/SdkApi/Service/CoreApi/Shipment/CapabilitiesService.php
+++ b/src/SdkApi/Service/CoreApi/Shipment/CapabilitiesService.php
@@ -190,8 +190,9 @@ class CapabilitiesService extends AbstractShipmentApiService
             if (! isset($allowed[$name])) {
                 // Convert name back to snake_case for the offset, as the SDK models store properties in snake_case but expose them as camelCase via attributeMap-driven getters/setters and jsonSerialize.
                 $snakeName = Str::snake($name);
-                // @phpstan-ignore unset.offset
-                unset($options[$snakeName]);
+                // Set the properties to null, this is how the SDK models handles properties that would be omitted from the incoming request body.
+                // @phpstan-ignore argument.type
+                $options->offsetSet($snakeName, null);
             }
         }
 

--- a/src/Shipment/Model/DeliveryOptions.php
+++ b/src/Shipment/Model/DeliveryOptions.php
@@ -48,16 +48,20 @@ class DeliveryOptions extends Model
     /**
      * Values
      */
-    public const DELIVERY_TYPE_MORNING_ID    = RefTypesDeliveryType::MORNING;
-    public const DELIVERY_TYPE_MORNING_NAME  = 'morning';
-    public const DELIVERY_TYPE_EVENING_ID    = RefTypesDeliveryType::EVENING;
-    public const DELIVERY_TYPE_EVENING_NAME  = 'evening';
-    public const DELIVERY_TYPE_STANDARD_ID   = RefTypesDeliveryType::STANDARD;
-    public const DELIVERY_TYPE_STANDARD_NAME = 'standard';
-    public const DELIVERY_TYPE_PICKUP_ID     = RefTypesDeliveryType::PICKUP;
-    public const DELIVERY_TYPE_PICKUP_NAME   = 'pickup';
-    public const DELIVERY_TYPE_EXPRESS_ID    = RefTypesDeliveryType::EXPRESS;
-    public const DELIVERY_TYPE_EXPRESS_NAME  = 'express';
+    public const DELIVERY_TYPE_MORNING_ID         = RefTypesDeliveryType::MORNING;
+    public const DELIVERY_TYPE_MORNING_NAME       = 'morning';
+    public const DELIVERY_TYPE_EVENING_ID         = RefTypesDeliveryType::EVENING;
+    public const DELIVERY_TYPE_EVENING_NAME       = 'evening';
+    public const DELIVERY_TYPE_STANDARD_ID        = RefTypesDeliveryType::STANDARD;
+    public const DELIVERY_TYPE_STANDARD_NAME      = 'standard';
+    public const DELIVERY_TYPE_PICKUP_ID          = RefTypesDeliveryType::PICKUP;
+    public const DELIVERY_TYPE_PICKUP_NAME        = 'pickup';
+    public const DELIVERY_TYPE_EXPRESS_ID         = RefTypesDeliveryType::EXPRESS;
+    public const DELIVERY_TYPE_EXPRESS_NAME       = 'express';
+    public const DELIVERY_TYPE_SAME_DAY_ID        = RefTypesDeliveryType::SAME_DAY;
+    public const DELIVERY_TYPE_SAME_DAY_NAME      = 'same_day';
+    public const DELIVERY_TYPE_EARLY_MORNING_ID   = RefTypesDeliveryType::EARLY_MORNING;
+    public const DELIVERY_TYPE_EARLY_MORNING_NAME = 'early_morning';
     /**
      * @var int[]
      */
@@ -67,6 +71,8 @@ class DeliveryOptions extends Model
         self::DELIVERY_TYPE_EVENING_ID,
         self::DELIVERY_TYPE_PICKUP_ID,
         self::DELIVERY_TYPE_EXPRESS_ID,
+        self::DELIVERY_TYPE_SAME_DAY_ID,
+        self::DELIVERY_TYPE_EARLY_MORNING_ID,
     ];
     /**
      * @var string[]
@@ -77,24 +83,30 @@ class DeliveryOptions extends Model
         self::DELIVERY_TYPE_EVENING_NAME,
         self::DELIVERY_TYPE_PICKUP_NAME,
         self::DELIVERY_TYPE_EXPRESS_NAME,
+        self::DELIVERY_TYPE_SAME_DAY_NAME,
+        self::DELIVERY_TYPE_EARLY_MORNING_NAME,
     ];
     /**
      * @var array
      */
     public const DELIVERY_TYPES_NAMES_IDS_MAP = [
-        self::DELIVERY_TYPE_MORNING_NAME  => self::DELIVERY_TYPE_MORNING_ID,
-        self::DELIVERY_TYPE_STANDARD_NAME => self::DELIVERY_TYPE_STANDARD_ID,
-        self::DELIVERY_TYPE_EVENING_NAME  => self::DELIVERY_TYPE_EVENING_ID,
-        self::DELIVERY_TYPE_PICKUP_NAME   => self::DELIVERY_TYPE_PICKUP_ID,
-        self::DELIVERY_TYPE_EXPRESS_NAME  => self::DELIVERY_TYPE_EXPRESS_ID,
+        self::DELIVERY_TYPE_MORNING_NAME       => self::DELIVERY_TYPE_MORNING_ID,
+        self::DELIVERY_TYPE_STANDARD_NAME      => self::DELIVERY_TYPE_STANDARD_ID,
+        self::DELIVERY_TYPE_EVENING_NAME       => self::DELIVERY_TYPE_EVENING_ID,
+        self::DELIVERY_TYPE_PICKUP_NAME        => self::DELIVERY_TYPE_PICKUP_ID,
+        self::DELIVERY_TYPE_EXPRESS_NAME       => self::DELIVERY_TYPE_EXPRESS_ID,
+        self::DELIVERY_TYPE_SAME_DAY_NAME      => self::DELIVERY_TYPE_SAME_DAY_ID,
+        self::DELIVERY_TYPE_EARLY_MORNING_NAME => self::DELIVERY_TYPE_EARLY_MORNING_ID,
     ];
 
     public const DELIVERY_TYPES_V2_MAP = [
-        self::DELIVERY_TYPE_MORNING_NAME  => RefTypesDeliveryTypeV2::MORNING,
-        self::DELIVERY_TYPE_STANDARD_NAME => RefTypesDeliveryTypeV2::STANDARD,
-        self::DELIVERY_TYPE_EVENING_NAME  => RefTypesDeliveryTypeV2::EVENING,
-        self::DELIVERY_TYPE_PICKUP_NAME   => RefTypesDeliveryTypeV2::PICKUP,
-        self::DELIVERY_TYPE_EXPRESS_NAME  => RefTypesDeliveryTypeV2::EXPRESS,
+        self::DELIVERY_TYPE_MORNING_NAME       => RefTypesDeliveryTypeV2::MORNING,
+        self::DELIVERY_TYPE_STANDARD_NAME      => RefTypesDeliveryTypeV2::STANDARD,
+        self::DELIVERY_TYPE_EVENING_NAME       => RefTypesDeliveryTypeV2::EVENING,
+        self::DELIVERY_TYPE_PICKUP_NAME        => RefTypesDeliveryTypeV2::PICKUP,
+        self::DELIVERY_TYPE_EXPRESS_NAME       => RefTypesDeliveryTypeV2::EXPRESS,
+        self::DELIVERY_TYPE_SAME_DAY_NAME      => RefTypesDeliveryTypeV2::SAME_DAY,
+        self::DELIVERY_TYPE_EARLY_MORNING_NAME => RefTypesDeliveryTypeV2::EARLY_MORNING,
     ];
 
     public const DEFAULT_DELIVERY_TYPE_ID     = self::DELIVERY_TYPE_STANDARD_ID;
@@ -108,11 +120,15 @@ class DeliveryOptions extends Model
     public const  PACKAGE_TYPE_LETTER_ID          = RefShipmentPackageType::UNFRANKED;
     public const  PACKAGE_TYPE_DIGITAL_STAMP_ID   = RefShipmentPackageType::DIGITAL_STAMP;
     public const  PACKAGE_TYPE_PACKAGE_SMALL_ID   = RefShipmentPackageType::SMALL_PACKAGE;
+    public const  PACKAGE_TYPE_PALLET_ID          = RefShipmentPackageType::PALLET;
+    public const  PACKAGE_TYPE_ENVELOPE_ID        = RefShipmentPackageType::ENVELOPE;
     public const  PACKAGE_TYPE_PACKAGE_NAME       = 'package';
     public const  PACKAGE_TYPE_MAILBOX_NAME       = 'mailbox';
     public const  PACKAGE_TYPE_LETTER_NAME        = 'letter';
     public const  PACKAGE_TYPE_DIGITAL_STAMP_NAME = 'digital_stamp';
     public const  PACKAGE_TYPE_PACKAGE_SMALL_NAME = 'package_small';
+    public const  PACKAGE_TYPE_PALLET_NAME        = 'pallet';
+    public const  PACKAGE_TYPE_ENVELOPE_NAME      = 'envelope';
 
     public const PACKAGE_TYPES_IDS = [
         self::PACKAGE_TYPE_PACKAGE_ID,
@@ -120,6 +136,8 @@ class DeliveryOptions extends Model
         self::PACKAGE_TYPE_LETTER_ID,
         self::PACKAGE_TYPE_DIGITAL_STAMP_ID,
         self::PACKAGE_TYPE_PACKAGE_SMALL_ID,
+        self::PACKAGE_TYPE_PALLET_ID,
+        self::PACKAGE_TYPE_ENVELOPE_ID,
     ];
     public const PACKAGE_TYPES_NAMES = [
         self::PACKAGE_TYPE_PACKAGE_NAME,
@@ -127,6 +145,8 @@ class DeliveryOptions extends Model
         self::PACKAGE_TYPE_LETTER_NAME,
         self::PACKAGE_TYPE_DIGITAL_STAMP_NAME,
         self::PACKAGE_TYPE_PACKAGE_SMALL_NAME,
+        self::PACKAGE_TYPE_PALLET_NAME,
+        self::PACKAGE_TYPE_ENVELOPE_NAME,
     ];
 
     public const PACKAGE_TYPES_NAMES_IDS_MAP     = [
@@ -135,6 +155,8 @@ class DeliveryOptions extends Model
         self::PACKAGE_TYPE_LETTER_NAME        => self::PACKAGE_TYPE_LETTER_ID,
         self::PACKAGE_TYPE_DIGITAL_STAMP_NAME => self::PACKAGE_TYPE_DIGITAL_STAMP_ID,
         self::PACKAGE_TYPE_PACKAGE_SMALL_NAME => self::PACKAGE_TYPE_PACKAGE_SMALL_ID,
+        self::PACKAGE_TYPE_PALLET_NAME        => self::PACKAGE_TYPE_PALLET_ID,
+        self::PACKAGE_TYPE_ENVELOPE_NAME      => self::PACKAGE_TYPE_ENVELOPE_ID,
     ];
 
     public const PACKAGE_TYPES_V2_MAP = [
@@ -142,8 +164,35 @@ class DeliveryOptions extends Model
         self::PACKAGE_TYPE_MAILBOX_NAME       => RefShipmentPackageTypeV2::MAILBOX,
         self::PACKAGE_TYPE_LETTER_NAME        => RefShipmentPackageTypeV2::UNFRANKED,
         self::PACKAGE_TYPE_DIGITAL_STAMP_NAME => RefShipmentPackageTypeV2::DIGITAL_STAMP,
-        self::PACKAGE_TYPE_PACKAGE_SMALL_NAME => RefShipmentPackageTypeV2::SMALL_PACKAGE
+        self::PACKAGE_TYPE_PACKAGE_SMALL_NAME => RefShipmentPackageTypeV2::SMALL_PACKAGE,
+        self::PACKAGE_TYPE_PALLET_NAME        => RefShipmentPackageTypeV2::PALLET,
+        self::PACKAGE_TYPE_ENVELOPE_NAME      => RefShipmentPackageTypeV2::ENVELOPE,
     ];
+
+    /**
+     * Whether a V2 delivery type is supported by this PDK version.
+     *
+     * Backed by {@see self::DELIVERY_TYPES_V2_MAP} — a value is "supported"
+     * when the PDK has a mapped legacy name (and therefore calculators and
+     * UI labels) for it. Used at the boundary (capabilities proxy, carrier
+     * serialization) so SDK enum values the PDK doesn't know about cannot
+     * reach the admin or checkout.
+     */
+    public static function isDeliveryTypeSupported(string $v2DeliveryType): bool
+    {
+        return in_array($v2DeliveryType, self::DELIVERY_TYPES_V2_MAP, true);
+    }
+
+    /**
+     * Whether a V2 package type is supported by this PDK version.
+     *
+     * Backed by {@see self::PACKAGE_TYPES_V2_MAP}; see
+     * {@see self::isDeliveryTypeSupported()} for the rationale.
+     */
+    public static function isPackageTypeSupported(string $v2PackageType): bool
+    {
+        return in_array($v2PackageType, self::PACKAGE_TYPES_V2_MAP, true);
+    }
 
     public const  DEFAULT_PACKAGE_TYPE_ID         = self::PACKAGE_TYPE_PACKAGE_ID;
     public const  DEFAULT_PACKAGE_TYPE_NAME       = self::PACKAGE_TYPE_PACKAGE_NAME;

--- a/tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php
+++ b/tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php
@@ -145,18 +145,15 @@ it('saves carrier capabilities as account->shop->carriers correctly', function (
     expect($options->getRecipientOnlyDelivery()->getIsSelectedByDefault())->toBeFalse();
     expect($options->getRecipientOnlyDelivery()->getIsRequired())->toBeFalse();
 
-    expect($options->getPrintReturnLabelAtDropOff()->getIsSelectedByDefault())->toBeFalse();
-    expect($options->getPrintReturnLabelAtDropOff()->getIsRequired())->toBeFalse();
-
     expect($options->getPriorityDelivery()->getIsSelectedByDefault())->toBeFalse();
     expect($options->getPriorityDelivery()->getIsRequired())->toBeFalse();
 
     expect($options->getReturnOnFirstFailedDelivery()->getIsSelectedByDefault())->toBeFalse();
     expect($options->getReturnOnFirstFailedDelivery()->getIsRequired())->toBeFalse();
 
-    expect($options->getNoTracking()->getIsSelectedByDefault())->toBeFalse();
-    expect($options->getNoTracking()->getIsRequired())->toBeFalse();
-
+    // printReturnLabelAtDropOff and noTracking have no registered OrderOptionDefinition,
+    // so the service strips them when CarrierCapabilitiesRepository asks for the
+    // PDK-supported subset. @see CapabilitiesService::filterSupportedCapabilities()
     // @TODO: tracked is currently dropped during SDK deserialization because it is missing from the attributeMap
     // of RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2 — fix the SDK model and this assertion should pass
     expect($options->getTracked()->getIsSelectedByDefault())->toBeFalse();

--- a/tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php
+++ b/tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php
@@ -151,11 +151,6 @@ it('saves carrier capabilities as account->shop->carriers correctly', function (
     expect($options->getReturnOnFirstFailedDelivery()->getIsSelectedByDefault())->toBeFalse();
     expect($options->getReturnOnFirstFailedDelivery()->getIsRequired())->toBeFalse();
 
-    // printReturnLabelAtDropOff and noTracking have no registered OrderOptionDefinition,
-    // so the service strips them when CarrierCapabilitiesRepository asks for the
-    // PDK-supported subset. @see CapabilitiesService::filterSupportedCapabilities()
-    // @TODO: tracked is currently dropped during SDK deserialization because it is missing from the attributeMap
-    // of RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2 — fix the SDK model and this assertion should pass
     expect($options->getTracked()->getIsSelectedByDefault())->toBeFalse();
     expect($options->getTracked()->getIsRequired())->toBeFalse();
 

--- a/tests/Unit/App/Action/Capabilities/CapabilitiesActionTest.php
+++ b/tests/Unit/App/Action/Capabilities/CapabilitiesActionTest.php
@@ -25,7 +25,7 @@ beforeEach(function () {
 it('handles OPTIONS preflight request', function () {
     $request = Request::create('/', 'OPTIONS');
 
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\Api\Handler\CorsHandler $mockCorsHandler */
+    /** @var \Mockery\MockInterface&CorsHandler $mockCorsHandler */
     $mockCorsHandler = Mockery::mock(CorsHandler::class);
     $mockCorsHandler->shouldReceive('handlePreflightRequest')
         ->with($request)
@@ -33,7 +33,7 @@ it('handles OPTIONS preflight request', function () {
 
     mockPdkProperty(CorsHandler::class, $mockCorsHandler);
 
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService $mockService */
+    /** @var \Mockery\MockInterface&CapabilitiesService $mockService */
     $mockService = Mockery::mock(CapabilitiesService::class);
     $mockService->shouldNotReceive('getCapabilities');
 
@@ -43,136 +43,7 @@ it('handles OPTIONS preflight request', function () {
     expect($response->getStatusCode())->toBe(204);
 });
 
-it('passes payload to capabilities service and returns results', function () {
-    $request = Request::create(
-        '/?action=proxyCapabilities',
-        'POST',
-        [],
-        [],
-        [],
-        ['CONTENT_TYPE' => 'application/json'],
-        '{"carrier":"postnl","country":"NL","package_type":"package"}'
-    );
-
-    $expectedPayload = ['carrier' => 'postnl', 'country' => 'NL', 'package_type' => 'package'];
-    $fakeResults     = [['carrier' => 'postnl', 'package_types' => ['package']]];
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService $mockService */
-    $mockService = Mockery::mock(CapabilitiesService::class);
-    $mockService->shouldReceive('getCapabilities')
-        ->once()
-        ->with($expectedPayload)
-        ->andReturn($fakeResults);
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\Api\Handler\CorsHandler $mockCorsHandler */
-    $mockCorsHandler = Mockery::mock(CorsHandler::class);
-    $mockCorsHandler->shouldReceive('addCorsHeaders')
-        ->once()
-        ->andReturnUsing(static fn($_request, $response) => $response);
-
-    mockPdkProperty(CorsHandler::class, $mockCorsHandler);
-
-    $action   = new CapabilitiesAction($mockService);
-    $response = $action->handle($request);
-
-    expect($response->getStatusCode())->toBe(200)
-        ->and(json_decode($response->getContent(), true))->toHaveKey('results');
-});
-
-it('passes options through unchanged by default (no filterOptions flag)', function () {
-    $request = Request::create(
-        '/',
-        'POST',
-        [],
-        [],
-        [],
-        ['CONTENT_TYPE' => 'application/json'],
-        '{"cc":"NL"}'
-    );
-
-    $fakeResults = [
-        [
-            'carrier' => 'POSTNL',
-            'options' => [
-                'requiresSignature' => ['available' => true],
-                'bogusOption'       => ['available' => true],
-            ],
-        ],
-    ];
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService $mockService */
-    $mockService = Mockery::mock(CapabilitiesService::class);
-    $mockService->shouldReceive('getCapabilities')
-        ->once()
-        ->with(['cc' => 'NL'])
-        ->andReturn($fakeResults);
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\Api\Handler\CorsHandler $mockCorsHandler */
-    $mockCorsHandler = Mockery::mock(CorsHandler::class);
-    $mockCorsHandler->shouldReceive('addCorsHeaders')
-        ->once()
-        ->andReturnUsing(static fn($_request, $response) => $response);
-
-    mockPdkProperty(CorsHandler::class, $mockCorsHandler);
-
-    $action   = new CapabilitiesAction($mockService);
-    $response = $action->handle($request);
-    $payload  = json_decode($response->getContent(), true);
-
-    expect($response->getStatusCode())->toBe(200)
-        ->and($payload['results'][0]['options'])->toHaveKeys(['requiresSignature', 'bogusOption']);
-});
-
-it('filters options to registered keys when filterOptions=true is in the body', function () {
-    $request = Request::create(
-        '/',
-        'POST',
-        [],
-        [],
-        [],
-        ['CONTENT_TYPE' => 'application/json'],
-        '{"cc":"NL","filterOptions":true}'
-    );
-
-    $fakeResults = [
-        [
-            'carrier' => 'POSTNL',
-            'options' => [
-                'requiresSignature' => ['available' => true],
-                'bogusOption'       => ['available' => true],
-            ],
-        ],
-    ];
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService $mockService */
-    $mockService = Mockery::mock(CapabilitiesService::class);
-    $mockService->shouldReceive('getCapabilities')
-        ->once()
-        ->andReturn($fakeResults);
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\Api\Handler\CorsHandler $mockCorsHandler */
-    $mockCorsHandler = Mockery::mock(CorsHandler::class);
-    $mockCorsHandler->shouldReceive('addCorsHeaders')
-        ->once()
-        ->andReturnUsing(static fn($_request, $response) => $response);
-
-    mockPdkProperty(CorsHandler::class, $mockCorsHandler);
-
-    $action   = new CapabilitiesAction($mockService);
-    $response = $action->handle($request);
-    $payload  = json_decode($response->getContent(), true);
-
-    expect($response->getStatusCode())->toBe(200)
-        ->and($payload['results'][0]['options'])->toHaveKey('requiresSignature')
-        ->and($payload['results'][0]['options'])->not->toHaveKey('bogusOption');
-
-    foreach (array_keys($payload['results'][0]['options']) as $optionKey) {
-        expect(\MyParcelNL\Pdk\Carrier\Model\Carrier::filterRegisteredOptions([$optionKey => []]))
-            ->toHaveKey($optionKey);
-    }
-});
-
-it('passes the payload through to the service unchanged (key conversion happens in the service)', function () {
+it('passes the JSON request body verbatim to the service and wraps the result under "results"', function () {
     $bodyShape = [
         'recipient'          => ['countryCode' => 'NL'],
         'physicalProperties' => ['weight' => ['value' => 2000, 'unit' => 'g']],
@@ -190,14 +61,14 @@ it('passes the payload through to the service unchanged (key conversion happens 
         json_encode($bodyShape)
     );
 
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService $mockService */
+    /** @var \Mockery\MockInterface&CapabilitiesService $mockService */
     $mockService = Mockery::mock(CapabilitiesService::class);
     $mockService->shouldReceive('getCapabilities')
         ->once()
-        ->with($bodyShape)
-        ->andReturn([]);
+        ->with($bodyShape, false)
+        ->andReturn(['stub-result']);
 
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\Api\Handler\CorsHandler $mockCorsHandler */
+    /** @var \Mockery\MockInterface&CorsHandler $mockCorsHandler */
     $mockCorsHandler = Mockery::mock(CorsHandler::class);
     $mockCorsHandler->shouldReceive('addCorsHeaders')
         ->once()
@@ -207,94 +78,14 @@ it('passes the payload through to the service unchanged (key conversion happens 
 
     $action   = new CapabilitiesAction($mockService);
     $response = $action->handle($request);
-
-    expect($response->getStatusCode())->toBe(200);
-});
-
-it('reads filterOptions from the query string (kept out of the body so it does not pollute the API payload)', function () {
-    $request = Request::create(
-        '/?filterOptions=true',
-        'POST',
-        [],
-        [],
-        [],
-        ['CONTENT_TYPE' => 'application/json'],
-        '{"recipient":{"countryCode":"NL"}}'
-    );
-
-    $fakeResults = [
-        [
-            'carrier' => 'POSTNL',
-            'options' => [
-                'requiresSignature' => ['available' => true],
-                'bogusOption'       => ['available' => true],
-            ],
-        ],
-    ];
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService $mockService */
-    $mockService = Mockery::mock(CapabilitiesService::class);
-    $mockService->shouldReceive('getCapabilities')
-        ->once()
-        ->withArgs(function (array $payload) {
-            return ! array_key_exists('filterOptions', $payload);
-        })
-        ->andReturn($fakeResults);
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\Api\Handler\CorsHandler $mockCorsHandler */
-    $mockCorsHandler = Mockery::mock(CorsHandler::class);
-    $mockCorsHandler->shouldReceive('addCorsHeaders')
-        ->once()
-        ->andReturnUsing(static fn($_request, $response) => $response);
-
-    mockPdkProperty(CorsHandler::class, $mockCorsHandler);
-
-    $action   = new CapabilitiesAction($mockService);
-    $response = $action->handle($request);
-    $payload  = json_decode($response->getContent(), true);
 
     expect($response->getStatusCode())->toBe(200)
-        ->and($payload['results'][0]['options'])->toHaveKey('requiresSignature')
-        ->and($payload['results'][0]['options'])->not->toHaveKey('bogusOption');
+        ->and(json_decode($response->getContent(), true))->toEqual(['results' => ['stub-result']]);
 });
 
-it('does not forward filterOptions to the SDK args (control flag must be stripped before calling getCapabilities)', function () {
+it('forwards filterSupported=true from the query string to the service', function () {
     $request = Request::create(
-        '/',
-        'POST',
-        [],
-        [],
-        [],
-        ['CONTENT_TYPE' => 'application/json'],
-        '{"cc":"NL","filterOptions":true}'
-    );
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService $mockService */
-    $mockService = Mockery::mock(CapabilitiesService::class);
-    $mockService->shouldReceive('getCapabilities')
-        ->once()
-        ->withArgs(function (array $payload) {
-            return ! array_key_exists('filterOptions', $payload);
-        })
-        ->andReturn([]);
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\Api\Handler\CorsHandler $mockCorsHandler */
-    $mockCorsHandler = Mockery::mock(CorsHandler::class);
-    $mockCorsHandler->shouldReceive('addCorsHeaders')
-        ->once()
-        ->andReturnUsing(static fn($_request, $response) => $response);
-
-    mockPdkProperty(CorsHandler::class, $mockCorsHandler);
-
-    $action   = new CapabilitiesAction($mockService);
-    $response = $action->handle($request);
-
-    expect($response->getStatusCode())->toBe(200);
-});
-
-it('drops capabilities for carriers this PDK version does not support', function () {
-    $request = Request::create(
-        '/',
+        '/?filterSupported=true',
         'POST',
         [],
         [],
@@ -303,17 +94,14 @@ it('drops capabilities for carriers this PDK version does not support', function
         '{"cc":"NL"}'
     );
 
-    $fakeResults = [
-        ['carrier' => 'POSTNL', 'package_types' => ['PACKAGE']],
-        ['carrier' => 'UNSUPPORTED_FUTURE_CARRIER', 'package_types' => ['PACKAGE']],
-        ['carrier' => 'DHL_FOR_YOU', 'package_types' => ['PACKAGE']],
-    ];
-
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService $mockService */
+    /** @var \Mockery\MockInterface&CapabilitiesService $mockService */
     $mockService = Mockery::mock(CapabilitiesService::class);
-    $mockService->shouldReceive('getCapabilities')->once()->andReturn($fakeResults);
+    $mockService->shouldReceive('getCapabilities')
+        ->once()
+        ->with(['cc' => 'NL'], true)
+        ->andReturn([]);
 
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\Api\Handler\CorsHandler $mockCorsHandler */
+    /** @var \Mockery\MockInterface&CorsHandler $mockCorsHandler */
     $mockCorsHandler = Mockery::mock(CorsHandler::class);
     $mockCorsHandler->shouldReceive('addCorsHeaders')
         ->once()
@@ -323,23 +111,20 @@ it('drops capabilities for carriers this PDK version does not support', function
 
     $action   = new CapabilitiesAction($mockService);
     $response = $action->handle($request);
-    $payload  = json_decode($response->getContent(), true);
 
-    expect($response->getStatusCode())->toBe(200)
-        ->and(array_column($payload['results'], 'carrier'))
-        ->toEqual(['POSTNL', 'DHL_FOR_YOU']);
+    expect($response->getStatusCode())->toBe(200);
 });
 
 it('passes through sdk core api error response', function () {
     $request = Request::create('/?foo=bar', 'POST', [], [], [], [], '{"invalid":true}');
 
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\SdkApi\Service\CoreApi\Shipment\CapabilitiesService $mockService */
+    /** @var \Mockery\MockInterface&CapabilitiesService $mockService */
     $mockService = Mockery::mock(CapabilitiesService::class);
     $mockService->shouldReceive('getCapabilities')
         ->once()
         ->andThrow(new CoreApiException('invalid', 422, [], '{"errors":[{"code":"invalid_request"}]}'));
 
-    /** @var \Mockery\MockInterface&\MyParcelNL\Pdk\Api\Handler\CorsHandler $mockCorsHandler */
+    /** @var \Mockery\MockInterface&CorsHandler $mockCorsHandler */
     $mockCorsHandler = Mockery::mock(CorsHandler::class);
     $mockCorsHandler->shouldReceive('addCorsHeaders')
         ->once()

--- a/tests/Unit/App/DeliveryOptions/Service/DeliveryOptionsServiceTest.php
+++ b/tests/Unit/App/DeliveryOptions/Service/DeliveryOptionsServiceTest.php
@@ -34,8 +34,15 @@ uses()->group('checkout');
 usesShared(new UsesMockPdkInstance(), new UsesAccountMock(), new UsesSdkApiMock());
 
 // Enqueue capabilities responses for tests that set a recipient country.
-// The default account setup (UsesAccountMock) creates carriers with ALL package types.
-// getPackageTypeWeights() makes one capabilities call per allowed package type (5 mapped types).
+//
+// getPackageTypeWeights() makes one capabilities call per package type the shipping
+// method allows. The default account (UsesAccountMock) uses CarrierFactory's
+// withAllCapabilities, which declares every SDK V2 package type on the carrier;
+// the shipping method INHERITs those — so allowedPackageTypes ends up equal to
+// PACKAGE_TYPES_V2_MAP in this fixture. We loop over the map to size the queue
+// because the carrier mirrors it; tests using a narrower carrier should size
+// their own queue to that carrier's packageTypes count.
+//
 // Tests without cc won't consume these; UsesSdkApiMock::afterEach() cleans up leftovers.
 beforeEach(function () {
     $responseData = [
@@ -56,8 +63,7 @@ beforeEach(function () {
         ],
     ];
 
-    // Enqueue one response per allowed package type (5 mapped V2 types from carrier contract definitions).
-    for ($i = 0; $i < 5; $i++) {
+    foreach (DeliveryOptions::PACKAGE_TYPES_V2_MAP as $_) {
         MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse($responseData));
     }
 });

--- a/tests/Unit/App/Order/Calculator/CapabilitiesPackageTypeCalculatorTest.php
+++ b/tests/Unit/App/Order/Calculator/CapabilitiesPackageTypeCalculatorTest.php
@@ -118,23 +118,16 @@ it('falls back to next available type when selected type is not in capabilities'
         ->withCarrier($carrier)
         ->store();
 
-    // Repository caches per unique (cc + package_type), so 5 total API calls:
-    // 1. MAILBOX + NL (initial check) → empty
-    // 2. PACKAGE + NL (from getPackageTypeWeights) → carrier present
-    // 3. UNFRANKED + NL → empty
-    // 4. DIGITAL_STAMP + NL → empty
-    // 5. SMALL_PACKAGE + NL → empty
-    // All subsequent lookups are cached.
-
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
-
+    // The repository caches per unique (cc + package_type). The calculator iterates
+    // over the carrier's declared package types only — here ['PACKAGE', 'MAILBOX'] —
+    // so we expect:
+    //   1. MAILBOX + NL (initial check in calculate()) → empty
+    //   2. PACKAGE + NL (first fallback iteration) → carrier present
+    //   - MAILBOX + NL on second fallback iteration is a cache hit, no fresh call.
+    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([])); // MAILBOX
     MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([
         pkgCapabilityResult($carrier, ['PACKAGE'], 1, 23000),
-    ]));
-
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
+    ])); // PACKAGE
 
     $order = factory(PdkOrder::class)
         ->withShippingAddress(factory(ShippingAddress::class)->withCc('NL'))
@@ -215,39 +208,17 @@ it('falls back when international mailbox is blocked by merchant setting', funct
         ->withCarrier($carrier, [CarrierSettings::ALLOW_INTERNATIONAL_MAILBOX => false])
         ->store();
 
-    // The repository caches responses per unique args, so each unique
-    // (cc + package_type) combination only triggers one API call.
-    //
-    // Call sequence:
-    // 1. Initial check: MAILBOX + BE → API call (cached)
-    // 2. getPackageTypeWeights iterates all 5 types:
-    //    - PACKAGE + BE → API call (new)
-    //    - MAILBOX + BE → cached from (1)
-    //    - UNFRANKED + BE → API call (new)
-    //    - DIGITAL_STAMP + BE → API call (new)
-    //    - SMALL_PACKAGE + BE → API call (new)
-    // 3. Carrier availability check: all cached from (1)+(2)
-    //
-    // Total: 5 API calls in order: MAILBOX, PACKAGE, UNFRANKED, DIGITAL_STAMP, SMALL_PACKAGE.
-
-    // 1. MAILBOX — initial check (carrier present but blocked by setting)
+    // The repository caches per (cc + package_type). The fallback iteration walks the
+    // carrier's declared types only — here ['PACKAGE', 'MAILBOX'] — so:
+    //   1. MAILBOX + BE (initial check) → carrier present but blocked by merchant setting
+    //   2. PACKAGE + BE (fallback iteration) → carrier present
+    //   - MAILBOX + BE on second fallback iteration is a cache hit, no fresh call.
     MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([
         pkgCapabilityResult($carrier, ['MAILBOX'], 1, 2000),
-    ]));
-
-    // 2. PACKAGE — from getPackageTypeWeights (carrier present)
+    ])); // MAILBOX
     MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([
         pkgCapabilityResult($carrier, ['PACKAGE'], 1, 23000),
-    ]));
-
-    // 3. UNFRANKED (letter) — empty
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
-
-    // 4. DIGITAL_STAMP — empty
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
-
-    // 5. SMALL_PACKAGE — empty
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
+    ])); // PACKAGE
 
     $order = factory(PdkOrder::class)
         ->withShippingAddress(factory(ShippingAddress::class)->withCc('BE'))
@@ -287,19 +258,11 @@ it('falls back to default when no capabilities match at all', function () {
         ->withCarrier($carrier)
         ->store();
 
-    // Repository caches per unique (cc + package_type), so 5 total API calls:
-    // 1. MAILBOX + NL (initial check) → empty
-    // 2. PACKAGE + NL → empty
-    // 3. UNFRANKED + NL → empty
-    // 4. DIGITAL_STAMP + NL → empty
-    // 5. SMALL_PACKAGE + NL → empty
-    // All subsequent lookups are cached.
-
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
-    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([]));
+    // The fallback iteration walks the carrier's declared types only — here ['PACKAGE'].
+    //   1. MAILBOX + NL (initial check) → empty
+    //   2. PACKAGE + NL (only fallback iteration) → empty
+    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([])); // MAILBOX
+    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([])); // PACKAGE
 
     $order = factory(PdkOrder::class)
         ->withShippingAddress(factory(ShippingAddress::class)->withCc('NL'))

--- a/tests/Unit/Carrier/Model/CarrierTest.php
+++ b/tests/Unit/Carrier/Model/CarrierTest.php
@@ -221,3 +221,4 @@ it('reports support only for carriers known to this PDK version', function () {
         ->and(Carrier::isSupported('UNSUPPORTED_FUTURE_CARRIER'))->toBeFalse()
         ->and(Carrier::isSupported(''))->toBeFalse();
 });
+

--- a/tests/Unit/SdkApi/Service/CoreApi/Shipment/CapabilitiesServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApi/Shipment/CapabilitiesServiceTest.php
@@ -187,6 +187,86 @@ it('getCapabilities rejects incorrect parameter types before making a request', 
     );
 });
 
+// Tests for filterSupported behaviour on getCapabilities()
+it('getCapabilities returns API results unfiltered by default', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $service = new MockableCapabilitiesService();
+    $service->mockHandler->append(new Response(200, [], json_encode([
+        'results' => [
+            [
+                'carrier'       => RefCapabilitiesSharedCarrierV2::POSTNL,
+                'deliveryTypes' => ['STANDARD_DELIVERY', 'SAME_DAY_DELIVERY'],
+                'packageTypes'  => ['PACKAGE', 'PALLET'],
+            ],
+        ],
+    ])));
+
+    $results = $service->getCapabilities([
+        'carrier'      => 'POSTNL',
+        'recipient'    => ['country_code' => 'NL', 'postal_code' => '2132WT'],
+        'package_type' => 'PACKAGE',
+    ]);
+
+    expect($results)->toHaveCount(1)
+        ->and($results[0]->getDeliveryTypes())->toEqual(['STANDARD_DELIVERY', 'SAME_DAY_DELIVERY'])
+        ->and($results[0]->getPackageTypes())->toEqual(['PACKAGE', 'PALLET']);
+});
+
+it('getCapabilities strips unregistered options from each capability when filterSupported is true', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $service = new MockableCapabilitiesService();
+    // `requiresSignature` has a registered OrderOptionDefinition (FEATURE_SIGNATURE);
+    // `customLabelText` does not — should be dropped entirely from the response.
+    $service->mockHandler->append(new Response(200, [], json_encode([
+        'results' => [
+            [
+                'carrier' => RefCapabilitiesSharedCarrierV2::POSTNL,
+                'options' => [
+                    'requiresSignature' => ['default' => false, 'isRequired' => false],
+                    'customLabelText'   => ['default' => null, 'isRequired' => false],
+                ],
+            ],
+        ],
+    ])));
+
+    $results = $service->getCapabilities(
+        [
+            'carrier'      => 'POSTNL',
+            'recipient'    => ['country_code' => 'NL', 'postal_code' => '2132WT'],
+            'package_type' => 'PACKAGE',
+        ],
+        true
+    );
+
+    $serialised = json_decode(json_encode($results[0]), true);
+
+    expect($serialised['options'])->toHaveKey('requiresSignature')
+        ->and($serialised['options'])->not->toHaveKey('customLabelText');
+});
+
+it('getContractDefinitions returns API items unfiltered by default', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $service = new MockableCapabilitiesService();
+    $service->mockHandler->append(new Response(200, [], json_encode([
+        'items' => [
+            [
+                'carrier'       => RefCapabilitiesSharedCarrierV2::POSTNL,
+                'deliveryTypes' => ['STANDARD_DELIVERY', 'SAME_DAY_DELIVERY'],
+                'packageTypes'  => ['PACKAGE', 'PALLET'],
+            ],
+        ],
+    ])));
+
+    $items = $service->getContractDefinitions(null);
+
+    expect($items)->toHaveCount(1)
+        ->and($items[0]->getDeliveryTypes())->toEqual(['STANDARD_DELIVERY', 'SAME_DAY_DELIVERY'])
+        ->and($items[0]->getPackageTypes())->toEqual(['PACKAGE', 'PALLET']);
+});
+
 // Tests for getContractDefinitions()
 it('getContractDefinitions returns array of items from API response', function () {
     TestBootstrapper::hasApiKey('valid-key');

--- a/tests/Unit/Shipment/Model/DeliveryOptionsSupportedTypesTest.php
+++ b/tests/Unit/Shipment/Model/DeliveryOptionsSupportedTypesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Shipment\Model;
+
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageTypeV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesDeliveryTypeV2;
+
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPdkInstance());
+
+it('reports support only for delivery types known to this PDK version', function () {
+    expect(DeliveryOptions::isDeliveryTypeSupported(RefTypesDeliveryTypeV2::STANDARD))->toBeTrue()
+        ->and(DeliveryOptions::isDeliveryTypeSupported(RefTypesDeliveryTypeV2::SAME_DAY))->toBeTrue()
+        ->and(DeliveryOptions::isDeliveryTypeSupported(RefTypesDeliveryTypeV2::EARLY_MORNING))->toBeTrue()
+        ->and(DeliveryOptions::isDeliveryTypeSupported('UNKNOWN_DELIVERY'))->toBeFalse()
+        ->and(DeliveryOptions::isDeliveryTypeSupported(''))->toBeFalse();
+});
+
+it('reports support only for package types known to this PDK version', function () {
+    expect(DeliveryOptions::isPackageTypeSupported(RefShipmentPackageTypeV2::PACKAGE))->toBeTrue()
+        ->and(DeliveryOptions::isPackageTypeSupported(RefShipmentPackageTypeV2::PALLET))->toBeTrue()
+        ->and(DeliveryOptions::isPackageTypeSupported(RefShipmentPackageTypeV2::ENVELOPE))->toBeTrue()
+        ->and(DeliveryOptions::isPackageTypeSupported('UNKNOWN_PACKAGE'))->toBeFalse()
+        ->and(DeliveryOptions::isPackageTypeSupported(''))->toBeFalse();
+});

--- a/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_delivery_options_config__1.json
+++ b/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_delivery_options_config__1.json
@@ -16,7 +16,8 @@
                         },
                         "path": "",
                         "property": "context",
-                        "responseProperty": null
+                        "responseProperty": null,
+                        "useDataEnvelope": true
                     },
                     "proxyAddressList": {
                         "body": null,
@@ -27,7 +28,8 @@
                         },
                         "path": "",
                         "property": "addresses",
-                        "responseProperty": null
+                        "responseProperty": null,
+                        "useDataEnvelope": true
                     },
                     "proxyAddressValidate": {
                         "body": null,
@@ -38,7 +40,8 @@
                         },
                         "path": "",
                         "property": "validate",
-                        "responseProperty": null
+                        "responseProperty": null,
+                        "useDataEnvelope": true
                     },
                     "fetchContext": {
                         "body": null,
@@ -49,7 +52,8 @@
                         },
                         "path": "",
                         "property": "context",
-                        "responseProperty": null
+                        "responseProperty": null,
+                        "useDataEnvelope": true
                     },
                     "proxyCapabilities": {
                         "body": null,
@@ -59,8 +63,9 @@
                             "action": "proxyCapabilities"
                         },
                         "path": "",
-                        "property": "capabilities",
-                        "responseProperty": null
+                        "property": null,
+                        "responseProperty": null,
+                        "useDataEnvelope": false
                     }
                 }
             },

--- a/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_global__1.json
+++ b/tests/__snapshots__/ContextServiceTest__it_gets_context_data_with_data_set_global__1.json
@@ -17,7 +17,8 @@
                     "action": "deleteAccount"
                 },
                 "path": "",
-                "responseProperty": "context"
+                "responseProperty": "context",
+                "useDataEnvelope": true
             },
             "updateAccount": {
                 "headers": [],
@@ -27,7 +28,8 @@
                 },
                 "path": "",
                 "property": "account_settings",
-                "responseProperty": "context"
+                "responseProperty": "context",
+                "useDataEnvelope": true
             },
             "updateSubscriptionFeatures": {
                 "headers": [],
@@ -36,7 +38,8 @@
                     "action": "updateSubscriptionFeatures"
                 },
                 "path": "",
-                "responseProperty": "data"
+                "responseProperty": "data",
+                "useDataEnvelope": true
             },
             "synchronizeOrders": {
                 "headers": [],
@@ -45,7 +48,8 @@
                     "action": "synchronizeOrders"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "exportOrders": {
                 "headers": [],
@@ -54,7 +58,8 @@
                     "action": "exportOrders"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "postOrderNotes": {
                 "headers": [],
@@ -63,7 +68,8 @@
                     "action": "postOrderNotes"
                 },
                 "path": "",
-                "property": "orderNotes"
+                "property": "orderNotes",
+                "useDataEnvelope": true
             },
             "fetchOrders": {
                 "headers": [],
@@ -72,7 +78,8 @@
                     "action": "fetchOrders"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "printOrders": {
                 "headers": [],
@@ -81,7 +88,8 @@
                     "action": "printOrders"
                 },
                 "path": "",
-                "property": "pdfs"
+                "property": "pdfs",
+                "useDataEnvelope": true
             },
             "updateOrders": {
                 "headers": [],
@@ -90,7 +98,8 @@
                     "action": "updateOrders"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "updateOrderStatus": {
                 "headers": [],
@@ -99,7 +108,8 @@
                     "action": "updateOrderStatus"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "updateShipments": {
                 "headers": [],
@@ -108,7 +118,8 @@
                     "action": "updateShipments"
                 },
                 "path": "",
-                "property": "shipments"
+                "property": "shipments",
+                "useDataEnvelope": true
             },
             "deleteShipments": {
                 "headers": [],
@@ -117,7 +128,8 @@
                     "action": "deleteShipments"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "printShipments": {
                 "headers": [],
@@ -126,7 +138,8 @@
                     "action": "printShipments"
                 },
                 "path": "",
-                "property": "pdfs"
+                "property": "pdfs",
+                "useDataEnvelope": true
             },
             "updatePluginSettings": {
                 "headers": [],
@@ -135,7 +148,8 @@
                     "action": "updatePluginSettings"
                 },
                 "path": "",
-                "property": "plugin_settings"
+                "property": "plugin_settings",
+                "useDataEnvelope": true
             },
             "updateProductSettings": {
                 "headers": [],
@@ -144,7 +158,8 @@
                     "action": "updateProductSettings"
                 },
                 "path": "",
-                "property": "product_settings"
+                "property": "product_settings",
+                "useDataEnvelope": true
             },
             "exportReturn": {
                 "headers": [],
@@ -153,7 +168,8 @@
                     "action": "exportReturn"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "createWebhooks": {
                 "headers": [],
@@ -162,7 +178,8 @@
                     "action": "createWebhooks"
                 },
                 "path": "",
-                "property": "webhooks"
+                "property": "webhooks",
+                "useDataEnvelope": true
             },
             "deleteWebhooks": {
                 "headers": [],
@@ -171,7 +188,8 @@
                     "action": "deleteWebhooks"
                 },
                 "path": "",
-                "property": "webhooks"
+                "property": "webhooks",
+                "useDataEnvelope": true
             },
             "fetchWebhooks": {
                 "headers": [],
@@ -180,7 +198,8 @@
                     "action": "fetchWebhooks"
                 },
                 "path": "",
-                "property": "webhooks"
+                "property": "webhooks",
+                "useDataEnvelope": true
             },
             "downloadLogs": {
                 "headers": {
@@ -190,7 +209,8 @@
                 "parameters": {
                     "action": "downloadLogs"
                 },
-                "path": ""
+                "path": "",
+                "useDataEnvelope": true
             },
             "switchToAcceptanceApi": {
                 "headers": {
@@ -200,7 +220,8 @@
                 "parameters": {
                     "action": "switchToAcceptanceApi"
                 },
-                "path": ""
+                "path": "",
+                "useDataEnvelope": true
             },
             "switchToProductionApi": {
                 "headers": {
@@ -210,7 +231,8 @@
                 "parameters": {
                     "action": "switchToProductionApi"
                 },
-                "path": ""
+                "path": "",
+                "useDataEnvelope": true
             },
             "fetchContext": {
                 "headers": [],
@@ -219,7 +241,8 @@
                     "action": "fetchContext"
                 },
                 "path": "",
-                "property": "context"
+                "property": "context",
+                "useDataEnvelope": true
             },
             "proxyCapabilities": {
                 "headers": [],
@@ -228,7 +251,7 @@
                     "action": "proxyCapabilities"
                 },
                 "path": "",
-                "property": "capabilities"
+                "useDataEnvelope": false
             }
         },
         "eventPing": "myparcel_pdk_ping",

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_delivery_options__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_delivery_options__1.json
@@ -32,7 +32,8 @@
                         },
                         "path": "",
                         "property": "context",
-                        "responseProperty": null
+                        "responseProperty": null,
+                        "useDataEnvelope": true
                     },
                     "proxyAddressList": {
                         "body": null,
@@ -43,7 +44,8 @@
                         },
                         "path": "",
                         "property": "addresses",
-                        "responseProperty": null
+                        "responseProperty": null,
+                        "useDataEnvelope": true
                     },
                     "proxyAddressValidate": {
                         "body": null,
@@ -54,7 +56,8 @@
                         },
                         "path": "",
                         "property": "validate",
-                        "responseProperty": null
+                        "responseProperty": null,
+                        "useDataEnvelope": true
                     },
                     "fetchContext": {
                         "body": null,
@@ -65,7 +68,8 @@
                         },
                         "path": "",
                         "property": "context",
-                        "responseProperty": null
+                        "responseProperty": null,
+                        "useDataEnvelope": true
                     },
                     "proxyCapabilities": {
                         "body": null,
@@ -75,8 +79,9 @@
                             "action": "proxyCapabilities"
                         },
                         "path": "",
-                        "property": "capabilities",
-                        "responseProperty": null
+                        "property": null,
+                        "responseProperty": null,
+                        "useDataEnvelope": false
                     }
                 }
             },

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_init_script__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_init_script__1.json
@@ -17,7 +17,8 @@
                     "action": "deleteAccount"
                 },
                 "path": "",
-                "responseProperty": "context"
+                "responseProperty": "context",
+                "useDataEnvelope": true
             },
             "updateAccount": {
                 "headers": [],
@@ -27,7 +28,8 @@
                 },
                 "path": "",
                 "property": "account_settings",
-                "responseProperty": "context"
+                "responseProperty": "context",
+                "useDataEnvelope": true
             },
             "updateSubscriptionFeatures": {
                 "headers": [],
@@ -36,7 +38,8 @@
                     "action": "updateSubscriptionFeatures"
                 },
                 "path": "",
-                "responseProperty": "data"
+                "responseProperty": "data",
+                "useDataEnvelope": true
             },
             "synchronizeOrders": {
                 "headers": [],
@@ -45,7 +48,8 @@
                     "action": "synchronizeOrders"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "exportOrders": {
                 "headers": [],
@@ -54,7 +58,8 @@
                     "action": "exportOrders"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "postOrderNotes": {
                 "headers": [],
@@ -63,7 +68,8 @@
                     "action": "postOrderNotes"
                 },
                 "path": "",
-                "property": "orderNotes"
+                "property": "orderNotes",
+                "useDataEnvelope": true
             },
             "fetchOrders": {
                 "headers": [],
@@ -72,7 +78,8 @@
                     "action": "fetchOrders"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "printOrders": {
                 "headers": [],
@@ -81,7 +88,8 @@
                     "action": "printOrders"
                 },
                 "path": "",
-                "property": "pdfs"
+                "property": "pdfs",
+                "useDataEnvelope": true
             },
             "updateOrders": {
                 "headers": [],
@@ -90,7 +98,8 @@
                     "action": "updateOrders"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "updateOrderStatus": {
                 "headers": [],
@@ -99,7 +108,8 @@
                     "action": "updateOrderStatus"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "updateShipments": {
                 "headers": [],
@@ -108,7 +118,8 @@
                     "action": "updateShipments"
                 },
                 "path": "",
-                "property": "shipments"
+                "property": "shipments",
+                "useDataEnvelope": true
             },
             "deleteShipments": {
                 "headers": [],
@@ -117,7 +128,8 @@
                     "action": "deleteShipments"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "printShipments": {
                 "headers": [],
@@ -126,7 +138,8 @@
                     "action": "printShipments"
                 },
                 "path": "",
-                "property": "pdfs"
+                "property": "pdfs",
+                "useDataEnvelope": true
             },
             "updatePluginSettings": {
                 "headers": [],
@@ -135,7 +148,8 @@
                     "action": "updatePluginSettings"
                 },
                 "path": "",
-                "property": "plugin_settings"
+                "property": "plugin_settings",
+                "useDataEnvelope": true
             },
             "updateProductSettings": {
                 "headers": [],
@@ -144,7 +158,8 @@
                     "action": "updateProductSettings"
                 },
                 "path": "",
-                "property": "product_settings"
+                "property": "product_settings",
+                "useDataEnvelope": true
             },
             "exportReturn": {
                 "headers": [],
@@ -153,7 +168,8 @@
                     "action": "exportReturn"
                 },
                 "path": "",
-                "property": "orders"
+                "property": "orders",
+                "useDataEnvelope": true
             },
             "createWebhooks": {
                 "headers": [],
@@ -162,7 +178,8 @@
                     "action": "createWebhooks"
                 },
                 "path": "",
-                "property": "webhooks"
+                "property": "webhooks",
+                "useDataEnvelope": true
             },
             "deleteWebhooks": {
                 "headers": [],
@@ -171,7 +188,8 @@
                     "action": "deleteWebhooks"
                 },
                 "path": "",
-                "property": "webhooks"
+                "property": "webhooks",
+                "useDataEnvelope": true
             },
             "fetchWebhooks": {
                 "headers": [],
@@ -180,7 +198,8 @@
                     "action": "fetchWebhooks"
                 },
                 "path": "",
-                "property": "webhooks"
+                "property": "webhooks",
+                "useDataEnvelope": true
             },
             "downloadLogs": {
                 "headers": {
@@ -190,7 +209,8 @@
                 "parameters": {
                     "action": "downloadLogs"
                 },
-                "path": ""
+                "path": "",
+                "useDataEnvelope": true
             },
             "switchToAcceptanceApi": {
                 "headers": {
@@ -200,7 +220,8 @@
                 "parameters": {
                     "action": "switchToAcceptanceApi"
                 },
-                "path": ""
+                "path": "",
+                "useDataEnvelope": true
             },
             "switchToProductionApi": {
                 "headers": {
@@ -210,7 +231,8 @@
                 "parameters": {
                     "action": "switchToProductionApi"
                 },
-                "path": ""
+                "path": "",
+                "useDataEnvelope": true
             },
             "fetchContext": {
                 "headers": [],
@@ -219,7 +241,8 @@
                     "action": "fetchContext"
                 },
                 "path": "",
-                "property": "context"
+                "property": "context",
+                "useDataEnvelope": true
             },
             "proxyCapabilities": {
                 "headers": [],
@@ -228,7 +251,7 @@
                     "action": "proxyCapabilities"
                 },
                 "path": "",
-                "property": "capabilities"
+                "useDataEnvelope": false
             }
         },
         "eventPing": "myparcel_pdk_ping",

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_product_settings__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_product_settings__1.json
@@ -1,1258 +1,1266 @@
 {
-  "productData": [
-    {
-      "isDeliverable": true,
-      "weight": 0,
-      "length": 0,
-      "width": 0,
-      "height": 0,
-      "settings": {
-        "exportAgeCheck": -1,
-        "exportReturn": -1,
-        "exportHideSender": -1,
-        "exportInsurance": -1,
-        "exportLargeFormat": -1,
-        "exportOnlyRecipient": -1,
-        "exportPriorityDelivery": -1,
-        "exportSignature": -1,
-        "exportTracked": -1,
-        "excludeParcelLockers": -1,
-        "exportFreshFood": -1,
-        "exportFrozen": -1,
-        "exportCooledDelivery": -1,
-        "id": "product",
-        "countryOfOrigin": -1,
-        "customsCode": -1,
-        "disableDeliveryOptions": -1,
-        "dropOffDelay": -1,
-        "fitInDigitalStamp": -1,
-        "fitInMailbox": -1,
-        "packageType": -1
-      },
-      "mergedSettings": {
-        "exportAgeCheck": -1,
-        "exportReturn": -1,
-        "exportHideSender": -1,
-        "exportInsurance": -1,
-        "exportLargeFormat": -1,
-        "exportOnlyRecipient": -1,
-        "exportPriorityDelivery": -1,
-        "exportSignature": -1,
-        "exportTracked": -1,
-        "excludeParcelLockers": -1,
-        "exportFreshFood": -1,
-        "exportFrozen": -1,
-        "exportCooledDelivery": -1,
-        "id": "product",
-        "countryOfOrigin": -1,
-        "customsCode": -1,
-        "disableDeliveryOptions": -1,
-        "dropOffDelay": -1,
-        "fitInDigitalStamp": -1,
-        "fitInMailbox": -1,
-        "packageType": -1
-      }
-    }
-  ],
-  "productSettingsView": {
-    "view": {
-      "id": "product",
-      "title": "settings_view_product_title",
-      "description": "settings_view_product_description",
-      "elements": [
+    "productData": [
         {
-          "$component": "SettingsDivider",
-          "$wrapper": false,
-          "content": "settings_product_myparcel_options_description",
-          "heading": "settings_product_myparcel_options_title",
-          "level": 2
-        },
-        {
-          "name": "packageType",
-          "$component": "SelectInput",
-          "options": [
-            {
-              "value": -1,
-              "label": "settings_default"
+            "isDeliverable": true,
+            "weight": 0,
+            "length": 0,
+            "width": 0,
+            "height": 0,
+            "settings": {
+                "exportAgeCheck": -1,
+                "exportReturn": -1,
+                "exportHideSender": -1,
+                "exportInsurance": -1,
+                "exportLargeFormat": -1,
+                "exportOnlyRecipient": -1,
+                "exportPriorityDelivery": -1,
+                "exportSignature": -1,
+                "exportTracked": -1,
+                "excludeParcelLockers": -1,
+                "exportFreshFood": -1,
+                "exportFrozen": -1,
+                "exportCooledDelivery": -1,
+                "id": "product",
+                "countryOfOrigin": -1,
+                "customsCode": -1,
+                "disableDeliveryOptions": -1,
+                "dropOffDelay": -1,
+                "fitInDigitalStamp": -1,
+                "fitInMailbox": -1,
+                "packageType": -1
             },
-            {
-              "value": "package",
-              "label": "package_type_package"
-            },
-            {
-              "value": "mailbox",
-              "label": "package_type_mailbox"
-            },
-            {
-              "value": "letter",
-              "label": "package_type_letter"
-            },
-            {
-              "value": "digital_stamp",
-              "label": "package_type_digital_stamp"
-            },
-            {
-              "value": "package_small",
-              "label": "package_type_package_small"
+            "mergedSettings": {
+                "exportAgeCheck": -1,
+                "exportReturn": -1,
+                "exportHideSender": -1,
+                "exportInsurance": -1,
+                "exportLargeFormat": -1,
+                "exportOnlyRecipient": -1,
+                "exportPriorityDelivery": -1,
+                "exportSignature": -1,
+                "exportTracked": -1,
+                "excludeParcelLockers": -1,
+                "exportFreshFood": -1,
+                "exportFrozen": -1,
+                "exportCooledDelivery": -1,
+                "id": "product",
+                "countryOfOrigin": -1,
+                "customsCode": -1,
+                "disableDeliveryOptions": -1,
+                "dropOffDelay": -1,
+                "fitInDigitalStamp": -1,
+                "fitInMailbox": -1,
+                "packageType": -1
             }
-          ],
-          "label": "settings_product_package_type",
-          "description": "settings_product_package_type_description"
-        },
-        {
-          "name": "fitInMailbox",
-          "$component": "NumberInput",
-          "min": -1,
-          "label": "settings_product_fit_in_mailbox",
-          "description": "settings_product_fit_in_mailbox_description"
-        },
-        {
-          "$component": "SettingsDivider",
-          "$wrapper": false,
-          "content": "settings_product_delivery_options_description",
-          "heading": "settings_product_delivery_options_title",
-          "level": 2
-        },
-        {
-          "name": "dropOffDelay",
-          "$component": "NumberInput",
-          "$attributes": {
-            "min": -1,
-            "max": 14
-          },
-          "label": "settings_product_drop_off_delay",
-          "description": "settings_product_drop_off_delay_description"
-        },
-        {
-          "name": "disableDeliveryOptions",
-          "$component": "TriStateInput",
-          "label": "settings_product_disable_delivery_options",
-          "description": "settings_product_disable_delivery_options_description"
-        },
-        {
-          "name": "excludeParcelLockers",
-          "$component": "TriStateInput",
-          "label": "settings_product_exclude_parcel_lockers",
-          "description": "settings_product_exclude_parcel_lockers_description"
-        },
-        {
-          "$component": "SettingsDivider",
-          "$wrapper": false,
-          "content": "settings_product_customs_options_description",
-          "heading": "settings_product_customs_options_title",
-          "level": 2
-        },
-        {
-          "name": "countryOfOrigin",
-          "$component": "SelectInput",
-          "options": [
-            {
-              "value": -1,
-              "label": "settings_none"
-            },
-            {
-              "value": "AD",
-              "label": "country_ad"
-            },
-            {
-              "value": "AE",
-              "label": "country_ae"
-            },
-            {
-              "value": "AF",
-              "label": "country_af"
-            },
-            {
-              "value": "AG",
-              "label": "country_ag"
-            },
-            {
-              "value": "AI",
-              "label": "country_ai"
-            },
-            {
-              "value": "AL",
-              "label": "country_al"
-            },
-            {
-              "value": "AM",
-              "label": "country_am"
-            },
-            {
-              "value": "AN",
-              "label": "country_an"
-            },
-            {
-              "value": "AO",
-              "label": "country_ao"
-            },
-            {
-              "value": "AQ",
-              "label": "country_aq"
-            },
-            {
-              "value": "AR",
-              "label": "country_ar"
-            },
-            {
-              "value": "AS",
-              "label": "country_as"
-            },
-            {
-              "value": "AT",
-              "label": "country_at"
-            },
-            {
-              "value": "AU",
-              "label": "country_au"
-            },
-            {
-              "value": "AW",
-              "label": "country_aw"
-            },
-            {
-              "value": "AX",
-              "label": "country_ax"
-            },
-            {
-              "value": "AZ",
-              "label": "country_az"
-            },
-            {
-              "value": "BA",
-              "label": "country_ba"
-            },
-            {
-              "value": "BB",
-              "label": "country_bb"
-            },
-            {
-              "value": "BD",
-              "label": "country_bd"
-            },
-            {
-              "value": "BE",
-              "label": "country_be"
-            },
-            {
-              "value": "BF",
-              "label": "country_bf"
-            },
-            {
-              "value": "BG",
-              "label": "country_bg"
-            },
-            {
-              "value": "BH",
-              "label": "country_bh"
-            },
-            {
-              "value": "BI",
-              "label": "country_bi"
-            },
-            {
-              "value": "BJ",
-              "label": "country_bj"
-            },
-            {
-              "value": "BL",
-              "label": "country_bl"
-            },
-            {
-              "value": "BM",
-              "label": "country_bm"
-            },
-            {
-              "value": "BN",
-              "label": "country_bn"
-            },
-            {
-              "value": "BO",
-              "label": "country_bo"
-            },
-            {
-              "value": "BQ",
-              "label": "country_bq"
-            },
-            {
-              "value": "BR",
-              "label": "country_br"
-            },
-            {
-              "value": "BS",
-              "label": "country_bs"
-            },
-            {
-              "value": "BT",
-              "label": "country_bt"
-            },
-            {
-              "value": "BV",
-              "label": "country_bv"
-            },
-            {
-              "value": "BW",
-              "label": "country_bw"
-            },
-            {
-              "value": "BY",
-              "label": "country_by"
-            },
-            {
-              "value": "BZ",
-              "label": "country_bz"
-            },
-            {
-              "value": "CA",
-              "label": "country_ca"
-            },
-            {
-              "value": "CC",
-              "label": "country_cc"
-            },
-            {
-              "value": "CD",
-              "label": "country_cd"
-            },
-            {
-              "value": "CF",
-              "label": "country_cf"
-            },
-            {
-              "value": "CG",
-              "label": "country_cg"
-            },
-            {
-              "value": "CH",
-              "label": "country_ch"
-            },
-            {
-              "value": "CI",
-              "label": "country_ci"
-            },
-            {
-              "value": "CK",
-              "label": "country_ck"
-            },
-            {
-              "value": "CL",
-              "label": "country_cl"
-            },
-            {
-              "value": "CM",
-              "label": "country_cm"
-            },
-            {
-              "value": "CN",
-              "label": "country_cn"
-            },
-            {
-              "value": "CO",
-              "label": "country_co"
-            },
-            {
-              "value": "CR",
-              "label": "country_cr"
-            },
-            {
-              "value": "CU",
-              "label": "country_cu"
-            },
-            {
-              "value": "CV",
-              "label": "country_cv"
-            },
-            {
-              "value": "CW",
-              "label": "country_cw"
-            },
-            {
-              "value": "CX",
-              "label": "country_cx"
-            },
-            {
-              "value": "CY",
-              "label": "country_cy"
-            },
-            {
-              "value": "CZ",
-              "label": "country_cz"
-            },
-            {
-              "value": "DE",
-              "label": "country_de"
-            },
-            {
-              "value": "DJ",
-              "label": "country_dj"
-            },
-            {
-              "value": "DK",
-              "label": "country_dk"
-            },
-            {
-              "value": "DM",
-              "label": "country_dm"
-            },
-            {
-              "value": "DO",
-              "label": "country_do"
-            },
-            {
-              "value": "DZ",
-              "label": "country_dz"
-            },
-            {
-              "value": "EC",
-              "label": "country_ec"
-            },
-            {
-              "value": "EE",
-              "label": "country_ee"
-            },
-            {
-              "value": "EG",
-              "label": "country_eg"
-            },
-            {
-              "value": "EH",
-              "label": "country_eh"
-            },
-            {
-              "value": "ER",
-              "label": "country_er"
-            },
-            {
-              "value": "ES",
-              "label": "country_es"
-            },
-            {
-              "value": "ET",
-              "label": "country_et"
-            },
-            {
-              "value": "FI",
-              "label": "country_fi"
-            },
-            {
-              "value": "FJ",
-              "label": "country_fj"
-            },
-            {
-              "value": "FK",
-              "label": "country_fk"
-            },
-            {
-              "value": "FM",
-              "label": "country_fm"
-            },
-            {
-              "value": "FO",
-              "label": "country_fo"
-            },
-            {
-              "value": "FR",
-              "label": "country_fr"
-            },
-            {
-              "value": "GA",
-              "label": "country_ga"
-            },
-            {
-              "value": "GB",
-              "label": "country_gb"
-            },
-            {
-              "value": "GD",
-              "label": "country_gd"
-            },
-            {
-              "value": "GE",
-              "label": "country_ge"
-            },
-            {
-              "value": "GF",
-              "label": "country_gf"
-            },
-            {
-              "value": "GG",
-              "label": "country_gg"
-            },
-            {
-              "value": "GH",
-              "label": "country_gh"
-            },
-            {
-              "value": "GI",
-              "label": "country_gi"
-            },
-            {
-              "value": "GL",
-              "label": "country_gl"
-            },
-            {
-              "value": "GM",
-              "label": "country_gm"
-            },
-            {
-              "value": "GN",
-              "label": "country_gn"
-            },
-            {
-              "value": "GP",
-              "label": "country_gp"
-            },
-            {
-              "value": "GQ",
-              "label": "country_gq"
-            },
-            {
-              "value": "GR",
-              "label": "country_gr"
-            },
-            {
-              "value": "GS",
-              "label": "country_gs"
-            },
-            {
-              "value": "GT",
-              "label": "country_gt"
-            },
-            {
-              "value": "GU",
-              "label": "country_gu"
-            },
-            {
-              "value": "GW",
-              "label": "country_gw"
-            },
-            {
-              "value": "GY",
-              "label": "country_gy"
-            },
-            {
-              "value": "HK",
-              "label": "country_hk"
-            },
-            {
-              "value": "HM",
-              "label": "country_hm"
-            },
-            {
-              "value": "HN",
-              "label": "country_hn"
-            },
-            {
-              "value": "HR",
-              "label": "country_hr"
-            },
-            {
-              "value": "HT",
-              "label": "country_ht"
-            },
-            {
-              "value": "HU",
-              "label": "country_hu"
-            },
-            {
-              "value": "ID",
-              "label": "country_id"
-            },
-            {
-              "value": "IE",
-              "label": "country_ie"
-            },
-            {
-              "value": "IL",
-              "label": "country_il"
-            },
-            {
-              "value": "IM",
-              "label": "country_im"
-            },
-            {
-              "value": "IN",
-              "label": "country_in"
-            },
-            {
-              "value": "IO",
-              "label": "country_io"
-            },
-            {
-              "value": "IQ",
-              "label": "country_iq"
-            },
-            {
-              "value": "IR",
-              "label": "country_ir"
-            },
-            {
-              "value": "IS",
-              "label": "country_is"
-            },
-            {
-              "value": "IT",
-              "label": "country_it"
-            },
-            {
-              "value": "JE",
-              "label": "country_je"
-            },
-            {
-              "value": "JM",
-              "label": "country_jm"
-            },
-            {
-              "value": "JO",
-              "label": "country_jo"
-            },
-            {
-              "value": "JP",
-              "label": "country_jp"
-            },
-            {
-              "value": "KE",
-              "label": "country_ke"
-            },
-            {
-              "value": "KG",
-              "label": "country_kg"
-            },
-            {
-              "value": "KH",
-              "label": "country_kh"
-            },
-            {
-              "value": "KI",
-              "label": "country_ki"
-            },
-            {
-              "value": "KM",
-              "label": "country_km"
-            },
-            {
-              "value": "KN",
-              "label": "country_kn"
-            },
-            {
-              "value": "KP",
-              "label": "country_kp"
-            },
-            {
-              "value": "KR",
-              "label": "country_kr"
-            },
-            {
-              "value": "KW",
-              "label": "country_kw"
-            },
-            {
-              "value": "KY",
-              "label": "country_ky"
-            },
-            {
-              "value": "KZ",
-              "label": "country_kz"
-            },
-            {
-              "value": "LA",
-              "label": "country_la"
-            },
-            {
-              "value": "LB",
-              "label": "country_lb"
-            },
-            {
-              "value": "LC",
-              "label": "country_lc"
-            },
-            {
-              "value": "LI",
-              "label": "country_li"
-            },
-            {
-              "value": "LK",
-              "label": "country_lk"
-            },
-            {
-              "value": "LR",
-              "label": "country_lr"
-            },
-            {
-              "value": "LS",
-              "label": "country_ls"
-            },
-            {
-              "value": "LT",
-              "label": "country_lt"
-            },
-            {
-              "value": "LU",
-              "label": "country_lu"
-            },
-            {
-              "value": "LV",
-              "label": "country_lv"
-            },
-            {
-              "value": "LY",
-              "label": "country_ly"
-            },
-            {
-              "value": "MA",
-              "label": "country_ma"
-            },
-            {
-              "value": "MC",
-              "label": "country_mc"
-            },
-            {
-              "value": "MD",
-              "label": "country_md"
-            },
-            {
-              "value": "ME",
-              "label": "country_me"
-            },
-            {
-              "value": "MF",
-              "label": "country_mf"
-            },
-            {
-              "value": "MG",
-              "label": "country_mg"
-            },
-            {
-              "value": "MH",
-              "label": "country_mh"
-            },
-            {
-              "value": "MK",
-              "label": "country_mk"
-            },
-            {
-              "value": "ML",
-              "label": "country_ml"
-            },
-            {
-              "value": "MM",
-              "label": "country_mm"
-            },
-            {
-              "value": "MN",
-              "label": "country_mn"
-            },
-            {
-              "value": "MO",
-              "label": "country_mo"
-            },
-            {
-              "value": "MP",
-              "label": "country_mp"
-            },
-            {
-              "value": "MQ",
-              "label": "country_mq"
-            },
-            {
-              "value": "MR",
-              "label": "country_mr"
-            },
-            {
-              "value": "MS",
-              "label": "country_ms"
-            },
-            {
-              "value": "MT",
-              "label": "country_mt"
-            },
-            {
-              "value": "MU",
-              "label": "country_mu"
-            },
-            {
-              "value": "MV",
-              "label": "country_mv"
-            },
-            {
-              "value": "MW",
-              "label": "country_mw"
-            },
-            {
-              "value": "MX",
-              "label": "country_mx"
-            },
-            {
-              "value": "MY",
-              "label": "country_my"
-            },
-            {
-              "value": "MZ",
-              "label": "country_mz"
-            },
-            {
-              "value": "NA",
-              "label": "country_na"
-            },
-            {
-              "value": "NC",
-              "label": "country_nc"
-            },
-            {
-              "value": "NE",
-              "label": "country_ne"
-            },
-            {
-              "value": "NF",
-              "label": "country_nf"
-            },
-            {
-              "value": "NG",
-              "label": "country_ng"
-            },
-            {
-              "value": "NI",
-              "label": "country_ni"
-            },
-            {
-              "value": "NL",
-              "label": "country_nl"
-            },
-            {
-              "value": "NO",
-              "label": "country_no"
-            },
-            {
-              "value": "NP",
-              "label": "country_np"
-            },
-            {
-              "value": "NR",
-              "label": "country_nr"
-            },
-            {
-              "value": "NU",
-              "label": "country_nu"
-            },
-            {
-              "value": "NZ",
-              "label": "country_nz"
-            },
-            {
-              "value": "OM",
-              "label": "country_om"
-            },
-            {
-              "value": "PA",
-              "label": "country_pa"
-            },
-            {
-              "value": "PE",
-              "label": "country_pe"
-            },
-            {
-              "value": "PF",
-              "label": "country_pf"
-            },
-            {
-              "value": "PG",
-              "label": "country_pg"
-            },
-            {
-              "value": "PH",
-              "label": "country_ph"
-            },
-            {
-              "value": "PK",
-              "label": "country_pk"
-            },
-            {
-              "value": "PL",
-              "label": "country_pl"
-            },
-            {
-              "value": "PM",
-              "label": "country_pm"
-            },
-            {
-              "value": "PN",
-              "label": "country_pn"
-            },
-            {
-              "value": "PR",
-              "label": "country_pr"
-            },
-            {
-              "value": "PS",
-              "label": "country_ps"
-            },
-            {
-              "value": "PT",
-              "label": "country_pt"
-            },
-            {
-              "value": "PW",
-              "label": "country_pw"
-            },
-            {
-              "value": "PY",
-              "label": "country_py"
-            },
-            {
-              "value": "QA",
-              "label": "country_qa"
-            },
-            {
-              "value": "RE",
-              "label": "country_re"
-            },
-            {
-              "value": "RO",
-              "label": "country_ro"
-            },
-            {
-              "value": "RS",
-              "label": "country_rs"
-            },
-            {
-              "value": "RU",
-              "label": "country_ru"
-            },
-            {
-              "value": "RW",
-              "label": "country_rw"
-            },
-            {
-              "value": "SA",
-              "label": "country_sa"
-            },
-            {
-              "value": "SB",
-              "label": "country_sb"
-            },
-            {
-              "value": "SC",
-              "label": "country_sc"
-            },
-            {
-              "value": "SD",
-              "label": "country_sd"
-            },
-            {
-              "value": "SE",
-              "label": "country_se"
-            },
-            {
-              "value": "SG",
-              "label": "country_sg"
-            },
-            {
-              "value": "SH",
-              "label": "country_sh"
-            },
-            {
-              "value": "SI",
-              "label": "country_si"
-            },
-            {
-              "value": "SJ",
-              "label": "country_sj"
-            },
-            {
-              "value": "SK",
-              "label": "country_sk"
-            },
-            {
-              "value": "SL",
-              "label": "country_sl"
-            },
-            {
-              "value": "SM",
-              "label": "country_sm"
-            },
-            {
-              "value": "SN",
-              "label": "country_sn"
-            },
-            {
-              "value": "SO",
-              "label": "country_so"
-            },
-            {
-              "value": "SR",
-              "label": "country_sr"
-            },
-            {
-              "value": "SS",
-              "label": "country_ss"
-            },
-            {
-              "value": "ST",
-              "label": "country_st"
-            },
-            {
-              "value": "SV",
-              "label": "country_sv"
-            },
-            {
-              "value": "SX",
-              "label": "country_sx"
-            },
-            {
-              "value": "SY",
-              "label": "country_sy"
-            },
-            {
-              "value": "SZ",
-              "label": "country_sz"
-            },
-            {
-              "value": "TC",
-              "label": "country_tc"
-            },
-            {
-              "value": "TD",
-              "label": "country_td"
-            },
-            {
-              "value": "TF",
-              "label": "country_tf"
-            },
-            {
-              "value": "TG",
-              "label": "country_tg"
-            },
-            {
-              "value": "TH",
-              "label": "country_th"
-            },
-            {
-              "value": "TJ",
-              "label": "country_tj"
-            },
-            {
-              "value": "TK",
-              "label": "country_tk"
-            },
-            {
-              "value": "TL",
-              "label": "country_tl"
-            },
-            {
-              "value": "TM",
-              "label": "country_tm"
-            },
-            {
-              "value": "TN",
-              "label": "country_tn"
-            },
-            {
-              "value": "TO",
-              "label": "country_to"
-            },
-            {
-              "value": "TR",
-              "label": "country_tr"
-            },
-            {
-              "value": "TT",
-              "label": "country_tt"
-            },
-            {
-              "value": "TV",
-              "label": "country_tv"
-            },
-            {
-              "value": "TW",
-              "label": "country_tw"
-            },
-            {
-              "value": "TZ",
-              "label": "country_tz"
-            },
-            {
-              "value": "UA",
-              "label": "country_ua"
-            },
-            {
-              "value": "UG",
-              "label": "country_ug"
-            },
-            {
-              "value": "UM",
-              "label": "country_um"
-            },
-            {
-              "value": "US",
-              "label": "country_us"
-            },
-            {
-              "value": "UY",
-              "label": "country_uy"
-            },
-            {
-              "value": "UZ",
-              "label": "country_uz"
-            },
-            {
-              "value": "VA",
-              "label": "country_va"
-            },
-            {
-              "value": "VC",
-              "label": "country_vc"
-            },
-            {
-              "value": "VE",
-              "label": "country_ve"
-            },
-            {
-              "value": "VG",
-              "label": "country_vg"
-            },
-            {
-              "value": "VI",
-              "label": "country_vi"
-            },
-            {
-              "value": "VN",
-              "label": "country_vn"
-            },
-            {
-              "value": "VU",
-              "label": "country_vu"
-            },
-            {
-              "value": "WF",
-              "label": "country_wf"
-            },
-            {
-              "value": "WS",
-              "label": "country_ws"
-            },
-            {
-              "value": "XK",
-              "label": "country_xk"
-            },
-            {
-              "value": "YE",
-              "label": "country_ye"
-            },
-            {
-              "value": "YT",
-              "label": "country_yt"
-            },
-            {
-              "value": "ZA",
-              "label": "country_za"
-            },
-            {
-              "value": "ZM",
-              "label": "country_zm"
-            },
-            {
-              "value": "ZW",
-              "label": "country_zw"
-            }
-          ],
-          "label": "settings_product_country_of_origin",
-          "description": "settings_product_country_of_origin_description"
-        },
-        {
-          "name": "customsCode",
-          "$component": "TextInput",
-          "$attributes": {
-            "maxlength": 10
-          },
-          "label": "settings_product_customs_code",
-          "description": "settings_product_customs_code_description"
-        },
-        {
-          "$component": "SettingsDivider",
-          "$wrapper": false,
-          "content": "settings_product_export_options_description",
-          "heading": "settings_product_export_options_title",
-          "level": 2
-        },
-        {
-          "name": "exportAgeCheck",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_age_check",
-          "description": "settings_product_export_age_check_description"
-        },
-        {
-          "name": "exportReturn",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_return",
-          "description": "settings_product_export_return_description"
-        },
-        {
-          "name": "exportHideSender",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_hide_sender",
-          "description": "settings_product_export_hide_sender_description"
-        },
-        {
-          "name": "exportInsurance",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_insurance",
-          "description": "settings_product_export_insurance_description"
-        },
-        {
-          "name": "exportLargeFormat",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_large_format",
-          "description": "settings_product_export_large_format_description"
-        },
-        {
-          "name": "exportOnlyRecipient",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_only_recipient",
-          "description": "settings_product_export_only_recipient_description"
-        },
-        {
-          "name": "exportPriorityDelivery",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_priority_delivery",
-          "description": "settings_product_export_priority_delivery_description"
-        },
-        {
-          "name": "exportSignature",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_signature",
-          "description": "settings_product_export_signature_description"
-        },
-        {
-          "name": "exportTracked",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_tracked",
-          "description": "settings_product_export_tracked_description"
-        },
-        {
-          "name": "excludeParcelLockers",
-          "$component": "TriStateInput",
-          "label": "settings_product_exclude_parcel_lockers",
-          "description": "settings_product_exclude_parcel_lockers_description"
-        },
-        {
-          "name": "exportFreshFood",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_fresh_food",
-          "description": "settings_product_export_fresh_food_description"
-        },
-        {
-          "name": "exportFrozen",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_frozen",
-          "description": "settings_product_export_frozen_description"
-        },
-        {
-          "name": "exportCooledDelivery",
-          "$component": "TriStateInput",
-          "label": "settings_product_export_cooled_delivery",
-          "description": "settings_product_export_cooled_delivery_description"
         }
-      ]
+    ],
+    "productSettingsView": {
+        "view": {
+            "id": "product",
+            "title": "settings_view_product_title",
+            "description": "settings_view_product_description",
+            "elements": [
+                {
+                    "$component": "SettingsDivider",
+                    "$wrapper": false,
+                    "content": "settings_product_myparcel_options_description",
+                    "heading": "settings_product_myparcel_options_title",
+                    "level": 2
+                },
+                {
+                    "name": "packageType",
+                    "$component": "SelectInput",
+                    "options": [
+                        {
+                            "value": -1,
+                            "label": "settings_default"
+                        },
+                        {
+                            "value": "package",
+                            "label": "package_type_package"
+                        },
+                        {
+                            "value": "mailbox",
+                            "label": "package_type_mailbox"
+                        },
+                        {
+                            "value": "letter",
+                            "label": "package_type_letter"
+                        },
+                        {
+                            "value": "digital_stamp",
+                            "label": "package_type_digital_stamp"
+                        },
+                        {
+                            "value": "package_small",
+                            "label": "package_type_package_small"
+                        },
+                        {
+                            "value": "pallet",
+                            "label": "package_type_pallet"
+                        },
+                        {
+                            "value": "envelope",
+                            "label": "package_type_envelope"
+                        }
+                    ],
+                    "label": "settings_product_package_type",
+                    "description": "settings_product_package_type_description"
+                },
+                {
+                    "name": "fitInMailbox",
+                    "$component": "NumberInput",
+                    "min": -1,
+                    "label": "settings_product_fit_in_mailbox",
+                    "description": "settings_product_fit_in_mailbox_description"
+                },
+                {
+                    "$component": "SettingsDivider",
+                    "$wrapper": false,
+                    "content": "settings_product_delivery_options_description",
+                    "heading": "settings_product_delivery_options_title",
+                    "level": 2
+                },
+                {
+                    "name": "dropOffDelay",
+                    "$component": "NumberInput",
+                    "$attributes": {
+                        "min": -1,
+                        "max": 14
+                    },
+                    "label": "settings_product_drop_off_delay",
+                    "description": "settings_product_drop_off_delay_description"
+                },
+                {
+                    "name": "disableDeliveryOptions",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_disable_delivery_options",
+                    "description": "settings_product_disable_delivery_options_description"
+                },
+                {
+                    "name": "excludeParcelLockers",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_exclude_parcel_lockers",
+                    "description": "settings_product_exclude_parcel_lockers_description"
+                },
+                {
+                    "$component": "SettingsDivider",
+                    "$wrapper": false,
+                    "content": "settings_product_customs_options_description",
+                    "heading": "settings_product_customs_options_title",
+                    "level": 2
+                },
+                {
+                    "name": "countryOfOrigin",
+                    "$component": "SelectInput",
+                    "options": [
+                        {
+                            "value": -1,
+                            "label": "settings_none"
+                        },
+                        {
+                            "value": "AD",
+                            "label": "country_ad"
+                        },
+                        {
+                            "value": "AE",
+                            "label": "country_ae"
+                        },
+                        {
+                            "value": "AF",
+                            "label": "country_af"
+                        },
+                        {
+                            "value": "AG",
+                            "label": "country_ag"
+                        },
+                        {
+                            "value": "AI",
+                            "label": "country_ai"
+                        },
+                        {
+                            "value": "AL",
+                            "label": "country_al"
+                        },
+                        {
+                            "value": "AM",
+                            "label": "country_am"
+                        },
+                        {
+                            "value": "AN",
+                            "label": "country_an"
+                        },
+                        {
+                            "value": "AO",
+                            "label": "country_ao"
+                        },
+                        {
+                            "value": "AQ",
+                            "label": "country_aq"
+                        },
+                        {
+                            "value": "AR",
+                            "label": "country_ar"
+                        },
+                        {
+                            "value": "AS",
+                            "label": "country_as"
+                        },
+                        {
+                            "value": "AT",
+                            "label": "country_at"
+                        },
+                        {
+                            "value": "AU",
+                            "label": "country_au"
+                        },
+                        {
+                            "value": "AW",
+                            "label": "country_aw"
+                        },
+                        {
+                            "value": "AX",
+                            "label": "country_ax"
+                        },
+                        {
+                            "value": "AZ",
+                            "label": "country_az"
+                        },
+                        {
+                            "value": "BA",
+                            "label": "country_ba"
+                        },
+                        {
+                            "value": "BB",
+                            "label": "country_bb"
+                        },
+                        {
+                            "value": "BD",
+                            "label": "country_bd"
+                        },
+                        {
+                            "value": "BE",
+                            "label": "country_be"
+                        },
+                        {
+                            "value": "BF",
+                            "label": "country_bf"
+                        },
+                        {
+                            "value": "BG",
+                            "label": "country_bg"
+                        },
+                        {
+                            "value": "BH",
+                            "label": "country_bh"
+                        },
+                        {
+                            "value": "BI",
+                            "label": "country_bi"
+                        },
+                        {
+                            "value": "BJ",
+                            "label": "country_bj"
+                        },
+                        {
+                            "value": "BL",
+                            "label": "country_bl"
+                        },
+                        {
+                            "value": "BM",
+                            "label": "country_bm"
+                        },
+                        {
+                            "value": "BN",
+                            "label": "country_bn"
+                        },
+                        {
+                            "value": "BO",
+                            "label": "country_bo"
+                        },
+                        {
+                            "value": "BQ",
+                            "label": "country_bq"
+                        },
+                        {
+                            "value": "BR",
+                            "label": "country_br"
+                        },
+                        {
+                            "value": "BS",
+                            "label": "country_bs"
+                        },
+                        {
+                            "value": "BT",
+                            "label": "country_bt"
+                        },
+                        {
+                            "value": "BV",
+                            "label": "country_bv"
+                        },
+                        {
+                            "value": "BW",
+                            "label": "country_bw"
+                        },
+                        {
+                            "value": "BY",
+                            "label": "country_by"
+                        },
+                        {
+                            "value": "BZ",
+                            "label": "country_bz"
+                        },
+                        {
+                            "value": "CA",
+                            "label": "country_ca"
+                        },
+                        {
+                            "value": "CC",
+                            "label": "country_cc"
+                        },
+                        {
+                            "value": "CD",
+                            "label": "country_cd"
+                        },
+                        {
+                            "value": "CF",
+                            "label": "country_cf"
+                        },
+                        {
+                            "value": "CG",
+                            "label": "country_cg"
+                        },
+                        {
+                            "value": "CH",
+                            "label": "country_ch"
+                        },
+                        {
+                            "value": "CI",
+                            "label": "country_ci"
+                        },
+                        {
+                            "value": "CK",
+                            "label": "country_ck"
+                        },
+                        {
+                            "value": "CL",
+                            "label": "country_cl"
+                        },
+                        {
+                            "value": "CM",
+                            "label": "country_cm"
+                        },
+                        {
+                            "value": "CN",
+                            "label": "country_cn"
+                        },
+                        {
+                            "value": "CO",
+                            "label": "country_co"
+                        },
+                        {
+                            "value": "CR",
+                            "label": "country_cr"
+                        },
+                        {
+                            "value": "CU",
+                            "label": "country_cu"
+                        },
+                        {
+                            "value": "CV",
+                            "label": "country_cv"
+                        },
+                        {
+                            "value": "CW",
+                            "label": "country_cw"
+                        },
+                        {
+                            "value": "CX",
+                            "label": "country_cx"
+                        },
+                        {
+                            "value": "CY",
+                            "label": "country_cy"
+                        },
+                        {
+                            "value": "CZ",
+                            "label": "country_cz"
+                        },
+                        {
+                            "value": "DE",
+                            "label": "country_de"
+                        },
+                        {
+                            "value": "DJ",
+                            "label": "country_dj"
+                        },
+                        {
+                            "value": "DK",
+                            "label": "country_dk"
+                        },
+                        {
+                            "value": "DM",
+                            "label": "country_dm"
+                        },
+                        {
+                            "value": "DO",
+                            "label": "country_do"
+                        },
+                        {
+                            "value": "DZ",
+                            "label": "country_dz"
+                        },
+                        {
+                            "value": "EC",
+                            "label": "country_ec"
+                        },
+                        {
+                            "value": "EE",
+                            "label": "country_ee"
+                        },
+                        {
+                            "value": "EG",
+                            "label": "country_eg"
+                        },
+                        {
+                            "value": "EH",
+                            "label": "country_eh"
+                        },
+                        {
+                            "value": "ER",
+                            "label": "country_er"
+                        },
+                        {
+                            "value": "ES",
+                            "label": "country_es"
+                        },
+                        {
+                            "value": "ET",
+                            "label": "country_et"
+                        },
+                        {
+                            "value": "FI",
+                            "label": "country_fi"
+                        },
+                        {
+                            "value": "FJ",
+                            "label": "country_fj"
+                        },
+                        {
+                            "value": "FK",
+                            "label": "country_fk"
+                        },
+                        {
+                            "value": "FM",
+                            "label": "country_fm"
+                        },
+                        {
+                            "value": "FO",
+                            "label": "country_fo"
+                        },
+                        {
+                            "value": "FR",
+                            "label": "country_fr"
+                        },
+                        {
+                            "value": "GA",
+                            "label": "country_ga"
+                        },
+                        {
+                            "value": "GB",
+                            "label": "country_gb"
+                        },
+                        {
+                            "value": "GD",
+                            "label": "country_gd"
+                        },
+                        {
+                            "value": "GE",
+                            "label": "country_ge"
+                        },
+                        {
+                            "value": "GF",
+                            "label": "country_gf"
+                        },
+                        {
+                            "value": "GG",
+                            "label": "country_gg"
+                        },
+                        {
+                            "value": "GH",
+                            "label": "country_gh"
+                        },
+                        {
+                            "value": "GI",
+                            "label": "country_gi"
+                        },
+                        {
+                            "value": "GL",
+                            "label": "country_gl"
+                        },
+                        {
+                            "value": "GM",
+                            "label": "country_gm"
+                        },
+                        {
+                            "value": "GN",
+                            "label": "country_gn"
+                        },
+                        {
+                            "value": "GP",
+                            "label": "country_gp"
+                        },
+                        {
+                            "value": "GQ",
+                            "label": "country_gq"
+                        },
+                        {
+                            "value": "GR",
+                            "label": "country_gr"
+                        },
+                        {
+                            "value": "GS",
+                            "label": "country_gs"
+                        },
+                        {
+                            "value": "GT",
+                            "label": "country_gt"
+                        },
+                        {
+                            "value": "GU",
+                            "label": "country_gu"
+                        },
+                        {
+                            "value": "GW",
+                            "label": "country_gw"
+                        },
+                        {
+                            "value": "GY",
+                            "label": "country_gy"
+                        },
+                        {
+                            "value": "HK",
+                            "label": "country_hk"
+                        },
+                        {
+                            "value": "HM",
+                            "label": "country_hm"
+                        },
+                        {
+                            "value": "HN",
+                            "label": "country_hn"
+                        },
+                        {
+                            "value": "HR",
+                            "label": "country_hr"
+                        },
+                        {
+                            "value": "HT",
+                            "label": "country_ht"
+                        },
+                        {
+                            "value": "HU",
+                            "label": "country_hu"
+                        },
+                        {
+                            "value": "ID",
+                            "label": "country_id"
+                        },
+                        {
+                            "value": "IE",
+                            "label": "country_ie"
+                        },
+                        {
+                            "value": "IL",
+                            "label": "country_il"
+                        },
+                        {
+                            "value": "IM",
+                            "label": "country_im"
+                        },
+                        {
+                            "value": "IN",
+                            "label": "country_in"
+                        },
+                        {
+                            "value": "IO",
+                            "label": "country_io"
+                        },
+                        {
+                            "value": "IQ",
+                            "label": "country_iq"
+                        },
+                        {
+                            "value": "IR",
+                            "label": "country_ir"
+                        },
+                        {
+                            "value": "IS",
+                            "label": "country_is"
+                        },
+                        {
+                            "value": "IT",
+                            "label": "country_it"
+                        },
+                        {
+                            "value": "JE",
+                            "label": "country_je"
+                        },
+                        {
+                            "value": "JM",
+                            "label": "country_jm"
+                        },
+                        {
+                            "value": "JO",
+                            "label": "country_jo"
+                        },
+                        {
+                            "value": "JP",
+                            "label": "country_jp"
+                        },
+                        {
+                            "value": "KE",
+                            "label": "country_ke"
+                        },
+                        {
+                            "value": "KG",
+                            "label": "country_kg"
+                        },
+                        {
+                            "value": "KH",
+                            "label": "country_kh"
+                        },
+                        {
+                            "value": "KI",
+                            "label": "country_ki"
+                        },
+                        {
+                            "value": "KM",
+                            "label": "country_km"
+                        },
+                        {
+                            "value": "KN",
+                            "label": "country_kn"
+                        },
+                        {
+                            "value": "KP",
+                            "label": "country_kp"
+                        },
+                        {
+                            "value": "KR",
+                            "label": "country_kr"
+                        },
+                        {
+                            "value": "KW",
+                            "label": "country_kw"
+                        },
+                        {
+                            "value": "KY",
+                            "label": "country_ky"
+                        },
+                        {
+                            "value": "KZ",
+                            "label": "country_kz"
+                        },
+                        {
+                            "value": "LA",
+                            "label": "country_la"
+                        },
+                        {
+                            "value": "LB",
+                            "label": "country_lb"
+                        },
+                        {
+                            "value": "LC",
+                            "label": "country_lc"
+                        },
+                        {
+                            "value": "LI",
+                            "label": "country_li"
+                        },
+                        {
+                            "value": "LK",
+                            "label": "country_lk"
+                        },
+                        {
+                            "value": "LR",
+                            "label": "country_lr"
+                        },
+                        {
+                            "value": "LS",
+                            "label": "country_ls"
+                        },
+                        {
+                            "value": "LT",
+                            "label": "country_lt"
+                        },
+                        {
+                            "value": "LU",
+                            "label": "country_lu"
+                        },
+                        {
+                            "value": "LV",
+                            "label": "country_lv"
+                        },
+                        {
+                            "value": "LY",
+                            "label": "country_ly"
+                        },
+                        {
+                            "value": "MA",
+                            "label": "country_ma"
+                        },
+                        {
+                            "value": "MC",
+                            "label": "country_mc"
+                        },
+                        {
+                            "value": "MD",
+                            "label": "country_md"
+                        },
+                        {
+                            "value": "ME",
+                            "label": "country_me"
+                        },
+                        {
+                            "value": "MF",
+                            "label": "country_mf"
+                        },
+                        {
+                            "value": "MG",
+                            "label": "country_mg"
+                        },
+                        {
+                            "value": "MH",
+                            "label": "country_mh"
+                        },
+                        {
+                            "value": "MK",
+                            "label": "country_mk"
+                        },
+                        {
+                            "value": "ML",
+                            "label": "country_ml"
+                        },
+                        {
+                            "value": "MM",
+                            "label": "country_mm"
+                        },
+                        {
+                            "value": "MN",
+                            "label": "country_mn"
+                        },
+                        {
+                            "value": "MO",
+                            "label": "country_mo"
+                        },
+                        {
+                            "value": "MP",
+                            "label": "country_mp"
+                        },
+                        {
+                            "value": "MQ",
+                            "label": "country_mq"
+                        },
+                        {
+                            "value": "MR",
+                            "label": "country_mr"
+                        },
+                        {
+                            "value": "MS",
+                            "label": "country_ms"
+                        },
+                        {
+                            "value": "MT",
+                            "label": "country_mt"
+                        },
+                        {
+                            "value": "MU",
+                            "label": "country_mu"
+                        },
+                        {
+                            "value": "MV",
+                            "label": "country_mv"
+                        },
+                        {
+                            "value": "MW",
+                            "label": "country_mw"
+                        },
+                        {
+                            "value": "MX",
+                            "label": "country_mx"
+                        },
+                        {
+                            "value": "MY",
+                            "label": "country_my"
+                        },
+                        {
+                            "value": "MZ",
+                            "label": "country_mz"
+                        },
+                        {
+                            "value": "NA",
+                            "label": "country_na"
+                        },
+                        {
+                            "value": "NC",
+                            "label": "country_nc"
+                        },
+                        {
+                            "value": "NE",
+                            "label": "country_ne"
+                        },
+                        {
+                            "value": "NF",
+                            "label": "country_nf"
+                        },
+                        {
+                            "value": "NG",
+                            "label": "country_ng"
+                        },
+                        {
+                            "value": "NI",
+                            "label": "country_ni"
+                        },
+                        {
+                            "value": "NL",
+                            "label": "country_nl"
+                        },
+                        {
+                            "value": "NO",
+                            "label": "country_no"
+                        },
+                        {
+                            "value": "NP",
+                            "label": "country_np"
+                        },
+                        {
+                            "value": "NR",
+                            "label": "country_nr"
+                        },
+                        {
+                            "value": "NU",
+                            "label": "country_nu"
+                        },
+                        {
+                            "value": "NZ",
+                            "label": "country_nz"
+                        },
+                        {
+                            "value": "OM",
+                            "label": "country_om"
+                        },
+                        {
+                            "value": "PA",
+                            "label": "country_pa"
+                        },
+                        {
+                            "value": "PE",
+                            "label": "country_pe"
+                        },
+                        {
+                            "value": "PF",
+                            "label": "country_pf"
+                        },
+                        {
+                            "value": "PG",
+                            "label": "country_pg"
+                        },
+                        {
+                            "value": "PH",
+                            "label": "country_ph"
+                        },
+                        {
+                            "value": "PK",
+                            "label": "country_pk"
+                        },
+                        {
+                            "value": "PL",
+                            "label": "country_pl"
+                        },
+                        {
+                            "value": "PM",
+                            "label": "country_pm"
+                        },
+                        {
+                            "value": "PN",
+                            "label": "country_pn"
+                        },
+                        {
+                            "value": "PR",
+                            "label": "country_pr"
+                        },
+                        {
+                            "value": "PS",
+                            "label": "country_ps"
+                        },
+                        {
+                            "value": "PT",
+                            "label": "country_pt"
+                        },
+                        {
+                            "value": "PW",
+                            "label": "country_pw"
+                        },
+                        {
+                            "value": "PY",
+                            "label": "country_py"
+                        },
+                        {
+                            "value": "QA",
+                            "label": "country_qa"
+                        },
+                        {
+                            "value": "RE",
+                            "label": "country_re"
+                        },
+                        {
+                            "value": "RO",
+                            "label": "country_ro"
+                        },
+                        {
+                            "value": "RS",
+                            "label": "country_rs"
+                        },
+                        {
+                            "value": "RU",
+                            "label": "country_ru"
+                        },
+                        {
+                            "value": "RW",
+                            "label": "country_rw"
+                        },
+                        {
+                            "value": "SA",
+                            "label": "country_sa"
+                        },
+                        {
+                            "value": "SB",
+                            "label": "country_sb"
+                        },
+                        {
+                            "value": "SC",
+                            "label": "country_sc"
+                        },
+                        {
+                            "value": "SD",
+                            "label": "country_sd"
+                        },
+                        {
+                            "value": "SE",
+                            "label": "country_se"
+                        },
+                        {
+                            "value": "SG",
+                            "label": "country_sg"
+                        },
+                        {
+                            "value": "SH",
+                            "label": "country_sh"
+                        },
+                        {
+                            "value": "SI",
+                            "label": "country_si"
+                        },
+                        {
+                            "value": "SJ",
+                            "label": "country_sj"
+                        },
+                        {
+                            "value": "SK",
+                            "label": "country_sk"
+                        },
+                        {
+                            "value": "SL",
+                            "label": "country_sl"
+                        },
+                        {
+                            "value": "SM",
+                            "label": "country_sm"
+                        },
+                        {
+                            "value": "SN",
+                            "label": "country_sn"
+                        },
+                        {
+                            "value": "SO",
+                            "label": "country_so"
+                        },
+                        {
+                            "value": "SR",
+                            "label": "country_sr"
+                        },
+                        {
+                            "value": "SS",
+                            "label": "country_ss"
+                        },
+                        {
+                            "value": "ST",
+                            "label": "country_st"
+                        },
+                        {
+                            "value": "SV",
+                            "label": "country_sv"
+                        },
+                        {
+                            "value": "SX",
+                            "label": "country_sx"
+                        },
+                        {
+                            "value": "SY",
+                            "label": "country_sy"
+                        },
+                        {
+                            "value": "SZ",
+                            "label": "country_sz"
+                        },
+                        {
+                            "value": "TC",
+                            "label": "country_tc"
+                        },
+                        {
+                            "value": "TD",
+                            "label": "country_td"
+                        },
+                        {
+                            "value": "TF",
+                            "label": "country_tf"
+                        },
+                        {
+                            "value": "TG",
+                            "label": "country_tg"
+                        },
+                        {
+                            "value": "TH",
+                            "label": "country_th"
+                        },
+                        {
+                            "value": "TJ",
+                            "label": "country_tj"
+                        },
+                        {
+                            "value": "TK",
+                            "label": "country_tk"
+                        },
+                        {
+                            "value": "TL",
+                            "label": "country_tl"
+                        },
+                        {
+                            "value": "TM",
+                            "label": "country_tm"
+                        },
+                        {
+                            "value": "TN",
+                            "label": "country_tn"
+                        },
+                        {
+                            "value": "TO",
+                            "label": "country_to"
+                        },
+                        {
+                            "value": "TR",
+                            "label": "country_tr"
+                        },
+                        {
+                            "value": "TT",
+                            "label": "country_tt"
+                        },
+                        {
+                            "value": "TV",
+                            "label": "country_tv"
+                        },
+                        {
+                            "value": "TW",
+                            "label": "country_tw"
+                        },
+                        {
+                            "value": "TZ",
+                            "label": "country_tz"
+                        },
+                        {
+                            "value": "UA",
+                            "label": "country_ua"
+                        },
+                        {
+                            "value": "UG",
+                            "label": "country_ug"
+                        },
+                        {
+                            "value": "UM",
+                            "label": "country_um"
+                        },
+                        {
+                            "value": "US",
+                            "label": "country_us"
+                        },
+                        {
+                            "value": "UY",
+                            "label": "country_uy"
+                        },
+                        {
+                            "value": "UZ",
+                            "label": "country_uz"
+                        },
+                        {
+                            "value": "VA",
+                            "label": "country_va"
+                        },
+                        {
+                            "value": "VC",
+                            "label": "country_vc"
+                        },
+                        {
+                            "value": "VE",
+                            "label": "country_ve"
+                        },
+                        {
+                            "value": "VG",
+                            "label": "country_vg"
+                        },
+                        {
+                            "value": "VI",
+                            "label": "country_vi"
+                        },
+                        {
+                            "value": "VN",
+                            "label": "country_vn"
+                        },
+                        {
+                            "value": "VU",
+                            "label": "country_vu"
+                        },
+                        {
+                            "value": "WF",
+                            "label": "country_wf"
+                        },
+                        {
+                            "value": "WS",
+                            "label": "country_ws"
+                        },
+                        {
+                            "value": "XK",
+                            "label": "country_xk"
+                        },
+                        {
+                            "value": "YE",
+                            "label": "country_ye"
+                        },
+                        {
+                            "value": "YT",
+                            "label": "country_yt"
+                        },
+                        {
+                            "value": "ZA",
+                            "label": "country_za"
+                        },
+                        {
+                            "value": "ZM",
+                            "label": "country_zm"
+                        },
+                        {
+                            "value": "ZW",
+                            "label": "country_zw"
+                        }
+                    ],
+                    "label": "settings_product_country_of_origin",
+                    "description": "settings_product_country_of_origin_description"
+                },
+                {
+                    "name": "customsCode",
+                    "$component": "TextInput",
+                    "$attributes": {
+                        "maxlength": 10
+                    },
+                    "label": "settings_product_customs_code",
+                    "description": "settings_product_customs_code_description"
+                },
+                {
+                    "$component": "SettingsDivider",
+                    "$wrapper": false,
+                    "content": "settings_product_export_options_description",
+                    "heading": "settings_product_export_options_title",
+                    "level": 2
+                },
+                {
+                    "name": "exportAgeCheck",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_age_check",
+                    "description": "settings_product_export_age_check_description"
+                },
+                {
+                    "name": "exportReturn",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_return",
+                    "description": "settings_product_export_return_description"
+                },
+                {
+                    "name": "exportHideSender",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_hide_sender",
+                    "description": "settings_product_export_hide_sender_description"
+                },
+                {
+                    "name": "exportInsurance",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_insurance",
+                    "description": "settings_product_export_insurance_description"
+                },
+                {
+                    "name": "exportLargeFormat",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_large_format",
+                    "description": "settings_product_export_large_format_description"
+                },
+                {
+                    "name": "exportOnlyRecipient",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_only_recipient",
+                    "description": "settings_product_export_only_recipient_description"
+                },
+                {
+                    "name": "exportPriorityDelivery",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_priority_delivery",
+                    "description": "settings_product_export_priority_delivery_description"
+                },
+                {
+                    "name": "exportSignature",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_signature",
+                    "description": "settings_product_export_signature_description"
+                },
+                {
+                    "name": "exportTracked",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_tracked",
+                    "description": "settings_product_export_tracked_description"
+                },
+                {
+                    "name": "excludeParcelLockers",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_exclude_parcel_lockers",
+                    "description": "settings_product_exclude_parcel_lockers_description"
+                },
+                {
+                    "name": "exportFreshFood",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_fresh_food",
+                    "description": "settings_product_export_fresh_food_description"
+                },
+                {
+                    "name": "exportFrozen",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_frozen",
+                    "description": "settings_product_export_frozen_description"
+                },
+                {
+                    "name": "exportCooledDelivery",
+                    "$component": "TriStateInput",
+                    "label": "settings_product_export_cooled_delivery",
+                    "description": "settings_product_export_cooled_delivery_description"
+                }
+            ]
+        }
     }
-  }
 }

--- a/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_product_settings__1.json
+++ b/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_product_settings__1.json
@@ -1,1201 +1,1209 @@
 {
-  "id": "product",
-  "title": "settings_view_product_title",
-  "titleSuffix": null,
-  "description": "settings_view_product_description",
-  "elements": [
-    {
-      "$component": "SettingsDivider",
-      "$wrapper": false,
-      "content": "settings_product_myparcel_options_description",
-      "heading": "settings_product_myparcel_options_title",
-      "level": 2
-    },
-    {
-      "name": "packageType",
-      "$component": "SelectInput",
-      "options": [
+    "id": "product",
+    "title": "settings_view_product_title",
+    "titleSuffix": null,
+    "description": "settings_view_product_description",
+    "elements": [
         {
-          "value": -1,
-          "label": "settings_default"
+            "$component": "SettingsDivider",
+            "$wrapper": false,
+            "content": "settings_product_myparcel_options_description",
+            "heading": "settings_product_myparcel_options_title",
+            "level": 2
         },
         {
-          "value": "package",
-          "label": "package_type_package"
+            "name": "packageType",
+            "$component": "SelectInput",
+            "options": [
+                {
+                    "value": -1,
+                    "label": "settings_default"
+                },
+                {
+                    "value": "package",
+                    "label": "package_type_package"
+                },
+                {
+                    "value": "mailbox",
+                    "label": "package_type_mailbox"
+                },
+                {
+                    "value": "letter",
+                    "label": "package_type_letter"
+                },
+                {
+                    "value": "digital_stamp",
+                    "label": "package_type_digital_stamp"
+                },
+                {
+                    "value": "package_small",
+                    "label": "package_type_package_small"
+                },
+                {
+                    "value": "pallet",
+                    "label": "package_type_pallet"
+                },
+                {
+                    "value": "envelope",
+                    "label": "package_type_envelope"
+                }
+            ],
+            "label": "settings_product_package_type",
+            "description": "settings_product_package_type_description"
         },
         {
-          "value": "mailbox",
-          "label": "package_type_mailbox"
+            "name": "fitInMailbox",
+            "$component": "NumberInput",
+            "min": -1,
+            "label": "settings_product_fit_in_mailbox",
+            "description": "settings_product_fit_in_mailbox_description"
         },
         {
-          "value": "letter",
-          "label": "package_type_letter"
+            "$component": "SettingsDivider",
+            "$wrapper": false,
+            "content": "settings_product_delivery_options_description",
+            "heading": "settings_product_delivery_options_title",
+            "level": 2
         },
         {
-          "value": "digital_stamp",
-          "label": "package_type_digital_stamp"
+            "name": "dropOffDelay",
+            "$component": "NumberInput",
+            "$attributes": {
+                "min": -1,
+                "max": 14
+            },
+            "label": "settings_product_drop_off_delay",
+            "description": "settings_product_drop_off_delay_description"
         },
         {
-          "value": "package_small",
-          "label": "package_type_package_small"
+            "name": "disableDeliveryOptions",
+            "$component": "TriStateInput",
+            "label": "settings_product_disable_delivery_options",
+            "description": "settings_product_disable_delivery_options_description"
+        },
+        {
+            "name": "excludeParcelLockers",
+            "$component": "TriStateInput",
+            "label": "settings_product_exclude_parcel_lockers",
+            "description": "settings_product_exclude_parcel_lockers_description"
+        },
+        {
+            "$component": "SettingsDivider",
+            "$wrapper": false,
+            "content": "settings_product_customs_options_description",
+            "heading": "settings_product_customs_options_title",
+            "level": 2
+        },
+        {
+            "name": "countryOfOrigin",
+            "$component": "SelectInput",
+            "options": [
+                {
+                    "value": -1,
+                    "label": "settings_none"
+                },
+                {
+                    "value": "AD",
+                    "label": "country_ad"
+                },
+                {
+                    "value": "AE",
+                    "label": "country_ae"
+                },
+                {
+                    "value": "AF",
+                    "label": "country_af"
+                },
+                {
+                    "value": "AG",
+                    "label": "country_ag"
+                },
+                {
+                    "value": "AI",
+                    "label": "country_ai"
+                },
+                {
+                    "value": "AL",
+                    "label": "country_al"
+                },
+                {
+                    "value": "AM",
+                    "label": "country_am"
+                },
+                {
+                    "value": "AN",
+                    "label": "country_an"
+                },
+                {
+                    "value": "AO",
+                    "label": "country_ao"
+                },
+                {
+                    "value": "AQ",
+                    "label": "country_aq"
+                },
+                {
+                    "value": "AR",
+                    "label": "country_ar"
+                },
+                {
+                    "value": "AS",
+                    "label": "country_as"
+                },
+                {
+                    "value": "AT",
+                    "label": "country_at"
+                },
+                {
+                    "value": "AU",
+                    "label": "country_au"
+                },
+                {
+                    "value": "AW",
+                    "label": "country_aw"
+                },
+                {
+                    "value": "AX",
+                    "label": "country_ax"
+                },
+                {
+                    "value": "AZ",
+                    "label": "country_az"
+                },
+                {
+                    "value": "BA",
+                    "label": "country_ba"
+                },
+                {
+                    "value": "BB",
+                    "label": "country_bb"
+                },
+                {
+                    "value": "BD",
+                    "label": "country_bd"
+                },
+                {
+                    "value": "BE",
+                    "label": "country_be"
+                },
+                {
+                    "value": "BF",
+                    "label": "country_bf"
+                },
+                {
+                    "value": "BG",
+                    "label": "country_bg"
+                },
+                {
+                    "value": "BH",
+                    "label": "country_bh"
+                },
+                {
+                    "value": "BI",
+                    "label": "country_bi"
+                },
+                {
+                    "value": "BJ",
+                    "label": "country_bj"
+                },
+                {
+                    "value": "BL",
+                    "label": "country_bl"
+                },
+                {
+                    "value": "BM",
+                    "label": "country_bm"
+                },
+                {
+                    "value": "BN",
+                    "label": "country_bn"
+                },
+                {
+                    "value": "BO",
+                    "label": "country_bo"
+                },
+                {
+                    "value": "BQ",
+                    "label": "country_bq"
+                },
+                {
+                    "value": "BR",
+                    "label": "country_br"
+                },
+                {
+                    "value": "BS",
+                    "label": "country_bs"
+                },
+                {
+                    "value": "BT",
+                    "label": "country_bt"
+                },
+                {
+                    "value": "BV",
+                    "label": "country_bv"
+                },
+                {
+                    "value": "BW",
+                    "label": "country_bw"
+                },
+                {
+                    "value": "BY",
+                    "label": "country_by"
+                },
+                {
+                    "value": "BZ",
+                    "label": "country_bz"
+                },
+                {
+                    "value": "CA",
+                    "label": "country_ca"
+                },
+                {
+                    "value": "CC",
+                    "label": "country_cc"
+                },
+                {
+                    "value": "CD",
+                    "label": "country_cd"
+                },
+                {
+                    "value": "CF",
+                    "label": "country_cf"
+                },
+                {
+                    "value": "CG",
+                    "label": "country_cg"
+                },
+                {
+                    "value": "CH",
+                    "label": "country_ch"
+                },
+                {
+                    "value": "CI",
+                    "label": "country_ci"
+                },
+                {
+                    "value": "CK",
+                    "label": "country_ck"
+                },
+                {
+                    "value": "CL",
+                    "label": "country_cl"
+                },
+                {
+                    "value": "CM",
+                    "label": "country_cm"
+                },
+                {
+                    "value": "CN",
+                    "label": "country_cn"
+                },
+                {
+                    "value": "CO",
+                    "label": "country_co"
+                },
+                {
+                    "value": "CR",
+                    "label": "country_cr"
+                },
+                {
+                    "value": "CU",
+                    "label": "country_cu"
+                },
+                {
+                    "value": "CV",
+                    "label": "country_cv"
+                },
+                {
+                    "value": "CW",
+                    "label": "country_cw"
+                },
+                {
+                    "value": "CX",
+                    "label": "country_cx"
+                },
+                {
+                    "value": "CY",
+                    "label": "country_cy"
+                },
+                {
+                    "value": "CZ",
+                    "label": "country_cz"
+                },
+                {
+                    "value": "DE",
+                    "label": "country_de"
+                },
+                {
+                    "value": "DJ",
+                    "label": "country_dj"
+                },
+                {
+                    "value": "DK",
+                    "label": "country_dk"
+                },
+                {
+                    "value": "DM",
+                    "label": "country_dm"
+                },
+                {
+                    "value": "DO",
+                    "label": "country_do"
+                },
+                {
+                    "value": "DZ",
+                    "label": "country_dz"
+                },
+                {
+                    "value": "EC",
+                    "label": "country_ec"
+                },
+                {
+                    "value": "EE",
+                    "label": "country_ee"
+                },
+                {
+                    "value": "EG",
+                    "label": "country_eg"
+                },
+                {
+                    "value": "EH",
+                    "label": "country_eh"
+                },
+                {
+                    "value": "ER",
+                    "label": "country_er"
+                },
+                {
+                    "value": "ES",
+                    "label": "country_es"
+                },
+                {
+                    "value": "ET",
+                    "label": "country_et"
+                },
+                {
+                    "value": "FI",
+                    "label": "country_fi"
+                },
+                {
+                    "value": "FJ",
+                    "label": "country_fj"
+                },
+                {
+                    "value": "FK",
+                    "label": "country_fk"
+                },
+                {
+                    "value": "FM",
+                    "label": "country_fm"
+                },
+                {
+                    "value": "FO",
+                    "label": "country_fo"
+                },
+                {
+                    "value": "FR",
+                    "label": "country_fr"
+                },
+                {
+                    "value": "GA",
+                    "label": "country_ga"
+                },
+                {
+                    "value": "GB",
+                    "label": "country_gb"
+                },
+                {
+                    "value": "GD",
+                    "label": "country_gd"
+                },
+                {
+                    "value": "GE",
+                    "label": "country_ge"
+                },
+                {
+                    "value": "GF",
+                    "label": "country_gf"
+                },
+                {
+                    "value": "GG",
+                    "label": "country_gg"
+                },
+                {
+                    "value": "GH",
+                    "label": "country_gh"
+                },
+                {
+                    "value": "GI",
+                    "label": "country_gi"
+                },
+                {
+                    "value": "GL",
+                    "label": "country_gl"
+                },
+                {
+                    "value": "GM",
+                    "label": "country_gm"
+                },
+                {
+                    "value": "GN",
+                    "label": "country_gn"
+                },
+                {
+                    "value": "GP",
+                    "label": "country_gp"
+                },
+                {
+                    "value": "GQ",
+                    "label": "country_gq"
+                },
+                {
+                    "value": "GR",
+                    "label": "country_gr"
+                },
+                {
+                    "value": "GS",
+                    "label": "country_gs"
+                },
+                {
+                    "value": "GT",
+                    "label": "country_gt"
+                },
+                {
+                    "value": "GU",
+                    "label": "country_gu"
+                },
+                {
+                    "value": "GW",
+                    "label": "country_gw"
+                },
+                {
+                    "value": "GY",
+                    "label": "country_gy"
+                },
+                {
+                    "value": "HK",
+                    "label": "country_hk"
+                },
+                {
+                    "value": "HM",
+                    "label": "country_hm"
+                },
+                {
+                    "value": "HN",
+                    "label": "country_hn"
+                },
+                {
+                    "value": "HR",
+                    "label": "country_hr"
+                },
+                {
+                    "value": "HT",
+                    "label": "country_ht"
+                },
+                {
+                    "value": "HU",
+                    "label": "country_hu"
+                },
+                {
+                    "value": "ID",
+                    "label": "country_id"
+                },
+                {
+                    "value": "IE",
+                    "label": "country_ie"
+                },
+                {
+                    "value": "IL",
+                    "label": "country_il"
+                },
+                {
+                    "value": "IM",
+                    "label": "country_im"
+                },
+                {
+                    "value": "IN",
+                    "label": "country_in"
+                },
+                {
+                    "value": "IO",
+                    "label": "country_io"
+                },
+                {
+                    "value": "IQ",
+                    "label": "country_iq"
+                },
+                {
+                    "value": "IR",
+                    "label": "country_ir"
+                },
+                {
+                    "value": "IS",
+                    "label": "country_is"
+                },
+                {
+                    "value": "IT",
+                    "label": "country_it"
+                },
+                {
+                    "value": "JE",
+                    "label": "country_je"
+                },
+                {
+                    "value": "JM",
+                    "label": "country_jm"
+                },
+                {
+                    "value": "JO",
+                    "label": "country_jo"
+                },
+                {
+                    "value": "JP",
+                    "label": "country_jp"
+                },
+                {
+                    "value": "KE",
+                    "label": "country_ke"
+                },
+                {
+                    "value": "KG",
+                    "label": "country_kg"
+                },
+                {
+                    "value": "KH",
+                    "label": "country_kh"
+                },
+                {
+                    "value": "KI",
+                    "label": "country_ki"
+                },
+                {
+                    "value": "KM",
+                    "label": "country_km"
+                },
+                {
+                    "value": "KN",
+                    "label": "country_kn"
+                },
+                {
+                    "value": "KP",
+                    "label": "country_kp"
+                },
+                {
+                    "value": "KR",
+                    "label": "country_kr"
+                },
+                {
+                    "value": "KW",
+                    "label": "country_kw"
+                },
+                {
+                    "value": "KY",
+                    "label": "country_ky"
+                },
+                {
+                    "value": "KZ",
+                    "label": "country_kz"
+                },
+                {
+                    "value": "LA",
+                    "label": "country_la"
+                },
+                {
+                    "value": "LB",
+                    "label": "country_lb"
+                },
+                {
+                    "value": "LC",
+                    "label": "country_lc"
+                },
+                {
+                    "value": "LI",
+                    "label": "country_li"
+                },
+                {
+                    "value": "LK",
+                    "label": "country_lk"
+                },
+                {
+                    "value": "LR",
+                    "label": "country_lr"
+                },
+                {
+                    "value": "LS",
+                    "label": "country_ls"
+                },
+                {
+                    "value": "LT",
+                    "label": "country_lt"
+                },
+                {
+                    "value": "LU",
+                    "label": "country_lu"
+                },
+                {
+                    "value": "LV",
+                    "label": "country_lv"
+                },
+                {
+                    "value": "LY",
+                    "label": "country_ly"
+                },
+                {
+                    "value": "MA",
+                    "label": "country_ma"
+                },
+                {
+                    "value": "MC",
+                    "label": "country_mc"
+                },
+                {
+                    "value": "MD",
+                    "label": "country_md"
+                },
+                {
+                    "value": "ME",
+                    "label": "country_me"
+                },
+                {
+                    "value": "MF",
+                    "label": "country_mf"
+                },
+                {
+                    "value": "MG",
+                    "label": "country_mg"
+                },
+                {
+                    "value": "MH",
+                    "label": "country_mh"
+                },
+                {
+                    "value": "MK",
+                    "label": "country_mk"
+                },
+                {
+                    "value": "ML",
+                    "label": "country_ml"
+                },
+                {
+                    "value": "MM",
+                    "label": "country_mm"
+                },
+                {
+                    "value": "MN",
+                    "label": "country_mn"
+                },
+                {
+                    "value": "MO",
+                    "label": "country_mo"
+                },
+                {
+                    "value": "MP",
+                    "label": "country_mp"
+                },
+                {
+                    "value": "MQ",
+                    "label": "country_mq"
+                },
+                {
+                    "value": "MR",
+                    "label": "country_mr"
+                },
+                {
+                    "value": "MS",
+                    "label": "country_ms"
+                },
+                {
+                    "value": "MT",
+                    "label": "country_mt"
+                },
+                {
+                    "value": "MU",
+                    "label": "country_mu"
+                },
+                {
+                    "value": "MV",
+                    "label": "country_mv"
+                },
+                {
+                    "value": "MW",
+                    "label": "country_mw"
+                },
+                {
+                    "value": "MX",
+                    "label": "country_mx"
+                },
+                {
+                    "value": "MY",
+                    "label": "country_my"
+                },
+                {
+                    "value": "MZ",
+                    "label": "country_mz"
+                },
+                {
+                    "value": "NA",
+                    "label": "country_na"
+                },
+                {
+                    "value": "NC",
+                    "label": "country_nc"
+                },
+                {
+                    "value": "NE",
+                    "label": "country_ne"
+                },
+                {
+                    "value": "NF",
+                    "label": "country_nf"
+                },
+                {
+                    "value": "NG",
+                    "label": "country_ng"
+                },
+                {
+                    "value": "NI",
+                    "label": "country_ni"
+                },
+                {
+                    "value": "NL",
+                    "label": "country_nl"
+                },
+                {
+                    "value": "NO",
+                    "label": "country_no"
+                },
+                {
+                    "value": "NP",
+                    "label": "country_np"
+                },
+                {
+                    "value": "NR",
+                    "label": "country_nr"
+                },
+                {
+                    "value": "NU",
+                    "label": "country_nu"
+                },
+                {
+                    "value": "NZ",
+                    "label": "country_nz"
+                },
+                {
+                    "value": "OM",
+                    "label": "country_om"
+                },
+                {
+                    "value": "PA",
+                    "label": "country_pa"
+                },
+                {
+                    "value": "PE",
+                    "label": "country_pe"
+                },
+                {
+                    "value": "PF",
+                    "label": "country_pf"
+                },
+                {
+                    "value": "PG",
+                    "label": "country_pg"
+                },
+                {
+                    "value": "PH",
+                    "label": "country_ph"
+                },
+                {
+                    "value": "PK",
+                    "label": "country_pk"
+                },
+                {
+                    "value": "PL",
+                    "label": "country_pl"
+                },
+                {
+                    "value": "PM",
+                    "label": "country_pm"
+                },
+                {
+                    "value": "PN",
+                    "label": "country_pn"
+                },
+                {
+                    "value": "PR",
+                    "label": "country_pr"
+                },
+                {
+                    "value": "PS",
+                    "label": "country_ps"
+                },
+                {
+                    "value": "PT",
+                    "label": "country_pt"
+                },
+                {
+                    "value": "PW",
+                    "label": "country_pw"
+                },
+                {
+                    "value": "PY",
+                    "label": "country_py"
+                },
+                {
+                    "value": "QA",
+                    "label": "country_qa"
+                },
+                {
+                    "value": "RE",
+                    "label": "country_re"
+                },
+                {
+                    "value": "RO",
+                    "label": "country_ro"
+                },
+                {
+                    "value": "RS",
+                    "label": "country_rs"
+                },
+                {
+                    "value": "RU",
+                    "label": "country_ru"
+                },
+                {
+                    "value": "RW",
+                    "label": "country_rw"
+                },
+                {
+                    "value": "SA",
+                    "label": "country_sa"
+                },
+                {
+                    "value": "SB",
+                    "label": "country_sb"
+                },
+                {
+                    "value": "SC",
+                    "label": "country_sc"
+                },
+                {
+                    "value": "SD",
+                    "label": "country_sd"
+                },
+                {
+                    "value": "SE",
+                    "label": "country_se"
+                },
+                {
+                    "value": "SG",
+                    "label": "country_sg"
+                },
+                {
+                    "value": "SH",
+                    "label": "country_sh"
+                },
+                {
+                    "value": "SI",
+                    "label": "country_si"
+                },
+                {
+                    "value": "SJ",
+                    "label": "country_sj"
+                },
+                {
+                    "value": "SK",
+                    "label": "country_sk"
+                },
+                {
+                    "value": "SL",
+                    "label": "country_sl"
+                },
+                {
+                    "value": "SM",
+                    "label": "country_sm"
+                },
+                {
+                    "value": "SN",
+                    "label": "country_sn"
+                },
+                {
+                    "value": "SO",
+                    "label": "country_so"
+                },
+                {
+                    "value": "SR",
+                    "label": "country_sr"
+                },
+                {
+                    "value": "SS",
+                    "label": "country_ss"
+                },
+                {
+                    "value": "ST",
+                    "label": "country_st"
+                },
+                {
+                    "value": "SV",
+                    "label": "country_sv"
+                },
+                {
+                    "value": "SX",
+                    "label": "country_sx"
+                },
+                {
+                    "value": "SY",
+                    "label": "country_sy"
+                },
+                {
+                    "value": "SZ",
+                    "label": "country_sz"
+                },
+                {
+                    "value": "TC",
+                    "label": "country_tc"
+                },
+                {
+                    "value": "TD",
+                    "label": "country_td"
+                },
+                {
+                    "value": "TF",
+                    "label": "country_tf"
+                },
+                {
+                    "value": "TG",
+                    "label": "country_tg"
+                },
+                {
+                    "value": "TH",
+                    "label": "country_th"
+                },
+                {
+                    "value": "TJ",
+                    "label": "country_tj"
+                },
+                {
+                    "value": "TK",
+                    "label": "country_tk"
+                },
+                {
+                    "value": "TL",
+                    "label": "country_tl"
+                },
+                {
+                    "value": "TM",
+                    "label": "country_tm"
+                },
+                {
+                    "value": "TN",
+                    "label": "country_tn"
+                },
+                {
+                    "value": "TO",
+                    "label": "country_to"
+                },
+                {
+                    "value": "TR",
+                    "label": "country_tr"
+                },
+                {
+                    "value": "TT",
+                    "label": "country_tt"
+                },
+                {
+                    "value": "TV",
+                    "label": "country_tv"
+                },
+                {
+                    "value": "TW",
+                    "label": "country_tw"
+                },
+                {
+                    "value": "TZ",
+                    "label": "country_tz"
+                },
+                {
+                    "value": "UA",
+                    "label": "country_ua"
+                },
+                {
+                    "value": "UG",
+                    "label": "country_ug"
+                },
+                {
+                    "value": "UM",
+                    "label": "country_um"
+                },
+                {
+                    "value": "US",
+                    "label": "country_us"
+                },
+                {
+                    "value": "UY",
+                    "label": "country_uy"
+                },
+                {
+                    "value": "UZ",
+                    "label": "country_uz"
+                },
+                {
+                    "value": "VA",
+                    "label": "country_va"
+                },
+                {
+                    "value": "VC",
+                    "label": "country_vc"
+                },
+                {
+                    "value": "VE",
+                    "label": "country_ve"
+                },
+                {
+                    "value": "VG",
+                    "label": "country_vg"
+                },
+                {
+                    "value": "VI",
+                    "label": "country_vi"
+                },
+                {
+                    "value": "VN",
+                    "label": "country_vn"
+                },
+                {
+                    "value": "VU",
+                    "label": "country_vu"
+                },
+                {
+                    "value": "WF",
+                    "label": "country_wf"
+                },
+                {
+                    "value": "WS",
+                    "label": "country_ws"
+                },
+                {
+                    "value": "XK",
+                    "label": "country_xk"
+                },
+                {
+                    "value": "YE",
+                    "label": "country_ye"
+                },
+                {
+                    "value": "YT",
+                    "label": "country_yt"
+                },
+                {
+                    "value": "ZA",
+                    "label": "country_za"
+                },
+                {
+                    "value": "ZM",
+                    "label": "country_zm"
+                },
+                {
+                    "value": "ZW",
+                    "label": "country_zw"
+                }
+            ],
+            "label": "settings_product_country_of_origin",
+            "description": "settings_product_country_of_origin_description"
+        },
+        {
+            "name": "customsCode",
+            "$component": "TextInput",
+            "$attributes": {
+                "maxlength": 10
+            },
+            "label": "settings_product_customs_code",
+            "description": "settings_product_customs_code_description"
+        },
+        {
+            "$component": "SettingsDivider",
+            "$wrapper": false,
+            "content": "settings_product_export_options_description",
+            "heading": "settings_product_export_options_title",
+            "level": 2
+        },
+        {
+            "name": "exportAgeCheck",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_age_check",
+            "description": "settings_product_export_age_check_description"
+        },
+        {
+            "name": "exportReturn",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_return",
+            "description": "settings_product_export_return_description"
+        },
+        {
+            "name": "exportHideSender",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_hide_sender",
+            "description": "settings_product_export_hide_sender_description"
+        },
+        {
+            "name": "exportInsurance",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_insurance",
+            "description": "settings_product_export_insurance_description"
+        },
+        {
+            "name": "exportLargeFormat",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_large_format",
+            "description": "settings_product_export_large_format_description"
+        },
+        {
+            "name": "exportOnlyRecipient",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_only_recipient",
+            "description": "settings_product_export_only_recipient_description"
+        },
+        {
+            "name": "exportPriorityDelivery",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_priority_delivery",
+            "description": "settings_product_export_priority_delivery_description"
+        },
+        {
+            "name": "exportSignature",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_signature",
+            "description": "settings_product_export_signature_description"
+        },
+        {
+            "name": "exportTracked",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_tracked",
+            "description": "settings_product_export_tracked_description"
+        },
+        {
+            "name": "excludeParcelLockers",
+            "$component": "TriStateInput",
+            "label": "settings_product_exclude_parcel_lockers",
+            "description": "settings_product_exclude_parcel_lockers_description"
+        },
+        {
+            "name": "exportFreshFood",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_fresh_food",
+            "description": "settings_product_export_fresh_food_description"
+        },
+        {
+            "name": "exportFrozen",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_frozen",
+            "description": "settings_product_export_frozen_description"
+        },
+        {
+            "name": "exportCooledDelivery",
+            "$component": "TriStateInput",
+            "label": "settings_product_export_cooled_delivery",
+            "description": "settings_product_export_cooled_delivery_description"
         }
-      ],
-      "label": "settings_product_package_type",
-      "description": "settings_product_package_type_description"
-    },
-    {
-      "name": "fitInMailbox",
-      "$component": "NumberInput",
-      "min": -1,
-      "label": "settings_product_fit_in_mailbox",
-      "description": "settings_product_fit_in_mailbox_description"
-    },
-    {
-      "$component": "SettingsDivider",
-      "$wrapper": false,
-      "content": "settings_product_delivery_options_description",
-      "heading": "settings_product_delivery_options_title",
-      "level": 2
-    },
-    {
-      "name": "dropOffDelay",
-      "$component": "NumberInput",
-      "$attributes": {
-        "min": -1,
-        "max": 14
-      },
-      "label": "settings_product_drop_off_delay",
-      "description": "settings_product_drop_off_delay_description"
-    },
-    {
-      "name": "disableDeliveryOptions",
-      "$component": "TriStateInput",
-      "label": "settings_product_disable_delivery_options",
-      "description": "settings_product_disable_delivery_options_description"
-    },
-    {
-      "name": "excludeParcelLockers",
-      "$component": "TriStateInput",
-      "label": "settings_product_exclude_parcel_lockers",
-      "description": "settings_product_exclude_parcel_lockers_description"
-    },
-    {
-      "$component": "SettingsDivider",
-      "$wrapper": false,
-      "content": "settings_product_customs_options_description",
-      "heading": "settings_product_customs_options_title",
-      "level": 2
-    },
-    {
-      "name": "countryOfOrigin",
-      "$component": "SelectInput",
-      "options": [
-        {
-          "value": -1,
-          "label": "settings_none"
-        },
-        {
-          "value": "AD",
-          "label": "country_ad"
-        },
-        {
-          "value": "AE",
-          "label": "country_ae"
-        },
-        {
-          "value": "AF",
-          "label": "country_af"
-        },
-        {
-          "value": "AG",
-          "label": "country_ag"
-        },
-        {
-          "value": "AI",
-          "label": "country_ai"
-        },
-        {
-          "value": "AL",
-          "label": "country_al"
-        },
-        {
-          "value": "AM",
-          "label": "country_am"
-        },
-        {
-          "value": "AN",
-          "label": "country_an"
-        },
-        {
-          "value": "AO",
-          "label": "country_ao"
-        },
-        {
-          "value": "AQ",
-          "label": "country_aq"
-        },
-        {
-          "value": "AR",
-          "label": "country_ar"
-        },
-        {
-          "value": "AS",
-          "label": "country_as"
-        },
-        {
-          "value": "AT",
-          "label": "country_at"
-        },
-        {
-          "value": "AU",
-          "label": "country_au"
-        },
-        {
-          "value": "AW",
-          "label": "country_aw"
-        },
-        {
-          "value": "AX",
-          "label": "country_ax"
-        },
-        {
-          "value": "AZ",
-          "label": "country_az"
-        },
-        {
-          "value": "BA",
-          "label": "country_ba"
-        },
-        {
-          "value": "BB",
-          "label": "country_bb"
-        },
-        {
-          "value": "BD",
-          "label": "country_bd"
-        },
-        {
-          "value": "BE",
-          "label": "country_be"
-        },
-        {
-          "value": "BF",
-          "label": "country_bf"
-        },
-        {
-          "value": "BG",
-          "label": "country_bg"
-        },
-        {
-          "value": "BH",
-          "label": "country_bh"
-        },
-        {
-          "value": "BI",
-          "label": "country_bi"
-        },
-        {
-          "value": "BJ",
-          "label": "country_bj"
-        },
-        {
-          "value": "BL",
-          "label": "country_bl"
-        },
-        {
-          "value": "BM",
-          "label": "country_bm"
-        },
-        {
-          "value": "BN",
-          "label": "country_bn"
-        },
-        {
-          "value": "BO",
-          "label": "country_bo"
-        },
-        {
-          "value": "BQ",
-          "label": "country_bq"
-        },
-        {
-          "value": "BR",
-          "label": "country_br"
-        },
-        {
-          "value": "BS",
-          "label": "country_bs"
-        },
-        {
-          "value": "BT",
-          "label": "country_bt"
-        },
-        {
-          "value": "BV",
-          "label": "country_bv"
-        },
-        {
-          "value": "BW",
-          "label": "country_bw"
-        },
-        {
-          "value": "BY",
-          "label": "country_by"
-        },
-        {
-          "value": "BZ",
-          "label": "country_bz"
-        },
-        {
-          "value": "CA",
-          "label": "country_ca"
-        },
-        {
-          "value": "CC",
-          "label": "country_cc"
-        },
-        {
-          "value": "CD",
-          "label": "country_cd"
-        },
-        {
-          "value": "CF",
-          "label": "country_cf"
-        },
-        {
-          "value": "CG",
-          "label": "country_cg"
-        },
-        {
-          "value": "CH",
-          "label": "country_ch"
-        },
-        {
-          "value": "CI",
-          "label": "country_ci"
-        },
-        {
-          "value": "CK",
-          "label": "country_ck"
-        },
-        {
-          "value": "CL",
-          "label": "country_cl"
-        },
-        {
-          "value": "CM",
-          "label": "country_cm"
-        },
-        {
-          "value": "CN",
-          "label": "country_cn"
-        },
-        {
-          "value": "CO",
-          "label": "country_co"
-        },
-        {
-          "value": "CR",
-          "label": "country_cr"
-        },
-        {
-          "value": "CU",
-          "label": "country_cu"
-        },
-        {
-          "value": "CV",
-          "label": "country_cv"
-        },
-        {
-          "value": "CW",
-          "label": "country_cw"
-        },
-        {
-          "value": "CX",
-          "label": "country_cx"
-        },
-        {
-          "value": "CY",
-          "label": "country_cy"
-        },
-        {
-          "value": "CZ",
-          "label": "country_cz"
-        },
-        {
-          "value": "DE",
-          "label": "country_de"
-        },
-        {
-          "value": "DJ",
-          "label": "country_dj"
-        },
-        {
-          "value": "DK",
-          "label": "country_dk"
-        },
-        {
-          "value": "DM",
-          "label": "country_dm"
-        },
-        {
-          "value": "DO",
-          "label": "country_do"
-        },
-        {
-          "value": "DZ",
-          "label": "country_dz"
-        },
-        {
-          "value": "EC",
-          "label": "country_ec"
-        },
-        {
-          "value": "EE",
-          "label": "country_ee"
-        },
-        {
-          "value": "EG",
-          "label": "country_eg"
-        },
-        {
-          "value": "EH",
-          "label": "country_eh"
-        },
-        {
-          "value": "ER",
-          "label": "country_er"
-        },
-        {
-          "value": "ES",
-          "label": "country_es"
-        },
-        {
-          "value": "ET",
-          "label": "country_et"
-        },
-        {
-          "value": "FI",
-          "label": "country_fi"
-        },
-        {
-          "value": "FJ",
-          "label": "country_fj"
-        },
-        {
-          "value": "FK",
-          "label": "country_fk"
-        },
-        {
-          "value": "FM",
-          "label": "country_fm"
-        },
-        {
-          "value": "FO",
-          "label": "country_fo"
-        },
-        {
-          "value": "FR",
-          "label": "country_fr"
-        },
-        {
-          "value": "GA",
-          "label": "country_ga"
-        },
-        {
-          "value": "GB",
-          "label": "country_gb"
-        },
-        {
-          "value": "GD",
-          "label": "country_gd"
-        },
-        {
-          "value": "GE",
-          "label": "country_ge"
-        },
-        {
-          "value": "GF",
-          "label": "country_gf"
-        },
-        {
-          "value": "GG",
-          "label": "country_gg"
-        },
-        {
-          "value": "GH",
-          "label": "country_gh"
-        },
-        {
-          "value": "GI",
-          "label": "country_gi"
-        },
-        {
-          "value": "GL",
-          "label": "country_gl"
-        },
-        {
-          "value": "GM",
-          "label": "country_gm"
-        },
-        {
-          "value": "GN",
-          "label": "country_gn"
-        },
-        {
-          "value": "GP",
-          "label": "country_gp"
-        },
-        {
-          "value": "GQ",
-          "label": "country_gq"
-        },
-        {
-          "value": "GR",
-          "label": "country_gr"
-        },
-        {
-          "value": "GS",
-          "label": "country_gs"
-        },
-        {
-          "value": "GT",
-          "label": "country_gt"
-        },
-        {
-          "value": "GU",
-          "label": "country_gu"
-        },
-        {
-          "value": "GW",
-          "label": "country_gw"
-        },
-        {
-          "value": "GY",
-          "label": "country_gy"
-        },
-        {
-          "value": "HK",
-          "label": "country_hk"
-        },
-        {
-          "value": "HM",
-          "label": "country_hm"
-        },
-        {
-          "value": "HN",
-          "label": "country_hn"
-        },
-        {
-          "value": "HR",
-          "label": "country_hr"
-        },
-        {
-          "value": "HT",
-          "label": "country_ht"
-        },
-        {
-          "value": "HU",
-          "label": "country_hu"
-        },
-        {
-          "value": "ID",
-          "label": "country_id"
-        },
-        {
-          "value": "IE",
-          "label": "country_ie"
-        },
-        {
-          "value": "IL",
-          "label": "country_il"
-        },
-        {
-          "value": "IM",
-          "label": "country_im"
-        },
-        {
-          "value": "IN",
-          "label": "country_in"
-        },
-        {
-          "value": "IO",
-          "label": "country_io"
-        },
-        {
-          "value": "IQ",
-          "label": "country_iq"
-        },
-        {
-          "value": "IR",
-          "label": "country_ir"
-        },
-        {
-          "value": "IS",
-          "label": "country_is"
-        },
-        {
-          "value": "IT",
-          "label": "country_it"
-        },
-        {
-          "value": "JE",
-          "label": "country_je"
-        },
-        {
-          "value": "JM",
-          "label": "country_jm"
-        },
-        {
-          "value": "JO",
-          "label": "country_jo"
-        },
-        {
-          "value": "JP",
-          "label": "country_jp"
-        },
-        {
-          "value": "KE",
-          "label": "country_ke"
-        },
-        {
-          "value": "KG",
-          "label": "country_kg"
-        },
-        {
-          "value": "KH",
-          "label": "country_kh"
-        },
-        {
-          "value": "KI",
-          "label": "country_ki"
-        },
-        {
-          "value": "KM",
-          "label": "country_km"
-        },
-        {
-          "value": "KN",
-          "label": "country_kn"
-        },
-        {
-          "value": "KP",
-          "label": "country_kp"
-        },
-        {
-          "value": "KR",
-          "label": "country_kr"
-        },
-        {
-          "value": "KW",
-          "label": "country_kw"
-        },
-        {
-          "value": "KY",
-          "label": "country_ky"
-        },
-        {
-          "value": "KZ",
-          "label": "country_kz"
-        },
-        {
-          "value": "LA",
-          "label": "country_la"
-        },
-        {
-          "value": "LB",
-          "label": "country_lb"
-        },
-        {
-          "value": "LC",
-          "label": "country_lc"
-        },
-        {
-          "value": "LI",
-          "label": "country_li"
-        },
-        {
-          "value": "LK",
-          "label": "country_lk"
-        },
-        {
-          "value": "LR",
-          "label": "country_lr"
-        },
-        {
-          "value": "LS",
-          "label": "country_ls"
-        },
-        {
-          "value": "LT",
-          "label": "country_lt"
-        },
-        {
-          "value": "LU",
-          "label": "country_lu"
-        },
-        {
-          "value": "LV",
-          "label": "country_lv"
-        },
-        {
-          "value": "LY",
-          "label": "country_ly"
-        },
-        {
-          "value": "MA",
-          "label": "country_ma"
-        },
-        {
-          "value": "MC",
-          "label": "country_mc"
-        },
-        {
-          "value": "MD",
-          "label": "country_md"
-        },
-        {
-          "value": "ME",
-          "label": "country_me"
-        },
-        {
-          "value": "MF",
-          "label": "country_mf"
-        },
-        {
-          "value": "MG",
-          "label": "country_mg"
-        },
-        {
-          "value": "MH",
-          "label": "country_mh"
-        },
-        {
-          "value": "MK",
-          "label": "country_mk"
-        },
-        {
-          "value": "ML",
-          "label": "country_ml"
-        },
-        {
-          "value": "MM",
-          "label": "country_mm"
-        },
-        {
-          "value": "MN",
-          "label": "country_mn"
-        },
-        {
-          "value": "MO",
-          "label": "country_mo"
-        },
-        {
-          "value": "MP",
-          "label": "country_mp"
-        },
-        {
-          "value": "MQ",
-          "label": "country_mq"
-        },
-        {
-          "value": "MR",
-          "label": "country_mr"
-        },
-        {
-          "value": "MS",
-          "label": "country_ms"
-        },
-        {
-          "value": "MT",
-          "label": "country_mt"
-        },
-        {
-          "value": "MU",
-          "label": "country_mu"
-        },
-        {
-          "value": "MV",
-          "label": "country_mv"
-        },
-        {
-          "value": "MW",
-          "label": "country_mw"
-        },
-        {
-          "value": "MX",
-          "label": "country_mx"
-        },
-        {
-          "value": "MY",
-          "label": "country_my"
-        },
-        {
-          "value": "MZ",
-          "label": "country_mz"
-        },
-        {
-          "value": "NA",
-          "label": "country_na"
-        },
-        {
-          "value": "NC",
-          "label": "country_nc"
-        },
-        {
-          "value": "NE",
-          "label": "country_ne"
-        },
-        {
-          "value": "NF",
-          "label": "country_nf"
-        },
-        {
-          "value": "NG",
-          "label": "country_ng"
-        },
-        {
-          "value": "NI",
-          "label": "country_ni"
-        },
-        {
-          "value": "NL",
-          "label": "country_nl"
-        },
-        {
-          "value": "NO",
-          "label": "country_no"
-        },
-        {
-          "value": "NP",
-          "label": "country_np"
-        },
-        {
-          "value": "NR",
-          "label": "country_nr"
-        },
-        {
-          "value": "NU",
-          "label": "country_nu"
-        },
-        {
-          "value": "NZ",
-          "label": "country_nz"
-        },
-        {
-          "value": "OM",
-          "label": "country_om"
-        },
-        {
-          "value": "PA",
-          "label": "country_pa"
-        },
-        {
-          "value": "PE",
-          "label": "country_pe"
-        },
-        {
-          "value": "PF",
-          "label": "country_pf"
-        },
-        {
-          "value": "PG",
-          "label": "country_pg"
-        },
-        {
-          "value": "PH",
-          "label": "country_ph"
-        },
-        {
-          "value": "PK",
-          "label": "country_pk"
-        },
-        {
-          "value": "PL",
-          "label": "country_pl"
-        },
-        {
-          "value": "PM",
-          "label": "country_pm"
-        },
-        {
-          "value": "PN",
-          "label": "country_pn"
-        },
-        {
-          "value": "PR",
-          "label": "country_pr"
-        },
-        {
-          "value": "PS",
-          "label": "country_ps"
-        },
-        {
-          "value": "PT",
-          "label": "country_pt"
-        },
-        {
-          "value": "PW",
-          "label": "country_pw"
-        },
-        {
-          "value": "PY",
-          "label": "country_py"
-        },
-        {
-          "value": "QA",
-          "label": "country_qa"
-        },
-        {
-          "value": "RE",
-          "label": "country_re"
-        },
-        {
-          "value": "RO",
-          "label": "country_ro"
-        },
-        {
-          "value": "RS",
-          "label": "country_rs"
-        },
-        {
-          "value": "RU",
-          "label": "country_ru"
-        },
-        {
-          "value": "RW",
-          "label": "country_rw"
-        },
-        {
-          "value": "SA",
-          "label": "country_sa"
-        },
-        {
-          "value": "SB",
-          "label": "country_sb"
-        },
-        {
-          "value": "SC",
-          "label": "country_sc"
-        },
-        {
-          "value": "SD",
-          "label": "country_sd"
-        },
-        {
-          "value": "SE",
-          "label": "country_se"
-        },
-        {
-          "value": "SG",
-          "label": "country_sg"
-        },
-        {
-          "value": "SH",
-          "label": "country_sh"
-        },
-        {
-          "value": "SI",
-          "label": "country_si"
-        },
-        {
-          "value": "SJ",
-          "label": "country_sj"
-        },
-        {
-          "value": "SK",
-          "label": "country_sk"
-        },
-        {
-          "value": "SL",
-          "label": "country_sl"
-        },
-        {
-          "value": "SM",
-          "label": "country_sm"
-        },
-        {
-          "value": "SN",
-          "label": "country_sn"
-        },
-        {
-          "value": "SO",
-          "label": "country_so"
-        },
-        {
-          "value": "SR",
-          "label": "country_sr"
-        },
-        {
-          "value": "SS",
-          "label": "country_ss"
-        },
-        {
-          "value": "ST",
-          "label": "country_st"
-        },
-        {
-          "value": "SV",
-          "label": "country_sv"
-        },
-        {
-          "value": "SX",
-          "label": "country_sx"
-        },
-        {
-          "value": "SY",
-          "label": "country_sy"
-        },
-        {
-          "value": "SZ",
-          "label": "country_sz"
-        },
-        {
-          "value": "TC",
-          "label": "country_tc"
-        },
-        {
-          "value": "TD",
-          "label": "country_td"
-        },
-        {
-          "value": "TF",
-          "label": "country_tf"
-        },
-        {
-          "value": "TG",
-          "label": "country_tg"
-        },
-        {
-          "value": "TH",
-          "label": "country_th"
-        },
-        {
-          "value": "TJ",
-          "label": "country_tj"
-        },
-        {
-          "value": "TK",
-          "label": "country_tk"
-        },
-        {
-          "value": "TL",
-          "label": "country_tl"
-        },
-        {
-          "value": "TM",
-          "label": "country_tm"
-        },
-        {
-          "value": "TN",
-          "label": "country_tn"
-        },
-        {
-          "value": "TO",
-          "label": "country_to"
-        },
-        {
-          "value": "TR",
-          "label": "country_tr"
-        },
-        {
-          "value": "TT",
-          "label": "country_tt"
-        },
-        {
-          "value": "TV",
-          "label": "country_tv"
-        },
-        {
-          "value": "TW",
-          "label": "country_tw"
-        },
-        {
-          "value": "TZ",
-          "label": "country_tz"
-        },
-        {
-          "value": "UA",
-          "label": "country_ua"
-        },
-        {
-          "value": "UG",
-          "label": "country_ug"
-        },
-        {
-          "value": "UM",
-          "label": "country_um"
-        },
-        {
-          "value": "US",
-          "label": "country_us"
-        },
-        {
-          "value": "UY",
-          "label": "country_uy"
-        },
-        {
-          "value": "UZ",
-          "label": "country_uz"
-        },
-        {
-          "value": "VA",
-          "label": "country_va"
-        },
-        {
-          "value": "VC",
-          "label": "country_vc"
-        },
-        {
-          "value": "VE",
-          "label": "country_ve"
-        },
-        {
-          "value": "VG",
-          "label": "country_vg"
-        },
-        {
-          "value": "VI",
-          "label": "country_vi"
-        },
-        {
-          "value": "VN",
-          "label": "country_vn"
-        },
-        {
-          "value": "VU",
-          "label": "country_vu"
-        },
-        {
-          "value": "WF",
-          "label": "country_wf"
-        },
-        {
-          "value": "WS",
-          "label": "country_ws"
-        },
-        {
-          "value": "XK",
-          "label": "country_xk"
-        },
-        {
-          "value": "YE",
-          "label": "country_ye"
-        },
-        {
-          "value": "YT",
-          "label": "country_yt"
-        },
-        {
-          "value": "ZA",
-          "label": "country_za"
-        },
-        {
-          "value": "ZM",
-          "label": "country_zm"
-        },
-        {
-          "value": "ZW",
-          "label": "country_zw"
-        }
-      ],
-      "label": "settings_product_country_of_origin",
-      "description": "settings_product_country_of_origin_description"
-    },
-    {
-      "name": "customsCode",
-      "$component": "TextInput",
-      "$attributes": {
-        "maxlength": 10
-      },
-      "label": "settings_product_customs_code",
-      "description": "settings_product_customs_code_description"
-    },
-    {
-      "$component": "SettingsDivider",
-      "$wrapper": false,
-      "content": "settings_product_export_options_description",
-      "heading": "settings_product_export_options_title",
-      "level": 2
-    },
-    {
-      "name": "exportAgeCheck",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_age_check",
-      "description": "settings_product_export_age_check_description"
-    },
-    {
-      "name": "exportReturn",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_return",
-      "description": "settings_product_export_return_description"
-    },
-    {
-      "name": "exportHideSender",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_hide_sender",
-      "description": "settings_product_export_hide_sender_description"
-    },
-    {
-      "name": "exportInsurance",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_insurance",
-      "description": "settings_product_export_insurance_description"
-    },
-    {
-      "name": "exportLargeFormat",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_large_format",
-      "description": "settings_product_export_large_format_description"
-    },
-    {
-      "name": "exportOnlyRecipient",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_only_recipient",
-      "description": "settings_product_export_only_recipient_description"
-    },
-    {
-      "name": "exportPriorityDelivery",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_priority_delivery",
-      "description": "settings_product_export_priority_delivery_description"
-    },
-    {
-      "name": "exportSignature",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_signature",
-      "description": "settings_product_export_signature_description"
-    },
-    {
-      "name": "exportTracked",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_tracked",
-      "description": "settings_product_export_tracked_description"
-    },
-    {
-      "name": "excludeParcelLockers",
-      "$component": "TriStateInput",
-      "label": "settings_product_exclude_parcel_lockers",
-      "description": "settings_product_exclude_parcel_lockers_description"
-    },
-    {
-      "name": "exportFreshFood",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_fresh_food",
-      "description": "settings_product_export_fresh_food_description"
-    },
-    {
-      "name": "exportFrozen",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_frozen",
-      "description": "settings_product_export_frozen_description"
-    },
-    {
-      "name": "exportCooledDelivery",
-      "$component": "TriStateInput",
-      "label": "settings_product_export_cooled_delivery",
-      "description": "settings_product_export_cooled_delivery_description"
-    }
-  ],
-  "children": null
+    ],
+    "children": null
 }

--- a/tests/factories/Carrier/Model/CarrierFactory.php
+++ b/tests/factories/Carrier/Model/CarrierFactory.php
@@ -148,11 +148,19 @@ final class CarrierFactory extends AbstractModelFactory
      */
     public function withAllCapabilities(string $carrier = RefCapabilitiesSharedCarrierV2::POSTNL): self
     {
+        // Match real (post-service-filter) data: only options the PDK has a registered
+        // OrderOptionDefinition for, which is the same set the boundary filter keeps.
+        $registeredKeys       = Carrier::getRegisteredCapabilitiesKeys();
         $shipmentOptionsTypes = RefCapabilitiesContractDefinitionsResponseOptionsOptionsV2::openAPITypes();
         $allShipmentOptions   = [];
 
         foreach ($shipmentOptionsTypes as $key => $model) {
             $optionKey = Str::camel($key);
+
+            if (! isset($registeredKeys[$optionKey])) {
+                continue;
+            }
+
             // Insurance requires a populated insuredAmount; all other options can be empty arrays.
             // openAPITypes() returns class names with a leading backslash, while ::class does not — trim before comparing.
             if (ltrim($model, '\\') === RefCapabilitiesContractDefinitionsResponseOptionsInsuranceOptionV2::class) {


### PR DESCRIPTION
prevent usage of carriers, delivery types, package types and shipment options that haven't been mapped to the identifiers for other endpoints.

refactor the capabilities proxy so that it doesn't need to deal with a `data.capabilities`-prefix.

fixes INT-1553