### PR TITLE
feat(account): add shipping-rules client for default carrier lookup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,83 +1,83 @@
 {
-  "name": "myparcelnl/pdk",
-  "version": "3.4.2",
-  "description": "MyParcel Plugin Development Kit",
-  "type": "library",
-  "homepage": "https://myparcel.nl",
-  "license": "MIT",
-  "require": {
-    "ext-zip": "*",
-    "fruitcake/php-cors": "^1.2",
-    "justinrainbow/json-schema": "^5.2",
-    "myparcelnl/sdk": "^11.0.0-beta.1",
-    "php": ">=7.4.0",
-    "php-di/php-di": "^6.0.0",
-    "psr/log": "^1.0.0 || ^2.0.0 || ^3.0.0",
-    "symfony/http-foundation": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-    "alcohol/iso4217": "^4.3",
-    "symfony/psr-http-message-bridge": "^2.3",
-    "league/openapi-psr7-validator": "^0.22.0"
-  },
-  "platform": {
-    "php": "7.4"
-  },
-  "scripts": {
-    "analyse": "php -dmemory_limit=-1 vendor/bin/phpstan analyse",
-    "analyse:generate": "composer run analyse -- --generate-baseline phpstan-baseline.php --allow-empty-baseline",
-    "analyze": "composer run analyse",
-    "analyze:generate": "composer run analyse:generate",
-    "console": "php bin/console",
-    "post-autoload-dump": "composer console generate:ide-helper",
-    "quality": "rector process --dry-run",
-    "quality:fix": "rector process",
-    "test": "composer run test:unit && composer run test:integration",
-    "test:integration": "behat",
-    "test:unit": "php -d auto_prepend_file=tests/bootstrap.php vendor/bin/pest",
-    "test:unit:coverage": "php -dmemory_limit=512M -dpcov.enabled=1 vendor/bin/pest --coverage-clover clover.xml",
-    "test:unit:snapshot": "pest -d --update-snapshots"
-  },
-  "require-dev": {
-    "behat/behat": "^3.13",
-    "brick/varexporter": "^0.4",
-    "guzzlehttp/guzzle": "^7.5",
-    "myparcelnl/devtools": "^1.0.0",
-    "nette/robot-loader": "^3.0.0",
-    "pestphp/pest": "^1.0.0",
-    "phpdocumentor/reflection-docblock": "^5.0.0",
-    "phpstan/phpstan": "^1.0.0",
-    "rector/rector": "^1.0.0",
-    "spatie/pest-plugin-snapshots": "^1.0.0",
-    "symfony/console": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
-    "mockery/mockery": "^1.6"
-  },
-  "autoload": {
-    "psr-4": {
-      "MyParcelNL\\Pdk\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "MyParcelNL\\Pdk\\": [
-        "tests/Unit/",
-        "tests/factories"
-      ],
-      "MyParcelNL\\Pdk\\Console\\": "private/",
-      "MyParcelNL\\Pdk\\Tests\\": "tests/"
+    "name": "myparcelnl/pdk",
+    "version": "3.4.2",
+    "description": "MyParcel Plugin Development Kit",
+    "type": "library",
+    "homepage": "https://myparcel.nl",
+    "license": "MIT",
+    "require": {
+        "ext-zip": "*",
+        "fruitcake/php-cors": "^1.2",
+        "justinrainbow/json-schema": "^5.2",
+        "myparcelnl/sdk": "^11.0.0-beta.19@beta",
+        "php": ">=7.4.0",
+        "php-di/php-di": "^6.0.0",
+        "psr/log": "^1.0.0 || ^2.0.0 || ^3.0.0",
+        "symfony/http-foundation": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "alcohol/iso4217": "^4.3",
+        "symfony/psr-http-message-bridge": "^2.3",
+        "league/openapi-psr7-validator": "^0.22.0"
     },
-    "files": [
-      "tests/functions.php",
-      "tests/usesShared.php"
-    ]
-  },
-  "authors": [
-    {
-      "name": "Edie Lemoine",
-      "email": "edie@myparcel.nl"
+    "platform": {
+        "php": "7.4"
+    },
+    "scripts": {
+        "analyse": "php -dmemory_limit=-1 vendor/bin/phpstan analyse",
+        "analyse:generate": "composer run analyse -- --generate-baseline phpstan-baseline.php --allow-empty-baseline",
+        "analyze": "composer run analyse",
+        "analyze:generate": "composer run analyse:generate",
+        "console": "php bin/console",
+        "post-autoload-dump": "composer console generate:ide-helper",
+        "quality": "rector process --dry-run",
+        "quality:fix": "rector process",
+        "test": "composer run test:unit && composer run test:integration",
+        "test:integration": "behat",
+        "test:unit": "php -d auto_prepend_file=tests/bootstrap.php vendor/bin/pest",
+        "test:unit:coverage": "php -dmemory_limit=512M -dpcov.enabled=1 vendor/bin/pest --coverage-clover clover.xml",
+        "test:unit:snapshot": "pest -d --update-snapshots"
+    },
+    "require-dev": {
+        "behat/behat": "^3.13",
+        "brick/varexporter": "^0.4",
+        "guzzlehttp/guzzle": "^7.5",
+        "myparcelnl/devtools": "^1.0.0",
+        "nette/robot-loader": "^3.0.0",
+        "pestphp/pest": "^1.0.0",
+        "phpdocumentor/reflection-docblock": "^5.0.0",
+        "phpstan/phpstan": "^1.0.0",
+        "rector/rector": "^1.0.0",
+        "spatie/pest-plugin-snapshots": "^1.0.0",
+        "symfony/console": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+        "mockery/mockery": "^1.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "MyParcelNL\\Pdk\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "MyParcelNL\\Pdk\\": [
+                "tests/Unit/",
+                "tests/factories"
+            ],
+            "MyParcelNL\\Pdk\\Console\\": "private/",
+            "MyParcelNL\\Pdk\\Tests\\": "tests/"
+        },
+        "files": [
+            "tests/functions.php",
+            "tests/usesShared.php"
+        ]
+    },
+    "authors": [
+        {
+            "name": "Edie Lemoine",
+            "email": "edie@myparcel.nl"
+        }
+    ],
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     }
-  ],
-  "config": {
-    "allow-plugins": {
-      "pestphp/pest-plugin": true
-    }
-  }
 }

--- a/docs/superpowers/specs/2026-05-19-default-carrier-from-shipping-rules-design.md
+++ b/docs/superpowers/specs/2026-05-19-default-carrier-from-shipping-rules-design.md
@@ -94,7 +94,7 @@ abstract class AbstractCoreApiPrivateService extends AbstractSdkApiService
 }
 ```
 
-Assumption: `AbstractSdkApiService::applyConfigSettings()` is generic enough to accept the private Configuration. If its signature is currently typed against `CoreApiConfiguration`, the plan widens it to the shared parent type — the field-setting body is identical.
+`AbstractSdkApiService::applyConfigSettings()` accepts `object` and returns `object`, so the private `Configuration` flows through unchanged — no widening needed.
 
 ### New: `ImplicationsService`
 
@@ -106,26 +106,50 @@ Single public method. No other endpoint methods are wrapped — INT-1586 explici
 class ImplicationsService extends AbstractCoreApiPrivateService
 {
     private ShippingRuleApi $api;
+    private CarrierRepositoryInterface $carrierRepository;
 
-    public function __construct()
+    public function __construct(CarrierRepositoryInterface $carrierRepository)
     {
-        $this->api = new ShippingRuleApi(null, $this->getApiConfig());
+        $this->api               = new ShippingRuleApi($this->createGuzzleClient(), $this->getApiConfig());
+        $this->carrierRepository = $carrierRepository;
     }
 
     public function getDefaultCarrierName(int $shopId): ?string
     {
-        return $this->executeOperationWithErrorHandling(
-            function () use ($shopId): ?string {
-                $implications = $this->api->getShippingRuleImplications($shopId);
-                $carrierId    = $implications->getCarrierId();
+        try {
+            $response     = $this->api->getShippingRuleImplications($shopId);
+            $implications = $response->getData()->getImplications();
 
-                return $carrierId ? (string) $carrierId : null;
-            },
-            'getShippingRuleImplications'
-        );
+            if (empty($implications)) {
+                return null;
+            }
+
+            $carrierId = $implications[0]->getCarrierId();
+
+            if ($carrierId === null) {
+                return null;
+            }
+
+            $carrier = $this->carrierRepository->findByLegacyId((int) $carrierId);
+
+            return $carrier ? $carrier->carrier : null;
+        } catch (ApiException $e) {
+            // LoggingMiddleware already records the HTTP failure at the Guzzle transport layer.
+            return null;
+        } catch (Throwable $e) {
+            // Unexpected programmer error — log so it doesn't get silently masked.
+            Logger::error('Unexpected error fetching default carrier name', [
+                'exception' => get_class($e),
+                'message'   => $e->getMessage(),
+            ]);
+
+            return null;
+        }
     }
 }
 ```
+
+The catch is split deliberately: `ApiException` is the expected SDK failure path and is already logged by `LoggingMiddleware::forApiRequests()` (pushed onto every SDK service's Guzzle handler stack), so we silently return `null`. Any other `Throwable` indicates something unexpected (response-shape change, programmer error in the chain) — log before returning `null` so real bugs surface in logs instead of disappearing.
 
 ### Extended: `Shop`
 
@@ -235,7 +259,7 @@ Same code path as the happy path. `setShopDefaultCarrier()` runs and overwrites 
 
 - **No API key**: short-circuits at `if (! $accountSettings->apiKey)`. Account is wiped. No Shop ⇒ no `defaultCarrier`.
 - **API key invalid (401)**: `accountRepository->getAccount()` throws; the surrounding `try` wipes the account and re-throws. `setShopDefaultCarrier()` never runs.
-- **Implications endpoint errors**: `executeOperationWithErrorHandling` swallows + logs, returns `null`. `setShopDefaultCarrier()` does **not** overwrite the previously stored value (decision β).
+- **Implications endpoint errors**: `ImplicationsService::getDefaultCarrierName()` catches `ApiException` (already logged by `LoggingMiddleware`) and other `Throwable`s (logged explicitly at error level), then returns `null`. `setShopDefaultCarrier()` does **not** overwrite the previously stored value (decision β).
 - **Unsupported `carrier_id`**: persisted on Shop; `Shop::getDefaultCarrierModelAttribute()` returns `null` via `CarrierRepository::find()`; `Carrier::isSupported()` logs the warning.
 
 ### Read by a caller
@@ -256,7 +280,7 @@ No API call on read. Local state only.
 | --- | --------------------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | 1   | No API key set                                                  | `UpdateAccountAction` guard                   | `setShopDefaultCarrier()` never runs.                                                           |
 | 2   | API key invalid (401)                                           | `accountRepository->getAccount()` throws      | Existing try/catch wipes account.                                                               |
-| 3   | Implications endpoint 5xx / network blip                        | `executeOperationWithErrorHandling`           | Log error, return `null`. **Preserve previous Shop value.**                                     |
+| 3   | Implications endpoint 5xx / network blip                        | `ImplicationsService` `ApiException` catch    | Silent return `null` (LoggingMiddleware already logged). **Preserve previous Shop value.**      |
 | 4   | Response deserializes; `carrier_id` empty / unsupported V2 name | Shop persists string; `find()` returns `null` | Attribute getter returns `null`. Existing `Carrier::isSupported()` warning fires when consumed. |
 | 5   | Shop has no `id` yet                                            | Defensive guard in `setShopDefaultCarrier`    | Skip fetch, log warning.                                                                        |
 

--- a/docs/superpowers/specs/2026-05-19-default-carrier-from-shipping-rules-design.md
+++ b/docs/superpowers/specs/2026-05-19-default-carrier-from-shipping-rules-design.md
@@ -1,0 +1,421 @@
+# Default carrier from shipping-rules implications
+
+- **Tickets**: [INT-1479](https://myparcelnl.atlassian.net/browse/INT-1479) (parent), [INT-1586](https://myparcelnl.atlassian.net/browse/INT-1586) (sub-task)
+- **Author**: Freek van Rijt
+- **Date**: 2026-05-19
+- **Status**: Pending review
+- **Parent epic**: INT-1504 (v4-capabilities cleanup)
+
+## Summary
+
+Replace the hard-coded "default carrier" entries in `proposition-*.json` with a value fetched from the CoreAPI shipping-rules `implications` endpoint, persisted on the `Shop` model, and resolved to a `Carrier` via the existing `CarrierRepository`.
+
+The fetch runs when the API key is saved (in `UpdateAccountAction::updateAndSaveAccount`) and when the account-debug "refresh" action fires. There is no TTL, no fallback to proposition config, and no retries — the persisted Shop attribute is the single source of truth between fetches.
+
+## Goals
+
+- Remove the `contracts.{outbound,inbound}.default.carrier` blocks from proposition config and `PropositionService::getDefaultCarrier()`.
+- Introduce a PDK-side service that calls the SDK's new `CoreApiPrivate\ShippingRuleApi::getShippingRuleImplications($shop_id)` and returns the implied default carrier as a V2 name.
+- Persist the resolved V2 carrier name on `Shop`.
+- Migrate the 5 existing callers of `PropositionService::getDefaultCarrier()` to read from the Shop, with explicit null-handling per site.
+
+## Non-goals
+
+- No SDK work. The `CoreApiPrivate` client and `ShippingRuleApi` already exist on a feature branch (pending merge) in `myparcelnl/sdk`. This spec assumes that branch lands and the SDK pin is bumped.
+- No additional shipping-rules methods. INT-1586 explicitly forbids unused endpoint wrappers.
+- No per-country / per-region implications. We only ever call the endpoint with `shop_id` — the default-rule path.
+- No TTL-based refresh.
+- No proposition-config fallback during the migration window.
+- Inbound/outbound distinction is dropped (no callers use `$outbound = false` today).
+
+## Constraints
+
+- PHP 7.4 compatible.
+- V4-capabilities branch already accepts breaking changes; we drop `PropositionService::getDefaultCarrier()` outright rather than deprecate.
+- PDK consumers: PrestaShop + WooCommerce plugins only.
+
+## Architecture
+
+```
+   UpdateAccountAction::updateAndSaveAccount
+     setShopCarriers($account)
+     setShopDefaultCarrier($account)   ← NEW: Service call + write to $shop->defaultCarrier
+     pdkAccountRepository->store($account)
+
+   Account debug "refresh" action
+     same fetch + write path
+
+         │
+         ▼ uses
+   src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php   NEW
+     extends AbstractCoreApiPrivateService   ← NEW base (mirror of AbstractCoreApiService
+                                                against CoreApiPrivate\Configuration)
+     + getDefaultCarrierName(int $shopId): ?string
+         pure passthrough: instantiate ShippingRuleApi,
+         call getShippingRuleImplications($shop_id),
+         return RefShippingRulesImplications->carrier_id (as V2 string) or null on error
+
+         │
+         ▼
+   Sdk\Client\Generated\CoreApiPrivate\Api\ShippingRuleApi
+
+   Shop  (extended)
+     attribute  defaultCarrier      ← NEW persisted V2 string, e.g. "POSTNL"
+     getter     getDefaultCarrierModelAttribute(): ?Carrier  ← NEW, resolves via CarrierRepository
+
+   PropositionService::getDefaultCarrier()              DELETED
+   proposition-*.json contracts.{out,in}bound.default   DELETED
+   5 call sites                                          MIGRATED to $shop->defaultCarrier
+```
+
+Three boundaries:
+
+- **PDK service** (`ImplicationsService`): owns the wire concern, directly uses the generated `ShippingRuleApi` and `RefShippingRulesImplications` — no intermediate wrapper layer. Pure passthrough; no cache of its own.
+- **Shop model**: owns the persisted state (V2 string) and the model→Carrier resolution.
+- **`UpdateAccountAction`**: owns the lifecycle (when to fetch and write).
+
+The Shop attribute is the only persistence layer. There is no `StorageInterface`-backed cache; if a second persistence layer were added, the two would drift.
+
+## Components
+
+### New: `AbstractCoreApiPrivateService`
+
+`src/SdkApi/Service/CoreApiPrivate/AbstractCoreApiPrivateService.php`
+
+Mirror of `AbstractCoreApiService` typed against `CoreApiPrivate\Configuration`.
+
+```php
+abstract class AbstractCoreApiPrivateService extends AbstractSdkApiService
+{
+    public function getApiConfig(): CoreApiPrivateConfiguration
+    {
+        return $this->applyConfigSettings(new CoreApiPrivateConfiguration());
+    }
+}
+```
+
+Assumption: `AbstractSdkApiService::applyConfigSettings()` is generic enough to accept the private Configuration. If its signature is currently typed against `CoreApiConfiguration`, the plan widens it to the shared parent type — the field-setting body is identical.
+
+### New: `ImplicationsService`
+
+`src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php`
+
+Single public method. No other endpoint methods are wrapped — INT-1586 explicitly forbids dead code.
+
+```php
+class ImplicationsService extends AbstractCoreApiPrivateService
+{
+    private ShippingRuleApi $api;
+
+    public function __construct()
+    {
+        $this->api = new ShippingRuleApi(null, $this->getApiConfig());
+    }
+
+    public function getDefaultCarrierName(int $shopId): ?string
+    {
+        return $this->executeOperationWithErrorHandling(
+            function () use ($shopId): ?string {
+                $implications = $this->api->getShippingRuleImplications($shopId);
+                $carrierId    = $implications->getCarrierId();
+
+                return $carrierId ? (string) $carrierId : null;
+            },
+            'getShippingRuleImplications'
+        );
+    }
+}
+```
+
+### Extended: `Shop`
+
+`src/Account/Model/Shop.php`
+
+```php
+/**
+ * @property null|string         $defaultCarrier        // V2 carrier name, e.g. "POSTNL"
+ * @property-read null|Carrier   $defaultCarrierModel   // resolved Carrier (virtual)
+ */
+class Shop extends Model
+{
+    public $attributes = [
+        // …existing…
+        'defaultCarrier' => null,
+    ];
+
+    protected $casts = [
+        // …existing…
+        'defaultCarrier' => 'string',
+    ];
+
+    public function getDefaultCarrierModelAttribute(): ?Carrier
+    {
+        if (! $this->defaultCarrier) {
+            return null;
+        }
+
+        return Pdk::get(CarrierRepository::class)->find($this->defaultCarrier);
+    }
+}
+```
+
+The persisted attribute holds the V2 string (round-trips cleanly through storage). The model getter is a virtual property — distinct name avoids a collision with the underlying attribute.
+
+### Extended: `UpdateAccountAction`
+
+`src/App/Action/Backend/Account/UpdateAccountAction.php`
+
+Add `ImplicationsService` to the constructor; add `setShopDefaultCarrier()`; call it from `updateAndSaveAccount` right after `setShopCarriers()`.
+
+```php
+protected function setShopDefaultCarrier(Account $account): void
+{
+    $shop = $account->shops->first();
+
+    if (! $shop || ! $shop->id) {
+        Logger::warning('Cannot fetch default carrier: no shop or shop id available');
+        return;
+    }
+
+    $defaultCarrier = $this->implicationsService->getDefaultCarrierName($shop->id);
+
+    // Preserve previously-stored value on transient error (decision β; see "Error handling").
+    if ($defaultCarrier !== null) {
+        $shop->defaultCarrier = $defaultCarrier;
+    }
+}
+```
+
+### Refresh debug action
+
+The account-debug "refresh" path must re-run the same fetch + write. The exact action class is identified during plan writing — at minimum we wire `setShopDefaultCarrier()` into whatever entry point the debug button invokes.
+
+### Deleted
+
+- `PropositionService::getDefaultCarrier()` and its `@TODO` block.
+- `contracts.outbound.default.carrier` and `contracts.inbound.default.carrier` from `config/proposition/proposition-1.json`, `-3.json`, `-6.json`. If `default` becomes empty after removal, drop the `default` key too. If `default` carries siblings still in use (e.g. `contractId`), only remove the `carrier` child.
+- Any tests asserting against `PropositionService::getDefaultCarrier()` (replaced by the new Shop/Service tests).
+
+## Data flow
+
+### Happy path: user saves a valid API key
+
+```
+Admin UI ── POST /account/update {api_key: …} ──▶ UpdateAccountAction::handle
+                                                       │
+                                                       ▼
+                                               updateAccountSettings()       (persists key)
+                                                       │
+                                                       ▼
+                                               updateAndSaveAccount()
+                                                       │
+                                                       ├─ accountRepository->getAccount()
+                                                       ├─ propositionService->setActivePropositionId(...)
+                                                       ├─ setShopCarriers($account)
+                                                       ├─ setShopDefaultCarrier($account)
+                                                       │     │
+                                                       │     ▼
+                                                       │   ImplicationsService::getDefaultCarrierName($shop->id)
+                                                       │     │
+                                                       │     ▼
+                                                       │   ShippingRuleApi::getShippingRuleImplications($shop_id)
+                                                       │     │
+                                                       │     ▼
+                                                       │   $shop->defaultCarrier = "POSTNL"
+                                                       │
+                                                       ├─ pdkAccountRepository->store($account)
+                                                       └─ setApiKeyValidity(true)
+```
+
+### Manual refresh
+
+Same code path as the happy path. `setShopDefaultCarrier()` runs and overwrites with the new value when the Service returns one.
+
+### Missing / fetch failed
+
+- **No API key**: short-circuits at `if (! $accountSettings->apiKey)`. Account is wiped. No Shop ⇒ no `defaultCarrier`.
+- **API key invalid (401)**: `accountRepository->getAccount()` throws; the surrounding `try` wipes the account and re-throws. `setShopDefaultCarrier()` never runs.
+- **Implications endpoint errors**: `executeOperationWithErrorHandling` swallows + logs, returns `null`. `setShopDefaultCarrier()` does **not** overwrite the previously stored value (decision β).
+- **Unsupported `carrier_id`**: persisted on Shop; `Shop::getDefaultCarrierModelAttribute()` returns `null` via `CarrierRepository::find()`; `Carrier::isSupported()` logs the warning.
+
+### Read by a caller
+
+```
+some site
+   │
+   ▼
+$shop    = accountSettingsService->getShop()
+$carrier = $shop?->defaultCarrierModel        // ?Carrier
+```
+
+No API call on read. Local state only.
+
+## Error handling
+
+| #   | Failure                                                         | Where                                         | Behaviour                                                                                       |
+| --- | --------------------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 1   | No API key set                                                  | `UpdateAccountAction` guard                   | `setShopDefaultCarrier()` never runs.                                                           |
+| 2   | API key invalid (401)                                           | `accountRepository->getAccount()` throws      | Existing try/catch wipes account.                                                               |
+| 3   | Implications endpoint 5xx / network blip                        | `executeOperationWithErrorHandling`           | Log error, return `null`. **Preserve previous Shop value.**                                     |
+| 4   | Response deserializes; `carrier_id` empty / unsupported V2 name | Shop persists string; `find()` returns `null` | Attribute getter returns `null`. Existing `Carrier::isSupported()` warning fires when consumed. |
+| 5   | Shop has no `id` yet                                            | Defensive guard in `setShopDefaultCarrier`    | Skip fetch, log warning.                                                                        |
+
+### Preserve-on-error (β)
+
+`setShopDefaultCarrier()` writes only when the Service returns non-null. A single flaky API call cannot null the default for every caller until the next successful refresh. The manual refresh button is the recovery path for legitimately-changed server-side state.
+
+### Deliberate omissions
+
+- No retries. Manual refresh / next key-save is the retry surface.
+- No fallback to proposition config. INT-1479 removes that path; reintroducing it as an error fallback would recreate the dependency we're deleting.
+- No request-scoped Service cache. The Service is only called from `UpdateAccountAction` and the debug refresh — once per invocation.
+
+## Migration of existing call sites
+
+| #   | File:line                                                 | Migration                                                                                                                                                                               |
+| --- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `src/Carrier/Concern/HasCarrierAttribute.php:38`          | Read `$shop?->defaultCarrierModel`. If null, propagate `null` (callers already accept missing carrier in this fallback path).                                                           |
+| 2   | `src/Context/Model/GlobalContext.php:81`                  | Read from Shop. Null path means "no default known yet"; the context payload tolerates absence post-INT-1479.                                                                            |
+| 3   | `src/Shipment/Request/PostReturnShipmentsRequest.php:148` | Read from Shop. **Null must produce an actionable error** — return shipments cannot silently submit without a carrier.                                                                  |
+| 4   | `src/Fulfilment/Model/Shipment.php:64`                    | Drops the `convertToName(..., Carrier::CARRIER_NAME_ID_MAP)` round-trip. New shape: `$this->attributes['carrier'] ??= $shop?->defaultCarrier;` (uses the persisted V2 string directly). |
+| 5   | `src/Shipment/Model/DeliveryOptions.php:330`              | Read from Shop. Existing fallback machinery for missing carrier absorbs the null branch.                                                                                                |
+
+Call site #3 is the only hard-failure surface and is pinned by a test (see Testing → call-site sanity).
+
+## Testing
+
+Pest v1, concrete assertions, no value-sensitive snapshots, mocks via PDK utilities, run via Docker (`yarn run test:unit`).
+
+### 1. `ImplicationsService` unit tests
+
+`tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php`
+
+- Returns V2 name when API succeeds.
+- Returns `null` on `ApiException`.
+- Passes `shop_id` unchanged; no extra `country`/`region`/`type` arguments.
+- Class surface only exposes `getDefaultCarrierName` (guards INT-1586 scope creep).
+
+### 2. `Shop::getDefaultCarrierModelAttribute()`
+
+`tests/Unit/Account/Model/ShopTest.php` (existing or new)
+
+- Returns `null` when `defaultCarrier` unset.
+- Resolves to Carrier via `CarrierRepository::find()`.
+- Returns `null` for unsupported V2 names.
+- V2 string round-trips through `toArray()` / `fill()`.
+
+### 3. `UpdateAccountAction::setShopDefaultCarrier`
+
+Extend `tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php`.
+
+- Writes V2 name on Service success.
+- Preserves prior value when Service returns `null` (decision β).
+- Skips when no Shop / no shop id; warning logged.
+- No fetch when API key empty.
+
+### 4. Debug refresh
+
+Identified during plan writing. Minimum: refresh re-runs fetch and overwrites; refresh populates a previously-null attribute on success.
+
+### 5. Call-site sanity (one focused test per site)
+
+- `HasCarrierAttribute`: returns `null` when shop has no default; resolved Carrier when set.
+- `GlobalContext`: payload includes V2 default carrier when set; absent when null.
+- `PostReturnShipmentsRequest`: explicit, actionable failure when Shop has no default. **This test pins our chosen failure mode.**
+- `Fulfilment\Shipment`: `carrier` attribute defaults to Shop's V2 string when not pre-set; untouched when pre-set.
+- `DeliveryOptions::carrier()`: returns Shop's `defaultCarrierModel` when none supplied; respects explicit carrier when supplied.
+
+### Out of scope for testing
+
+- The `ShippingRuleApi` wire format (SDK's contract; mocked at the API class boundary).
+- Specific carrier semantics (per PDK testing rule: opaque V2 strings as test data).
+- Proposition JSON diffs (checked in; no runtime test needed).
+
+## Dependencies & sequencing
+
+- Blocked on SDK PR landing the `CoreApiPrivate` namespace and `ShippingRuleApi` (currently on branch `feat/placeholder-private-coreapi-client-for-shipping-rules` in `myparcelnl/sdk`).
+- Composer pin bumps to the SDK version that publishes that namespace.
+- This work is part of the v4-capabilities cleanup (INT-1504). Commit footer must include `Resolves INT-1504`.
+- Coordinates with INT-1441 (SDK mapping centralisation) — we deliberately do not touch the V1↔V2 mapping layer; V2 strings flow end-to-end. If INT-1441 lands first the design is unaffected.
+
+## Branching, commits & PRs
+
+The work splits into two PRs, one per Jira ticket. Both target the `v4-capabilities` branch. PR 1 is additive only and merges first; PR 2 wires up consumers and removes the old path.
+
+### PR 1 — INT-1586: PDK service for shipping-rules implications
+
+Scope matches the sub-task definition exactly: a single PDK service wrapping `ShippingRuleApi::getShippingRuleImplications`. No callers wired up yet — that's PR 2's job.
+
+- **Branch**: `feat/INT-1586-shipping-rules-service`
+- **Includes**:
+  - `src/SdkApi/Service/CoreApiPrivate/AbstractCoreApiPrivateService.php`
+  - `src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php`
+  - `tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php`
+  - `composer.json` pin bump (once SDK PR is merged & released)
+- **PR title** (end-user framing): `feat(account): add shipping-rules client for default carrier lookup`
+- **PR description** (same shape as squash commit body):
+
+  ```
+  feat(account): add shipping-rules client for default carrier lookup
+
+  Adds the PDK-side service that calls the CoreAPI shipping-rules
+  `implications` endpoint to retrieve the default carrier configured
+  for a shop. No callers are wired up in this PR; the service is
+  additive infrastructure consumed by the follow-up that replaces
+  the hard-coded default in proposition config.
+
+  No functional change for end users in this PR — default carrier
+  selection still flows from proposition config until INT-1479 lands.
+
+  Resolves INT-1586
+  Resolves INT-1504
+  ```
+
+### PR 2 — INT-1479: derive default carrier from shipping rules
+
+Wires the Service into the account lifecycle, persists on Shop, migrates the 5 call sites, removes the proposition-config path.
+
+- **Branch**: `feat/INT-1479-default-carrier-from-shipping-rules`
+- **Includes**:
+  - `Shop` model: new `defaultCarrier` attribute + `defaultCarrierModel` getter.
+  - `UpdateAccountAction`: `setShopDefaultCarrier()`, constructor dependency on `ImplicationsService`.
+  - Account-debug refresh action: re-runs `setShopDefaultCarrier()`.
+  - 5 call-site migrations (`HasCarrierAttribute`, `GlobalContext`, `PostReturnShipmentsRequest`, `Fulfilment\Shipment`, `DeliveryOptions`).
+  - `PropositionService::getDefaultCarrier()` deletion.
+  - `config/proposition/proposition-*.json` cleanup.
+  - Tests for Shop, `UpdateAccountAction`, debug refresh, and the 5 call-site sanity checks.
+- **PR title** (end-user framing): `feat(account): default carrier follows your shop's shipping rules`
+- **PR description**:
+
+  ```
+  feat(account): default carrier follows your shop's shipping rules
+
+  The default carrier used for shipments, returns, and the checkout
+  delivery options now reflects the shipping rule configured for your
+  shop in the MyParcel backoffice. Changes you make there propagate
+  to the plugin on the next API-key save or via the "refresh" action
+  in account debug.
+
+  Previously the default was a static value baked into the plugin's
+  proposition configuration; updating it required a plugin release.
+
+  No new settings. Existing carrier preferences set per shipment are
+  unaffected — the default only applies when no carrier is selected.
+
+  Resolves INT-1479
+  Resolves INT-1504
+  ```
+
+### Commit shape within each PR
+
+- One PR = one squash merge. Internal commits during development can be granular; the squashed commit body matches the PR description above.
+- Conventional-commit prefix: `feat(account):` for both PRs (capability surface, not infra).
+- Every commit footer includes `Resolves INT-1504`. PR-defining commits also include the relevant `Resolves INT-XXXX` for the ticket being closed.
+- Internal/WIP commits during development omit the `Resolves` lines so squash doesn't accumulate them.
+
+### Jira linkage
+
+- PR 1's GitHub PR auto-links to INT-1586 via the branch name (`INT-1586` token) and the `Resolves INT-1586` footer.
+- PR 2 auto-links to INT-1479 the same way.
+- Both PRs also list INT-1504 via the footer so the epic captures the cleanup.
+- If additional sub-tasks are created later (e.g. for the account-debug refresh wire-up if it grows beyond a one-liner), each gets its own branch + PR following the same pattern.

--- a/src/SdkApi/Service/CoreApiPrivate/AbstractCoreApiPrivateService.php
+++ b/src/SdkApi/Service/CoreApiPrivate/AbstractCoreApiPrivateService.php
@@ -10,36 +10,11 @@ use MyParcelNL\Sdk\Client\Generated\CoreApiPrivate\Configuration as CoreApiPriva
 /**
  * Abstract base class for CoreAPI Private-specific services.
  *
- * This class extends the generic SDK service base with CoreAPI Private-specific configuration,
+ * Extends the generic SDK service base with CoreAPI Private-specific configuration,
  * providing a ready-to-use Configuration object for OpenAPI CoreAPI Private client classes.
  *
- * The CoreAPI Private namespace contains endpoints for:
- * - Shipping rules implications
- *
- * **Usage:**
  * Extend this class to create services for specific business domains within the CoreAPI Private.
  * Use {@see getApiConfig()} in your constructor when instantiating OpenAPI API classes.
- *
- * **Example:**
- * ```php
- * class ImplicationsService extends AbstractCoreApiPrivateService
- * {
- *     protected ImplicationsApi $implicationsApi;
- *
- *     public function __construct()
- *     {
- *         $this->implicationsApi = new ImplicationsApi(null, $this->getApiConfig());
- *     }
- *
- *     public function getImplications(array $rules): array
- *     {
- *         return $this->executeOperationWithErrorHandling(
- *             fn() => $this->implicationsApi->postShippingRulesImplications(...),
- *             'postShippingRulesImplications'
- *         );
- *     }
- * }
- * ```
  *
  * @see \MyParcelNL\Pdk\SdkApi\Service\AbstractSdkApiService
  * @see \MyParcelNL\Sdk\Client\Generated\CoreApiPrivate\Configuration

--- a/src/SdkApi/Service/CoreApiPrivate/AbstractCoreApiPrivateService.php
+++ b/src/SdkApi/Service/CoreApiPrivate/AbstractCoreApiPrivateService.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate;
+
+use MyParcelNL\Pdk\SdkApi\Service\AbstractSdkApiService;
+use MyParcelNL\Sdk\Client\Generated\CoreApiPrivate\Configuration as CoreApiPrivateConfiguration;
+
+/**
+ * Abstract base class for CoreAPI Private-specific services.
+ *
+ * This class extends the generic SDK service base with CoreAPI Private-specific configuration,
+ * providing a ready-to-use Configuration object for OpenAPI CoreAPI Private client classes.
+ *
+ * The CoreAPI Private namespace contains endpoints for:
+ * - Shipping rules implications
+ *
+ * **Usage:**
+ * Extend this class to create services for specific business domains within the CoreAPI Private.
+ * Use {@see getApiConfig()} in your constructor when instantiating OpenAPI API classes.
+ *
+ * **Example:**
+ * ```php
+ * class ImplicationsService extends AbstractCoreApiPrivateService
+ * {
+ *     protected ImplicationsApi $implicationsApi;
+ *
+ *     public function __construct()
+ *     {
+ *         $this->implicationsApi = new ImplicationsApi(null, $this->getApiConfig());
+ *     }
+ *
+ *     public function getImplications(array $rules): array
+ *     {
+ *         return $this->executeOperationWithErrorHandling(
+ *             fn() => $this->implicationsApi->postShippingRulesImplications(...),
+ *             'postShippingRulesImplications'
+ *         );
+ *     }
+ * }
+ * ```
+ *
+ * @see \MyParcelNL\Pdk\SdkApi\Service\AbstractSdkApiService
+ * @see \MyParcelNL\Sdk\Client\Generated\CoreApiPrivate\Configuration
+ */
+abstract class AbstractCoreApiPrivateService extends AbstractSdkApiService
+{
+    /**
+     * Get a configured CoreAPI Private configuration object.
+     *
+     * Factory: builds a fresh Configuration instance and delegates field-setting to
+     * {@see AbstractSdkApiService::applyConfigSettings()} so that the same business logic
+     * is shared with {@see AbstractSdkApiService::refreshApiConfig()}.
+     *
+     * @return CoreApiPrivateConfiguration The configured API configuration
+     */
+    public function getApiConfig(): CoreApiPrivateConfiguration
+    {
+        return $this->applyConfigSettings(new CoreApiPrivateConfiguration());
+    }
+}

--- a/src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php
+++ b/src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php
@@ -7,6 +7,7 @@ namespace MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\ShippingRule;
 use MyParcelNL\Pdk\Carrier\Repository\CarrierRepository;
 use MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\AbstractCoreApiPrivateService;
 use MyParcelNL\Sdk\Client\Generated\CoreApiPrivate\Api\ShippingRuleApi;
+use Throwable;
 
 /**
  * Retrieves shipping rule implications for a shop and extracts the default carrier name.
@@ -69,7 +70,7 @@ class ImplicationsService extends AbstractCoreApiPrivateService
             $carrier = $this->carrierRepository->findByLegacyId((int) $carrierId);
 
             return $carrier ? $carrier->carrier : null;
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             return null;
         }
     }

--- a/src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php
+++ b/src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\ShippingRule;
 
 use MyParcelNL\Pdk\Carrier\Contract\CarrierRepositoryInterface;
+use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\AbstractCoreApiPrivateService;
 use MyParcelNL\Sdk\Client\Generated\CoreApiPrivate\Api\ShippingRuleApi;
+use MyParcelNL\Sdk\Client\Generated\CoreApiPrivate\ApiException;
 use Throwable;
 
 /**
@@ -40,9 +42,6 @@ class ImplicationsService extends AbstractCoreApiPrivateService
      * it to a V2 carrier name via CarrierRepository. Returns null when the implications list
      * is empty, carrier_id is absent, the id is unmapped, or the API call fails.
      *
-     * Errors are intentionally not re-logged here: LoggingMiddleware already records all
-     * SDK request failures at the Guzzle transport layer before rethrowing.
-     *
      * @param  int $shopId
      *
      * @return null|string V2 carrier name (e.g. "POSTNL"), or null on any failure path.
@@ -70,7 +69,18 @@ class ImplicationsService extends AbstractCoreApiPrivateService
             $carrier = $this->carrierRepository->findByLegacyId((int) $carrierId);
 
             return $carrier ? $carrier->carrier : null;
+        } catch (ApiException $e) {
+            // Expected SDK request failure — LoggingMiddleware already logged the HTTP error
+            // at the Guzzle transport layer before the exception was rethrown.
+            return null;
         } catch (Throwable $e) {
+            // Unexpected error (TypeError on unexpected response shape, undefined offset, etc.).
+            // Log so programmer errors don't get silently masked.
+            Logger::error('Unexpected error fetching default carrier name', [
+                'exception' => get_class($e),
+                'message'   => $e->getMessage(),
+            ]);
+
             return null;
         }
     }

--- a/src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php
+++ b/src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\ShippingRule;
+
+use MyParcelNL\Pdk\Carrier\Repository\CarrierRepository;
+use MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\AbstractCoreApiPrivateService;
+use MyParcelNL\Sdk\Client\Generated\CoreApiPrivate\Api\ShippingRuleApi;
+
+/**
+ * Retrieves shipping rule implications for a shop and extracts the default carrier name.
+ */
+class ImplicationsService extends AbstractCoreApiPrivateService
+{
+    /**
+     * @var ShippingRuleApi
+     */
+    private $api;
+
+    /**
+     * @var CarrierRepository
+     */
+    private $carrierRepository;
+
+    /**
+     * @param  CarrierRepository $carrierRepository
+     */
+    public function __construct(CarrierRepository $carrierRepository)
+    {
+        $this->api               = new ShippingRuleApi($this->createGuzzleClient(), $this->getApiConfig());
+        $this->carrierRepository = $carrierRepository;
+    }
+
+    /**
+     * Return the V2 carrier name implied by the shop's shipping rules, or null when unavailable.
+     *
+     * Fetches the first implication returned for the shop, reads its carrier_id, and maps
+     * it to a V2 carrier name via CarrierRepository. Returns null when the implications list
+     * is empty, carrier_id is absent, the id is unmapped, or the API call fails.
+     *
+     * Errors are intentionally not re-logged here: LoggingMiddleware already records all
+     * SDK request failures at the Guzzle transport layer before rethrowing.
+     *
+     * @param  int $shopId
+     *
+     * @return null|string V2 carrier name (e.g. "POSTNL"), or null on any failure path.
+     */
+    public function getDefaultCarrierName(int $shopId): ?string
+    {
+        try {
+            $response     = $this->api->getShippingRuleImplications($shopId);
+            $implications = $response->getData()->getImplications();
+
+            if (empty($implications)) {
+                return null;
+            }
+
+            // getCarrierId() is declared as RefTypesCarrier (an integer enum), but the underlying
+            // container holds a raw int or null when carrier_id is absent from the API response.
+            $carrierId = $implications[0]->getCarrierId();
+
+            // @phpstan-ignore identical.alwaysFalse (carrier_id container value is a raw int or null at runtime; RefTypesCarrier is a constant-only enum class that is never instantiated)
+            if ($carrierId === null) {
+                return null;
+            }
+
+            // @phpstan-ignore cast.int (same reason: container holds a raw int, not an instantiated RefTypesCarrier)
+            $carrier = $this->carrierRepository->findByLegacyId((int) $carrierId);
+
+            return $carrier ? $carrier->carrier : null;
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getApiClients(): array
+    {
+        return [$this->api];
+    }
+}

--- a/src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php
+++ b/src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\ShippingRule;
 
-use MyParcelNL\Pdk\Carrier\Repository\CarrierRepository;
+use MyParcelNL\Pdk\Carrier\Contract\CarrierRepositoryInterface;
 use MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\AbstractCoreApiPrivateService;
 use MyParcelNL\Sdk\Client\Generated\CoreApiPrivate\Api\ShippingRuleApi;
 use Throwable;
@@ -20,14 +20,14 @@ class ImplicationsService extends AbstractCoreApiPrivateService
     private $api;
 
     /**
-     * @var CarrierRepository
+     * @var CarrierRepositoryInterface
      */
     private $carrierRepository;
 
     /**
-     * @param  CarrierRepository $carrierRepository
+     * @param  CarrierRepositoryInterface $carrierRepository
      */
-    public function __construct(CarrierRepository $carrierRepository)
+    public function __construct(CarrierRepositoryInterface $carrierRepository)
     {
         $this->api               = new ShippingRuleApi($this->createGuzzleClient(), $this->getApiConfig());
         $this->carrierRepository = $carrierRepository;

--- a/tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php
@@ -127,11 +127,8 @@ it('returns null when the first implication has no carrier_id', function () {
     $carrierRepository->shouldNotReceive('findByLegacyId');
 
     // Omit carrier_id so the deserialized model has null for that field.
-    $body    = (string) json_encode(['data' => ['implications' => [
-        ['contract_id' => 1, 'shipment_options' => [], 'physical_properties' => []],
-    ]]]);
     $service = new MockableImplicationsService($carrierRepository);
-    $service->mockHandler->append(new Response(200, [], $body));
+    $service->mockHandler->append(new Response(200, [], implResponse()));
 
     expect($service->getDefaultCarrierName(42))->toBeNull();
 });
@@ -183,7 +180,7 @@ it('passes shop_id through unchanged and does not add extra query params', funct
 
     $uri = $service->capturedRequests[0]->getUri();
 
-    expect((string) $uri->getPath())->toContain('/shops/42/shipping_rules/implications')
+    expect((string) $uri->getPath())->toBe('/shops/42/shipping_rules/implications')
         ->and($uri->getQuery())->toBe('');
 });
 

--- a/tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Mockery;
 use MyParcelNL\Pdk\Carrier\Model\Carrier;
-use MyParcelNL\Pdk\Carrier\Repository\CarrierRepository;
+use MyParcelNL\Pdk\Carrier\Contract\CarrierRepositoryInterface;
 use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
 use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
 use Psr\Http\Message\RequestInterface;
@@ -33,7 +33,7 @@ class MockableImplicationsService extends ImplicationsService
     /** @var RequestInterface[] */
     public $capturedRequests = [];
 
-    public function __construct(CarrierRepository $carrierRepository)
+    public function __construct(CarrierRepositoryInterface $carrierRepository)
     {
         $this->mockHandler = new MockHandler();
         parent::__construct($carrierRepository);
@@ -94,7 +94,7 @@ function emptyImplResponse(): string
 it('returns the V2 carrier name when implications contain a known carrier id', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
     $carrierRepository->shouldReceive('findByLegacyId')
         ->once()
         ->with(1)
@@ -110,7 +110,7 @@ it('returns the V2 carrier name when implications contain a known carrier id', f
 it('returns null when the implications array is empty', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
     $carrierRepository->shouldNotReceive('findByLegacyId');
 
     $service = new MockableImplicationsService($carrierRepository);
@@ -123,7 +123,7 @@ it('returns null when the implications array is empty', function () {
 it('returns null when the first implication has no carrier_id', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
     $carrierRepository->shouldNotReceive('findByLegacyId');
 
     // Omit carrier_id so the deserialized model has null for that field.
@@ -139,7 +139,7 @@ it('returns null when the carrier id is not found in the carrier repository', fu
 
     // Use a valid SDK enum value (2 = BPOST) that is not present in this shop's carriers.
     // findByLegacyId returns null when the carrier is not in the account's carrier list.
-    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
     $carrierRepository->shouldReceive('findByLegacyId')
         ->once()
         ->with(2)
@@ -155,7 +155,7 @@ it('returns null when the carrier id is not found in the carrier repository', fu
 it('returns null when the API returns a non-2xx response', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
     $carrierRepository->shouldNotReceive('findByLegacyId');
 
     $service = new MockableImplicationsService($carrierRepository);
@@ -168,7 +168,7 @@ it('returns null when the API returns a non-2xx response', function () {
 it('passes shop_id through unchanged and does not add extra query params', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
     $carrierRepository->shouldReceive('findByLegacyId')->andReturn(new Carrier(['carrier' => 'POSTNL']));
 
     $service = new MockableImplicationsService($carrierRepository);

--- a/tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php
@@ -1,0 +1,208 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection,PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\ShippingRule;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use Mockery;
+use MyParcelNL\Pdk\Carrier\Model\Carrier;
+use MyParcelNL\Pdk\Carrier\Repository\CarrierRepository;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use Psr\Http\Message\RequestInterface;
+
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPdkInstance());
+
+/**
+ * Test subclass that replaces only the real Guzzle transport with a MockHandler.
+ *
+ * Overrides createGuzzleClient() so the full real middleware chain from
+ * AbstractSdkApiService (LoggingMiddleware) is preserved without duplication.
+ */
+class MockableImplicationsService extends ImplicationsService
+{
+    /** @var MockHandler */
+    public $mockHandler;
+
+    /** @var RequestInterface[] */
+    public $capturedRequests = [];
+
+    public function __construct(CarrierRepository $carrierRepository)
+    {
+        $this->mockHandler = new MockHandler();
+        parent::__construct($carrierRepository);
+    }
+
+    protected function createGuzzleClient(): \GuzzleHttp\Client
+    {
+        $capturedRequests = &$this->capturedRequests;
+
+        $stack = $this->createGuzzleClientHandlerStack();
+        $stack->setHandler($this->mockHandler);
+
+        $stack->push(function (callable $handler) use (&$capturedRequests) {
+            return function (RequestInterface $request, array $options) use ($handler, &$capturedRequests) {
+                $capturedRequests[] = $request;
+
+                return $handler($request, $options);
+            };
+        });
+
+        return new \GuzzleHttp\Client(['handler' => $stack]);
+    }
+}
+
+/**
+ * Build a response body with one implication entry.
+ *
+ * @param  int|null $carrierId  Omit carrier_id from the implication when null.
+ * @param  array    $extra      Extra fields merged into the implication object.
+ *
+ * @return string JSON-encoded response body.
+ */
+function implResponse(?int $carrierId = null, array $extra = []): string
+{
+    $implication = array_merge(
+        ['contract_id' => 1, 'shipment_options' => [], 'physical_properties' => []],
+        $extra
+    );
+
+    if ($carrierId !== null) {
+        $implication['carrier_id'] = $carrierId;
+    }
+
+    return (string) json_encode(['data' => ['implications' => [$implication]]]);
+}
+
+/**
+ * Build a response body with an empty implications array.
+ *
+ * @return string JSON-encoded response body.
+ */
+function emptyImplResponse(): string
+{
+    return (string) json_encode(['data' => ['implications' => []]]);
+}
+
+// Test 1: returns V2 name on success
+it('returns the V2 carrier name when implications contain a known carrier id', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository->shouldReceive('findByLegacyId')
+        ->once()
+        ->with(1)
+        ->andReturn(new Carrier(['carrier' => 'POSTNL']));
+
+    $service = new MockableImplicationsService($carrierRepository);
+    $service->mockHandler->append(new Response(200, [], implResponse(1)));
+
+    expect($service->getDefaultCarrierName(42))->toBe('POSTNL');
+});
+
+// Test 2: returns null when implications array is empty
+it('returns null when the implications array is empty', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository->shouldNotReceive('findByLegacyId');
+
+    $service = new MockableImplicationsService($carrierRepository);
+    $service->mockHandler->append(new Response(200, [], emptyImplResponse()));
+
+    expect($service->getDefaultCarrierName(42))->toBeNull();
+});
+
+// Test 3: returns null when carrier_id is absent from the implication
+it('returns null when the first implication has no carrier_id', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository->shouldNotReceive('findByLegacyId');
+
+    // Omit carrier_id so the deserialized model has null for that field.
+    $body    = (string) json_encode(['data' => ['implications' => [
+        ['contract_id' => 1, 'shipment_options' => [], 'physical_properties' => []],
+    ]]]);
+    $service = new MockableImplicationsService($carrierRepository);
+    $service->mockHandler->append(new Response(200, [], $body));
+
+    expect($service->getDefaultCarrierName(42))->toBeNull();
+});
+
+// Test 4: returns null when carrier id is not found in CarrierRepository
+it('returns null when the carrier id is not found in the carrier repository', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    // Use a valid SDK enum value (2 = BPOST) that is not present in this shop's carriers.
+    // findByLegacyId returns null when the carrier is not in the account's carrier list.
+    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository->shouldReceive('findByLegacyId')
+        ->once()
+        ->with(2)
+        ->andReturn(null);
+
+    $service = new MockableImplicationsService($carrierRepository);
+    $service->mockHandler->append(new Response(200, [], implResponse(2)));
+
+    expect($service->getDefaultCarrierName(42))->toBeNull();
+});
+
+// Test 5: returns null on API error response
+it('returns null when the API returns a non-2xx response', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository->shouldNotReceive('findByLegacyId');
+
+    $service = new MockableImplicationsService($carrierRepository);
+    $service->mockHandler->append(new Response(500, [], '{"error":"internal server error"}'));
+
+    expect($service->getDefaultCarrierName(42))->toBeNull();
+});
+
+// Test 6: shop_id is passed through unchanged in the request URI
+it('passes shop_id through unchanged and does not add extra query params', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    $carrierRepository = Mockery::mock(CarrierRepository::class);
+    $carrierRepository->shouldReceive('findByLegacyId')->andReturn(new Carrier(['carrier' => 'POSTNL']));
+
+    $service = new MockableImplicationsService($carrierRepository);
+    $service->mockHandler->append(new Response(200, [], implResponse(1)));
+
+    $service->getDefaultCarrierName(42);
+
+    expect($service->capturedRequests)->toHaveCount(1);
+
+    $uri = $service->capturedRequests[0]->getUri();
+
+    expect((string) $uri->getPath())->toContain('/shops/42/shipping_rules/implications')
+        ->and($uri->getQuery())->toBe('');
+});
+
+// Test 7: service surface is restricted to exactly one public non-constructor non-inherited method
+it('exposes only getDefaultCarrierName as a public non-constructor non-inherited method', function () {
+    $reflection    = new \ReflectionClass(ImplicationsService::class);
+    $parentMethods = array_map(
+        static function (\ReflectionMethod $m): string { return $m->getName(); },
+        (new \ReflectionClass(get_parent_class(ImplicationsService::class)))->getMethods(\ReflectionMethod::IS_PUBLIC)
+    );
+
+    $ownPublicMethods = array_values(array_filter(
+        $reflection->getMethods(\ReflectionMethod::IS_PUBLIC),
+        static function (\ReflectionMethod $m) use ($parentMethods): bool {
+            return $m->getName() !== '__construct'
+                && ! in_array($m->getName(), $parentMethods, true);
+        }
+    ));
+
+    expect($ownPublicMethods)->toHaveCount(1)
+        ->and($ownPublicMethods[0]->getName())->toBe('getDefaultCarrierName');
+});

--- a/tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php
@@ -152,16 +152,67 @@ it('returns null when the carrier id is not found in the carrier repository', fu
 });
 
 // Test 5: returns null on API error response
-it('returns null when the API returns a non-2xx response', function () {
+it('returns null on ApiException without re-logging at the service layer', function () {
     TestBootstrapper::hasApiKey('test-key');
 
     $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
     $carrierRepository->shouldNotReceive('findByLegacyId');
 
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = \MyParcelNL\Pdk\Facade\Pdk::get(\MyParcelNL\Pdk\Logger\Contract\PdkLoggerInterface::class);
+    $logger->clear();
+
     $service = new MockableImplicationsService($carrierRepository);
     $service->mockHandler->append(new Response(500, [], '{"error":"internal server error"}'));
 
     expect($service->getDefaultCarrierName(42))->toBeNull();
+
+    // LoggingMiddleware logs the HTTP failure, but the service must NOT add its own
+    // "unexpected error" log for an expected SDK ApiException.
+    foreach ($logger->getLogs(\Psr\Log\LogLevel::ERROR) as $log) {
+        expect($log['message'] ?? '')->not->toContain('Unexpected error fetching default carrier name');
+    }
+});
+
+it('logs an unexpected error and returns null when a non-API exception bubbles up', function () {
+    TestBootstrapper::hasApiKey('test-key');
+
+    // Force a TypeError out of CarrierRepository to simulate a programmer error somewhere
+    // inside the try block. The ApiException catch must NOT swallow this — the Throwable
+    // catch must log it before returning null so the bug is surfaced.
+    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
+    $carrierRepository->shouldReceive('findByLegacyId')
+        ->once()
+        ->andThrow(new \TypeError('unexpected boom'));
+
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = \MyParcelNL\Pdk\Facade\Pdk::get(\MyParcelNL\Pdk\Logger\Contract\PdkLoggerInterface::class);
+    $logger->clear();
+
+    $service = new MockableImplicationsService($carrierRepository);
+    $service->mockHandler->append(new Response(200, [], implResponse(1)));
+
+    expect($service->getDefaultCarrierName(42))->toBeNull();
+
+    $errors = $logger->getLogs(\Psr\Log\LogLevel::ERROR);
+
+    expect($errors)->not->toBeEmpty();
+
+    $hasUnexpectedLog = false;
+
+    foreach ($errors as $log) {
+        $message   = $log['message'] ?? '';
+        $exception = $log['context']['exception'] ?? '';
+
+        if (strpos($message, 'Unexpected error fetching default carrier name') !== false
+            && strpos($exception, 'TypeError') !== false) {
+            $hasUnexpectedLog = true;
+
+            break;
+        }
+    }
+
+    expect($hasUnexpectedLog)->toBeTrue();
 });
 
 // Test 6: shop_id is passed through unchanged in the request URI


### PR DESCRIPTION
## Summary

Adds the PDK-side service that calls the CoreAPI shipping-rules `implications` endpoint to retrieve the default carrier configured for a shop. No callers are wired up in this PR; the service is additive infrastructure consumed by the follow-up that replaces the hard-coded default in proposition config.

No functional change for end users in this PR — default carrier selection still flows from proposition config until INT-1479 lands.

Design: `docs/superpowers/specs/2026-05-19-default-carrier-from-shipping-rules-design.md` (PR 1 section).

## Status

Draft — implementation in progress. Tracking 3 tasks per the plan:

- [x] **Task 1**: \`executeOperationWithErrorHandling\` helper on \`AbstractSdkApiService\` + tests
- [ ] **Task 2**: \`AbstractCoreApiPrivateService\` base class
- [ ] **Task 3**: \`ImplicationsService\` (the actual shipping-rules wrapper) + tests

This PR also depends on the SDK release that publishes the \`CoreApiPrivate\` namespace ([SDK branch \`feat/placeholder-private-coreapi-client-for-shipping-rules\`](https://github.com/myparcelnl/sdk)). The local \`composer.json\` is staged via path-repo for development; the committed \`composer.json\` change to bump the pin happens once the SDK release ships.

## Test plan

- [ ] \`docker compose run --rm php composer test:unit\` — all PDK unit tests pass
- [ ] \`docker compose run --rm php composer analyse\` — PHPStan clean
- [ ] After SDK release: bump \`myparcelnl/sdk\` pin, drop the local path repo, re-run tests
- [ ] After PR 2 (INT-1479) consumer wiring lands: smoke check that \`Pdk::get(ImplicationsService::class)->getDefaultCarrierName(\$shopId)\` returns the expected V2 carrier name against a real API key

Resolves INT-1586
Resolves INT-1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)