### PR TITLE
fix: correct insurance cents-to-micros conversion factor

### DIFF
--- a/src/App/Endpoint/Resource/DeliveryOptionsV1Resource.php
+++ b/src/App/Endpoint/Resource/DeliveryOptionsV1Resource.php
@@ -100,8 +100,8 @@ final class DeliveryOptionsV1Resource extends AbstractVersionedResource
 
         foreach ($filteredOptions as $key => $value) {
             if ($key === ShipmentOptions::INSURANCE) {
-                // Insurance amount converted to integer micro as per ADR-0014
-                $amount = ((int)$value) * 1_000_000;
+                // Insurance is stored in cents; convert to integer micros (1 cent = 10_000 micros).
+                $amount = ((int)$value) * 10_000;
                 $currency = (new ISO4217())->getByAlpha3('EUR'); // Assuming EUR, adjust in the future as needed
                 $formattedOptions[$orderApiShipmentOptions['insurance']] = ['amount' => $amount, 'currency' => $currency['alpha3']];
             } elseif ($key === ShipmentOptions::LABEL_DESCRIPTION) {

--- a/tests/Unit/App/Endpoint/GetDeliveryOptionsEndpointTest.php
+++ b/tests/Unit/App/Endpoint/GetDeliveryOptionsEndpointTest.php
@@ -321,7 +321,7 @@ it('insurance: resolves to exportInsuranceUpTo amount in micro-units when shipme
     factory(Settings::class)
         ->withCarrier('postnl', [
             CarrierSettings::EXPORT_INSURANCE        => true,
-            CarrierSettings::EXPORT_INSURANCE_UP_TO => 500,
+            CarrierSettings::EXPORT_INSURANCE_UP_TO => 50000, // 50000 cents = €500
         ])
         ->store();
 
@@ -332,7 +332,8 @@ it('insurance: resolves to exportInsuranceUpTo amount in micro-units when shipme
 
     $content = json_decode($response->getContent(), true);
 
-    expect($content['shipmentOptions']['insurance']['amount'])->toBe(500 * 1_000_000);
+    // 50000 cents (€500) → 500_000_000 micros
+    expect($content['shipmentOptions']['insurance']['amount'])->toBe(50000 * 10_000);
 
     Pdk::get(PdkSettingsRepositoryInterface::class)->reset();
 });
@@ -385,8 +386,9 @@ it('insurance: preserves an explicit monetary amount already set on the order sh
 
     $content = json_decode($response->getContent(), true);
 
-    // The explicit amount (10000) must win over the carrier setting (500).
-    expect($content['shipmentOptions']['insurance']['amount'])->toBe(10000 * 1_000_000);
+    // The explicit amount (10000 cents = €100) must win over the carrier setting (500 cents).
+    // 10000 cents → 100_000_000 micros
+    expect($content['shipmentOptions']['insurance']['amount'])->toBe(10000 * 10_000);
 
     Pdk::get(PdkSettingsRepositoryInterface::class)->reset();
 });

--- a/tests/Unit/App/Endpoint/Resource/DeliveryOptionsV1ResourceTest.php
+++ b/tests/Unit/App/Endpoint/Resource/DeliveryOptionsV1ResourceTest.php
@@ -61,10 +61,10 @@ it('formats delivery options correctly', function () {
     expect($result['shipmentOptions']['oversizedPackage'])->toBeInstanceOf(ArrayObject::class);
     expect($result['shipmentOptions']['requiresAgeVerification'])->toBeInstanceOf(ArrayObject::class);
 
-    // Check that insurance has amount in micro units
+    // Insurance: 50000 cents (€500) → 500_000_000 micros (€500 × 1_000_000)
     expect($result['shipmentOptions']['insurance'])
         ->toBeArray()
-        ->toHaveKey('amount', 50000 * 1000000);
+        ->toHaveKey('amount', 50000 * 10_000);
 });
 
 it('returns empty object when no shipment options are enabled', function () {
@@ -91,7 +91,7 @@ it('returns empty object when no shipment options are enabled', function () {
 
 it('correctly formats insurance amount in micro units', function () {
     $shipmentOptions = new ShipmentOptions([
-        'insurance' => 100, // €100
+        'insurance' => 10000, // 10000 cents = €100
     ]);
 
     $deliveryOptions = new DeliveryOptions([
@@ -101,11 +101,12 @@ it('correctly formats insurance amount in micro units', function () {
     $resource = new DeliveryOptionsV1Resource($deliveryOptions);
     $result = $resource->format();
 
+    // 10000 cents (€100) → 100_000_000 micros (€100 × 1_000_000)
     expect($result['shipmentOptions'])
         ->toHaveKey('insurance')
         ->and($result['shipmentOptions']['insurance'])
         ->toBeArray()
-        ->toHaveKey('amount', 100 * 1000000);
+        ->toHaveKey('amount', 10000 * 10_000);
 });
 
 it('ignores inherited shipment options', function () {


### PR DESCRIPTION
INT-1598
Insurance amounts are stored in cents throughout the PDK, but the DeliveryOptionsV1Resource multiplied by 1_000_000 (treating the value as euros), yielding amounts 100× too large. The correct factor from cents to integer micros is 10_000 (= 1_000_000 ÷ 100).

Also corrects existing tests that had baked in the wrong expected values, and fixes a test where EXPORT_INSURANCE_UP_TO was set to 500 (cents = €5) but was asserting €500 in micros.