### PR TITLE
fix(capabilities): respect carrier delivery-options setting in weight aggregation

### DIFF
--- a/src/Carrier/Service/CapabilitiesValidationService.php
+++ b/src/Carrier/Service/CapabilitiesValidationService.php
@@ -6,6 +6,8 @@ namespace MyParcelNL\Pdk\Carrier\Service;
 
 use MyParcelNL\Pdk\Base\Support\Utils;
 use MyParcelNL\Pdk\Carrier\Repository\CarrierCapabilitiesRepository;
+use MyParcelNL\Pdk\Facade\Settings;
+use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesResponseCapabilityV2;
 
@@ -60,14 +62,26 @@ class CapabilitiesValidationService
      *
      * Returns null for types where the API does not define a max weight constraint.
      *
-     * @param  string $cc           ISO 3166-1 alpha-2 country code
-     * @param  array  $allowedTypes PDK name => V2 name
+     * By default, only carriers with delivery options enabled in shop settings
+     * contribute to the per-type aggregation — disabled carriers are not available
+     * in checkout and should not affect package-type ordering. Pass
+     * $filterByEnabledCarriers = false for use cases that need the raw API view
+     * across all carriers the merchant has access to.
+     *
+     * @param  string $cc                       ISO 3166-1 alpha-2 country code
+     * @param  array  $allowedTypes             PDK name => V2 name
+     * @param  bool   $filterByEnabledCarriers  When true, exclude carriers without
+     *                                          CarrierSettings::DELIVERY_OPTIONS_ENABLED
      *
      * @return array<string, null|int> PDK package type name => max weight in grams, or null if unconstrained
      */
-    public function getPackageTypeWeights(string $cc, array $allowedTypes): array
-    {
-        $weights = [];
+    public function getPackageTypeWeights(
+        string $cc,
+        array $allowedTypes,
+        bool $filterByEnabledCarriers = true
+    ): array {
+        $enabledCarriers = $filterByEnabledCarriers ? $this->getEnabledCarrierNames() : null;
+        $weights         = [];
 
         foreach ($allowedTypes as $packageTypeName => $v2PackageType) {
             $capabilities = $this->indexByCarrier(
@@ -76,10 +90,34 @@ class CapabilitiesValidationService
                     'package_type' => $v2PackageType,
                 ])
             );
+
+            if ($enabledCarriers !== null) {
+                $capabilities = array_intersect_key($capabilities, array_flip($enabledCarriers));
+            }
+
             $weights[$packageTypeName] = $this->getHighestMaxWeight($capabilities);
         }
 
         return $weights;
+    }
+
+    /**
+     * V2 carrier names for which delivery options are enabled in shop settings.
+     *
+     * @return string[]
+     */
+    private function getEnabledCarrierNames(): array
+    {
+        $carrierSettings = Settings::get(CarrierSettings::ID) ?? [];
+
+        return array_keys(
+            array_filter(
+                $carrierSettings,
+                static function ($settings): bool {
+                    return ! empty($settings[CarrierSettings::DELIVERY_OPTIONS_ENABLED]);
+                }
+            )
+        );
     }
 
     /**

--- a/src/Carrier/Service/CapabilitiesValidationService.php
+++ b/src/Carrier/Service/CapabilitiesValidationService.php
@@ -18,7 +18,8 @@ use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesResponseCapabil
  * type has the highest weight limit?" using data from the capabilities API.
  *
  * Reusable across checkout, order export, and admin UI — does not depend on
- * cart, settings, or frontend concerns.
+ * cart or frontend state. Reads CarrierSettings to skip carriers without
+ * delivery options enabled when aggregating per-package-type weights.
  */
 class CapabilitiesValidationService
 {

--- a/tests/Unit/Carrier/Service/CapabilitiesValidationServiceTest.php
+++ b/tests/Unit/Carrier/Service/CapabilitiesValidationServiceTest.php
@@ -7,19 +7,45 @@ declare(strict_types=1);
 namespace MyParcelNL\Pdk\Carrier\Service;
 
 use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
+use MyParcelNL\Pdk\Settings\Model\Settings;
 use MyParcelNL\Pdk\Tests\SdkApi\MockSdkApiHandler;
 use MyParcelNL\Pdk\Tests\SdkApi\Response\ExampleCapabilitiesResponse;
 use MyParcelNL\Pdk\Tests\Uses\UsesAccountMock;
 use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
 use MyParcelNL\Pdk\Tests\Uses\UsesSdkApiMock;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesSharedCarrierV2;
 
+use function MyParcelNL\Pdk\Tests\factory;
 use function MyParcelNL\Pdk\Tests\usesShared;
 
 uses()->group('checkout', 'capabilities');
 
 usesShared(new UsesMockPdkInstance(), new UsesAccountMock(), new UsesSdkApiMock());
 
+/**
+ * Seed CarrierSettings::DELIVERY_OPTIONS_ENABLED for the given V2 carrier names so
+ * the default carrier-enablement filter in getPackageTypeWeights() lets them through.
+ *
+ * @param  string[] $carrierNames
+ */
+function seedEnabledCarriers(array $carrierNames): void
+{
+    $settingsFactory = factory(Settings::class);
+
+    foreach ($carrierNames as $carrierName) {
+        $settingsFactory = $settingsFactory->withCarrier(
+            $carrierName,
+            factory(CarrierSettings::class, $carrierName)->withDeliveryOptionsEnabled(true)
+        );
+    }
+
+    $settingsFactory->store();
+}
+
 it('takes the highest defined max weight when one carrier has no max defined', function () {
+    seedEnabledCarriers([RefCapabilitiesSharedCarrierV2::POSTNL, RefCapabilitiesSharedCarrierV2::BPOST]);
+
     MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([
         [
             'carrier'            => 'POSTNL',
@@ -57,6 +83,8 @@ it('takes the highest defined max weight when one carrier has no max defined', f
 });
 
 it('returns null when no carrier in the response defines a max weight', function () {
+    seedEnabledCarriers([RefCapabilitiesSharedCarrierV2::POSTNL]);
+
     MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([
         [
             'carrier'            => 'POSTNL',
@@ -75,4 +103,96 @@ it('returns null when no carrier in the response defines a max weight', function
     $weights = $service->getPackageTypeWeights('NL', ['package' => 'PACKAGE']);
 
     expect($weights)->toBe(['package' => null]);
+});
+
+it('excludes weights from carriers without delivery options enabled', function () {
+    // Only POSTNL is enabled in shop settings; BPOST has a heavier defined max
+    // but should not contribute to the per-type aggregation.
+    seedEnabledCarriers([RefCapabilitiesSharedCarrierV2::POSTNL]);
+
+    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([
+        [
+            'carrier'            => 'POSTNL',
+            'contract'           => ['id' => 1, 'type' => 'MAIN'],
+            'packageTypes'       => ['PACKAGE'],
+            'options'            => (object) [],
+            'physicalProperties' => [
+                'weight' => [
+                    'min' => ['value' => 1, 'unit' => 'g'],
+                    'max' => ['value' => 10000, 'unit' => 'g'],
+                ],
+            ],
+            'deliveryTypes'      => ['STANDARD_DELIVERY'],
+            'transactionTypes'   => [],
+            'collo'              => ['max' => 1],
+        ],
+        [
+            'carrier'            => 'BPOST',
+            'contract'           => ['id' => 2, 'type' => 'MAIN'],
+            'packageTypes'       => ['PACKAGE'],
+            'options'            => (object) [],
+            'physicalProperties' => [
+                'weight' => [
+                    'min' => ['value' => 1, 'unit' => 'g'],
+                    'max' => ['value' => 23000, 'unit' => 'g'],
+                ],
+            ],
+            'deliveryTypes'      => ['STANDARD_DELIVERY'],
+            'transactionTypes'   => [],
+            'collo'              => ['max' => 1],
+        ],
+    ]));
+
+    /** @var CapabilitiesValidationService $service */
+    $service = Pdk::get(CapabilitiesValidationService::class);
+
+    $weights = $service->getPackageTypeWeights('NL', ['package' => 'PACKAGE']);
+
+    expect($weights)->toBe(['package' => 10000]);
+});
+
+it('includes weights from all carriers when filter is opted out', function () {
+    // POSTNL is the only enabled carrier in settings, but the opt-out flag
+    // bypasses the filter so BPOST's heavier max still contributes.
+    seedEnabledCarriers([RefCapabilitiesSharedCarrierV2::POSTNL]);
+
+    MockSdkApiHandler::enqueue(new ExampleCapabilitiesResponse([
+        [
+            'carrier'            => 'POSTNL',
+            'contract'           => ['id' => 1, 'type' => 'MAIN'],
+            'packageTypes'       => ['PACKAGE'],
+            'options'            => (object) [],
+            'physicalProperties' => [
+                'weight' => [
+                    'min' => ['value' => 1, 'unit' => 'g'],
+                    'max' => ['value' => 10000, 'unit' => 'g'],
+                ],
+            ],
+            'deliveryTypes'      => ['STANDARD_DELIVERY'],
+            'transactionTypes'   => [],
+            'collo'              => ['max' => 1],
+        ],
+        [
+            'carrier'            => 'BPOST',
+            'contract'           => ['id' => 2, 'type' => 'MAIN'],
+            'packageTypes'       => ['PACKAGE'],
+            'options'            => (object) [],
+            'physicalProperties' => [
+                'weight' => [
+                    'min' => ['value' => 1, 'unit' => 'g'],
+                    'max' => ['value' => 23000, 'unit' => 'g'],
+                ],
+            ],
+            'deliveryTypes'      => ['STANDARD_DELIVERY'],
+            'transactionTypes'   => [],
+            'collo'              => ['max' => 1],
+        ],
+    ]));
+
+    /** @var CapabilitiesValidationService $service */
+    $service = Pdk::get(CapabilitiesValidationService::class);
+
+    $weights = $service->getPackageTypeWeights('NL', ['package' => 'PACKAGE'], false);
+
+    expect($weights)->toBe(['package' => 23000]);
 });


### PR DESCRIPTION
## Summary

- `CapabilitiesValidationService::getPackageTypeWeights()` now filters out carriers without `CarrierSettings::DELIVERY_OPTIONS_ENABLED` before per-package-type weight aggregation (default-on, opt-out via new third parameter).
- Prevents disabled carriers from influencing package-type ordering at checkout — e.g. promoting a shipping class to a larger package type even though the carriers supporting that type are turned off in shop settings.
- Existing PDK caller (`DeliveryOptionsService::getCandidatePackageTypes`) picks up the filter by default; behaviour is strictly more correct for that path. WooCommerce's new shipping-class auto-selection path (PR #1597 rebase) gets the same protection without any caller-side change.

## Test plan

- [x] New unit cases: filter excludes disabled-carrier weight; opt-out includes it
- [x] Updated existing `CapabilitiesValidationServiceTest` cases to seed enabled carriers
- [x] `composer analyse` clean
- [x] Full suite green (2571 passed, 19 skipped) + integration scenarios (10/10)
- [ ] Manually verify in a shop with mixed enabled/disabled carriers that shipping-class auto-selection no longer promotes to a type whose only supporting carrier is disabled

Resolves INT-1500