### PR TITLE
feat: enable manual shipment export inside Order v2

### DIFF
--- a/config/pdk-default.php
+++ b/config/pdk-default.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use MyParcelNL\Pdk\Account\Contract\AccountFeaturesServiceInterface;
 use MyParcelNL\Pdk\Base\Support\Arr;
 use MyParcelNL\Pdk\Facade\AccountSettings;
 use MyParcelNL\Pdk\Facade\Pdk;
@@ -85,24 +86,32 @@ return [
      */
 
     'allBulkActions' => value([
-        'default'   => [
+        'Shipments' => [
             'action_print',
             'action_export_print',
             'action_export',
             'action_edit',
         ],
-        'orderMode' => [
+        'OrderV1'   => [
             'action_edit',
             'action_export',
+        ],
+        'OrderV2'   => [
+            'action_print',
+            'action_export_print',
+            'action_export',
+            'action_edit',
         ],
     ]),
 
     'bulkActions'              => factory(static function (): array {
         $all = PdkFacade::get('allBulkActions');
+        $key = [
+            AccountFeaturesServiceInterface::ORDER_MODE_V1 => 'OrderV1',
+            AccountFeaturesServiceInterface::ORDER_MODE_V2 => 'OrderV2',
+        ][AccountSettings::getEffectiveOrderMode()] ?? 'Shipments';
 
-        return AccountSettings::usesOrderMode()
-            ? Arr::get($all, 'orderMode', [])
-            : Arr::get($all, 'default', []);
+        return Arr::get($all, $key, []);
     }),
 
     /**

--- a/src/Account/Contract/AccountFeaturesServiceInterface.php
+++ b/src/Account/Contract/AccountFeaturesServiceInterface.php
@@ -45,4 +45,26 @@ interface AccountFeaturesServiceInterface
      * @return int
      */
     public function getOrderModeVersion(): int;
+
+    /**
+     * The order management version the PDK should behave as.
+     *
+     * Use this from any code path that adapts behaviour to the order management mode
+     * — export dispatch, bulk actions, settings filtering, UI gating, webhook routing.
+     * Returns one of the same {@see self::ORDER_MODE_*} constants as
+     * {@see self::getOrderModeVersion()}, but the value may diverge from the raw mode
+     * once business rules layer on top.
+     *
+     * Reserve {@see self::getOrderModeVersion()} for code that genuinely needs the raw
+     * IAM feature value (display, diagnostics, or behaviour that must follow IAM
+     * regardless of plugin-side business rules).
+     *
+     * @TODO INT-1590: implementations will downgrade ORDER_MODE_V2 to
+     *       ORDER_MODE_SHIPMENTS when the customer has no active sales channel,
+     *       so manual shipment export keeps working without callers needing
+     *       per-mode branches.
+     *
+     * @return int
+     */
+    public function getEffectiveOrderMode(): int;
 }

--- a/src/Account/Contract/AccountSettingsServiceInterface.php
+++ b/src/Account/Contract/AccountSettingsServiceInterface.php
@@ -42,6 +42,11 @@ interface AccountSettingsServiceInterface
     public function getOrderModeVersion(): int;
 
     /**
+     * @return int
+     */
+    public function getEffectiveOrderMode(): int;
+
+    /**
      * @return bool
      */
     public function usesOrderMode(): bool;

--- a/src/Account/Service/AccountSettingsService.php
+++ b/src/Account/Service/AccountSettingsService.php
@@ -139,6 +139,21 @@ class AccountSettingsService implements AccountSettingsServiceInterface
     }
 
     /**
+     * The order management version the PDK should behave as.
+     *
+     * Delegates to {@see AccountFeaturesServiceInterface::getEffectiveOrderMode()} —
+     * see there for intent and future evolution. Use this (or its facade
+     * {@see \MyParcelNL\Pdk\Facade\AccountSettings::getEffectiveOrderMode()}) for any
+     * code path that adapts behaviour to the order management mode.
+     *
+     * @return int
+     */
+    public function getEffectiveOrderMode(): int
+    {
+        return $this->featuresService->getEffectiveOrderMode();
+    }
+
+    /**
      * @return bool
      */
     public function usesOrderMode(): bool

--- a/src/Account/Service/PdkAccountFeaturesService.php
+++ b/src/Account/Service/PdkAccountFeaturesService.php
@@ -117,6 +117,28 @@ class PdkAccountFeaturesService implements AccountFeaturesServiceInterface
     }
 
     /**
+     * The order management version the PDK should behave as.
+     *
+     * Use this from any code path that adapts behaviour to the order management mode —
+     * export dispatch, bulk actions, settings filtering, UI gating, webhook routing.
+     * Keep {@see self::getOrderModeVersion()} for code that genuinely needs the raw IAM
+     * feature value (display, diagnostics).
+     *
+     * In this phase the value is identical to the raw mode; the hybrid-V2 behaviour
+     * lives in the callers rather than here.
+     *
+     * @TODO INT-1590: downgrade ORDER_MODE_V2 to ORDER_MODE_SHIPMENTS when the
+     *       customer has no active sales channel, so manual shipment export keeps
+     *       working without callers needing per-mode branches.
+     *
+     * @return int
+     */
+    public function getEffectiveOrderMode(): int
+    {
+        return $this->getOrderModeVersion();
+    }
+
+    /**
      * @param  string $featureName
      *
      * @return bool

--- a/src/App/Action/Backend/Order/ExportOrderAction.php
+++ b/src/App/Action/Backend/Order/ExportOrderAction.php
@@ -104,21 +104,23 @@ class ExportOrderAction extends AbstractOrderAction
      */
     protected function export(PdkOrderCollection $orders, Request $request): PdkOrderCollection
     {
-        if (! AccountSettings::usesOrderMode()) {
-            return $this->exportShipments($orders);
+        if (AccountFeaturesServiceInterface::ORDER_MODE_V1 === AccountSettings::getEffectiveOrderMode()) {
+            $response = $this->exportOrders($orders);
+
+            Actions::execute(PdkBackendActions::POST_ORDER_NOTES, [
+                'orderIds' => $this->getOrderIds($request),
+            ]);
+
+            return $response;
         }
 
-        if (AccountSettings::getOrderModeVersion() >= AccountFeaturesServiceInterface::ORDER_MODE_V2) {
-            return $orders;
-        }
-
-        $response = $this->exportOrders($orders);
-
-        Actions::execute(PdkBackendActions::POST_ORDER_NOTES, [
-            'orderIds' => $this->getOrderIds($request),
-        ]);
-
-        return $response;
+        // SHIPMENTS or V2 — both currently run the shipments-export path so manual export
+        // works inside V2 (hybrid: V2 fulfilment continues externally, manual export creates
+        // shipments via the shipments API).
+        // @TODO INT-1590: once sales-channel detection lands, V2 should become a distinct
+        //       no-op branch here so manual export does not duplicate sales-channel-driven
+        //       fulfilment.
+        return $this->exportShipments($orders);
     }
 
     /**

--- a/src/App/Webhook/Service/ShipmentWebhookService.php
+++ b/src/App/Webhook/Service/ShipmentWebhookService.php
@@ -41,9 +41,9 @@ class ShipmentWebhookService
      */
     public function handleStatusChange(array $content): void
     {
-        $orderModeVersion = (int) $this->accountFeaturesService->getOrderModeVersion();
+        $effectiveMode = (int) $this->accountFeaturesService->getEffectiveOrderMode();
 
-        $orderIds = $this->getOrderIds($content, $orderModeVersion);
+        $orderIds = $this->getOrderIds($content, $effectiveMode);
 
         if (empty($orderIds)) {
             $this->logSkippedWebhook(
@@ -64,9 +64,14 @@ class ShipmentWebhookService
      */
     public function handleLabelCreated(array $content): void
     {
-        $orderModeVersion = (int) $this->accountFeaturesService->getOrderModeVersion();
+        $effectiveMode = (int) $this->accountFeaturesService->getEffectiveOrderMode();
 
-        if (AccountFeaturesServiceInterface::ORDER_MODE_V2 !== $orderModeVersion) {
+        // V1 has its own order-id flow via handleStatusChange and does not process
+        // label_created webhooks. V2 and SHIPMENTS both arrive on the wire with
+        // shipment_reference_identifier === plugin externalIdentifier (whether the
+        // shipment was created via V2 fulfillment or a manual export), so one path
+        // covers both.
+        if (AccountFeaturesServiceInterface::ORDER_MODE_V1 === $effectiveMode) {
             return;
         }
 
@@ -74,7 +79,7 @@ class ShipmentWebhookService
 
         if (empty($orderIds)) {
             $this->logSkippedWebhook(
-                'Skipping order v2 shipment webhook without a shipment reference identifier',
+                'Skipping shipment label created webhook without a shipment reference identifier',
                 $content
             );
 
@@ -86,13 +91,13 @@ class ShipmentWebhookService
 
     /**
      * @param  array $content
-     * @param  int   $orderModeVersion
+     * @param  int   $effectiveMode
      *
      * @return string[]
      */
-    private function getOrderIds(array $content, int $orderModeVersion): array
+    private function getOrderIds(array $content, int $effectiveMode): array
     {
-        if (AccountFeaturesServiceInterface::ORDER_MODE_V1 === $orderModeVersion) {
+        if (AccountFeaturesServiceInterface::ORDER_MODE_V1 === $effectiveMode) {
             return $this->getOrderIdsForOrderV1($content);
         }
 

--- a/src/Facade/AccountSettings.php
+++ b/src/Facade/AccountSettings.php
@@ -13,6 +13,7 @@ use MyParcelNL\Pdk\Carrier\Collection\CarrierCollection;
 /**
  * @method static null|Account getAccount()
  * @method static CarrierCollection getCarriers()
+ * @method static int getEffectiveOrderMode()
  * @method static int getOrderModeVersion()
  * @method static null|Shop getShop()
  * @method static bool hasCarrier(string $name)

--- a/tests/Unit/Account/Service/PdkAccountFeaturesServiceTest.php
+++ b/tests/Unit/Account/Service/PdkAccountFeaturesServiceTest.php
@@ -92,6 +92,29 @@ it('returns 0 (shipments fallback) when account has no features at all', functio
     expect($service->getOrderModeVersion())->toBe(AccountFeaturesServiceInterface::ORDER_MODE_SHIPMENTS);
 });
 
+// getEffectiveOrderMode — identity today (INT-1590 will add sales-channel-conditional logic)
+
+it('returns the raw mode unchanged from getEffectiveOrderMode when V2 is active', function () {
+    TestBootstrapper::hasSubscriptionFeatures([PdkAccountFeaturesService::FEATURE_ORDER_MANAGEMENT]);
+    $service = Pdk::get(AccountFeaturesServiceInterface::class);
+
+    expect($service->getEffectiveOrderMode())->toBe(AccountFeaturesServiceInterface::ORDER_MODE_V2);
+});
+
+it('returns the raw mode unchanged from getEffectiveOrderMode when V1 is active', function () {
+    TestBootstrapper::hasSubscriptionFeatures([PdkAccountFeaturesService::FEATURE_LEGACY_ORDER_MANAGEMENT]);
+    $service = Pdk::get(AccountFeaturesServiceInterface::class);
+
+    expect($service->getEffectiveOrderMode())->toBe(AccountFeaturesServiceInterface::ORDER_MODE_V1);
+});
+
+it('returns the raw mode unchanged from getEffectiveOrderMode when no order management is active', function () {
+    TestBootstrapper::hasSubscriptionFeatures([]);
+    $service = Pdk::get(AccountFeaturesServiceInterface::class);
+
+    expect($service->getEffectiveOrderMode())->toBe(AccountFeaturesServiceInterface::ORDER_MODE_SHIPMENTS);
+});
+
 // usesOrderMode
 
 it('returns true for usesOrderMode when any order management feature is present', function () {

--- a/tests/Unit/App/Action/Backend/Order/ExportOrderActionTest.php
+++ b/tests/Unit/App/Action/Backend/Order/ExportOrderActionTest.php
@@ -509,7 +509,7 @@ it('exports orders and returns correct action response shape', function (
         ->toArray();
 
     TestBootstrapper::hasSubscriptionFeatures(
-        $orderMode ? [PdkAccountFeaturesService::FEATURE_ORDER_MANAGEMENT] : []
+        $orderMode ? [PdkAccountFeaturesService::FEATURE_LEGACY_ORDER_MANAGEMENT] : []
     );
 
     factory(Settings::class)
@@ -574,7 +574,7 @@ it('merges partial payload with existing order', function (
         ->toArray();
 
     TestBootstrapper::hasSubscriptionFeatures(
-        $orderMode ? [PdkAccountFeaturesService::FEATURE_ORDER_MANAGEMENT] : []
+        $orderMode ? [PdkAccountFeaturesService::FEATURE_LEGACY_ORDER_MANAGEMENT] : []
     );
 
     factory(Settings::class)
@@ -822,6 +822,41 @@ it('exports order and directly returns barcode if concept shipments is off', fun
         ->toHaveLength(count($responseOrders))
         ->and($response->getStatusCode())
         ->toBe(200)
+        ->and($responseShipments)->each->toHaveLength(1)
+        ->and(Arr::pluck($responseShipments[0], 'id'))->each->toBeInt();
+});
+
+it('exports as shipments under order v2 (hybrid: V2 fulfilment continues externally, manual export creates shipments)', function () {
+    TestBootstrapper::hasSubscriptionFeatures([PdkAccountFeaturesService::FEATURE_ORDER_MANAGEMENT]);
+
+    factory(Settings::class)
+        ->withCarrier(RefCapabilitiesSharedCarrierV2::POSTNL)
+        ->store();
+
+    $collection = factory(PdkOrderCollection::class, 1)
+        ->store()
+        ->make();
+
+    // Hybrid V2 takes the shipments-export path, so we enqueue a shipments response,
+    // not a fulfilment-orders one.
+    MockApi::enqueue(new ExamplePostShipmentsResponse());
+
+    $response = Actions::execute(PdkBackendActions::EXPORT_ORDERS, [
+        'orderIds' => Arr::pluck($collection->toArray(), 'externalIdentifier'),
+    ]);
+
+    $content           = json_decode($response->getContent(), true);
+    $responseOrders    = $content['data']['orders'];
+    $responseShipments = Arr::pluck($responseOrders, 'shipments');
+
+    $lastRequest = MockApi::ensureLastRequest();
+    $body        = json_decode($lastRequest->getBody()->getContents(), true);
+
+    expect($response->getStatusCode())->toBe(200)
+        // Shipments path was taken (data.shipments present, not data.orders[].shipment).
+        ->and($body['data'])->toHaveKey('shipments')
+        ->and($body['data'])->not->toHaveKey('orders')
+        // Each plugin order received a shipment from the shipments API.
         ->and($responseShipments)->each->toHaveLength(1)
         ->and(Arr::pluck($responseShipments[0], 'id'))->each->toBeInt();
 });

--- a/tests/Unit/App/Webhook/Hook/ShipmentLabelCreatedWebhookTest.php
+++ b/tests/Unit/App/Webhook/Hook/ShipmentLabelCreatedWebhookTest.php
@@ -191,7 +191,7 @@ it('uses fetched shipment status for order status updates instead of webhook sta
     expect($statusLog['context']['status'])->toBe(OrderSettings::STATUS_WHEN_LABEL_SCANNED);
 });
 
-it('skips order v2 label created webhook when shipment reference identifier is missing', function () {
+it('skips label created webhook when shipment reference identifier is missing', function () {
     setShipmentLabelCreatedAccountFeatures([PdkAccountFeaturesService::FEATURE_ORDER_MANAGEMENT]);
 
     $body = validShipmentLabelCreatedHookBody(['shipment_reference_identifier' => null]);
@@ -203,7 +203,7 @@ it('skips order v2 label created webhook when shipment reference identifier is m
         ->and($result['logger']->getLogs('debug'))
         ->toContain([
             'level'   => 'debug',
-            'message' => '[PDK]: Skipping order v2 shipment webhook without a shipment reference identifier',
+            'message' => '[PDK]: Skipping shipment label created webhook without a shipment reference identifier',
             'context' => [
                 'shipment_id'                   => 231032886,
                 'order_id'                      => null,
@@ -233,13 +233,25 @@ it('skips order v2 label created webhook when shipment id is missing', function 
         ]);
 });
 
-it('keeps shipment label created as a no-op outside order v2', function (array $features) {
-    setShipmentLabelCreatedAccountFeatures($features);
+it('keeps shipment label created as a no-op for order v1', function () {
+    setShipmentLabelCreatedAccountFeatures([PdkAccountFeaturesService::FEATURE_LEGACY_ORDER_MANAGEMENT]);
 
     $result = dispatchShipmentLabelCreatedWebhook(validShipmentLabelCreatedHookBody(), false);
 
     expect($result['actions']->getCalls())->toHaveCount(0);
-})->with([
-    'shipments only' => [[]],
-    'order v1'       => [[PdkAccountFeaturesService::FEATURE_LEGACY_ORDER_MANAGEMENT]],
-]);
+});
+
+it('dispatches update shipments for label created webhooks in shipments-only mode', function () {
+    setShipmentLabelCreatedAccountFeatures([]);
+
+    $result = dispatchShipmentLabelCreatedWebhook(validShipmentLabelCreatedHookBody());
+    $call   = $result['actions']->getCalls()->firstWhere('action', PdkBackendActions::UPDATE_SHIPMENTS);
+
+    expect($call['parameters'])
+        ->toMatchArray([
+            'orderIds'                        => ['197'],
+            'shipmentIds'                     => [231032886],
+            'useShipmentStatusForOrderStatus' => true,
+            'linkFirstShipmentToFirstOrder'   => true,
+        ]);
+});

--- a/tests/Unit/Base/Config/BulkActionsDefinitionTest.php
+++ b/tests/Unit/Base/Config/BulkActionsDefinitionTest.php
@@ -11,12 +11,12 @@ use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Tests\Bootstrap\MockPdkFactory;
 use function MyParcelNL\Pdk\Tests\factory;
 
-it('gets bulk actions', function (bool $orderMode, array $actions) {
+it('gets bulk actions for the active order mode', function (array $features, array $actions) {
     MockPdkFactory::create();
 
-    if ($orderMode) {
+    if (! empty($features)) {
         factory(Account::class)
-            ->withSubscriptionFeatures([PdkAccountFeaturesService::FEATURE_ORDER_MANAGEMENT])
+            ->withSubscriptionFeatures($features)
             ->store();
     }
 
@@ -29,9 +29,9 @@ it('gets bulk actions', function (bool $orderMode, array $actions) {
         ->toBe($actions);
 })
     ->with([
-        'default' => [
-            'order mode' => false,
-            'default'    => [
+        'shipments mode' => [
+            'features' => [],
+            'actions'  => [
                 'action_print',
                 'action_export_print',
                 'action_export',
@@ -39,11 +39,21 @@ it('gets bulk actions', function (bool $orderMode, array $actions) {
             ],
         ],
 
-        'order mode' => [
-            'order mode' => true,
-            'actions'    => [
+        'order v1 mode' => [
+            'features' => [PdkAccountFeaturesService::FEATURE_LEGACY_ORDER_MANAGEMENT],
+            'actions'  => [
                 'action_edit',
                 'action_export',
+            ],
+        ],
+
+        'order v2 mode (hybrid: shipment-mode actions remain available)' => [
+            'features' => [PdkAccountFeaturesService::FEATURE_ORDER_MANAGEMENT],
+            'actions'  => [
+                'action_print',
+                'action_export_print',
+                'action_export',
+                'action_edit',
             ],
         ],
     ]);


### PR DESCRIPTION
Order v2 plugins previously hid shipment-export buttons and dropped the matching webhooks, leaving merchants without an active sales channel unable to create labels. This change makes V2 behave as a hybrid of V2 and shipment mode: manual export creates shipments via the standard shipments flow, and incoming `shipment_label_created` and `status_change` webhooks are routed through the same reference-identifier path that shipment-only mode uses, with non-matching references silently dropped as the implicit filter for foreign integrators.

A new `AccountFeaturesServiceInterface::getEffectiveOrderMode()` seam is introduced as the single read site for mode-driven behaviour. It returns the raw mode unchanged in this phase; INT-1590 will land its sales-channel-conditional downgrade inside this one method without touching call sites or plugins. `ExportOrderAction`, the `bulkActions` config and `ShipmentWebhookService` all read effective mode now.

The default `allBulkActions` config expands to `Shipments` / `OrderV1` / `OrderV2` keys; the `OrderV2` row receives the same actions as `Shipments` to realise the hybrid. Order v1 behaviour is unchanged.

Resolves INT-1594
Resolves INT-1504