### PR TITLE
fix(account): fix default carrier not always being set when switching between api keys

### DIFF
--- a/src/App/Action/Backend/Account/UpdateAccountAction.php
+++ b/src/App/Action/Backend/Account/UpdateAccountAction.php
@@ -141,7 +141,7 @@ class UpdateAccountAction implements ActionInterface
     }
 
     /**
-     * Persist the API key's validity flag for {@see AbstractPdkAccountRepository} to consult.
+     * Persist the API key's validity flag for {@see \MyParcelNL\Pdk\App\Account\Repository\AbstractPdkAccountRepository} to consult.
      * Re-evaluated whenever the user (re-)saves a key after a 401 surfaces in the backoffice.
      *
      * @param  bool $apiKeyIsValid

--- a/src/App/Action/Backend/Account/UpdateAccountAction.php
+++ b/src/App/Action/Backend/Account/UpdateAccountAction.php
@@ -108,11 +108,14 @@ class UpdateAccountAction implements ActionInterface
             return;
         }
 
-        $resolved = $this->implicationsService->getDefaultCarrierName($shop->id);
+        $apiResult = $this->implicationsService->getDefaultCarrierName($shop->id);
 
-        if ($resolved === null) {
-            // Service returned null (transient error). Carry forward the previously persisted
-            // value when available so a single flaky call doesn't wipe the cached default.
+        // Availability is checked against the in-memory $shop->carriers (just resolved from
+        // contract definitions); the persisted account is one step behind at this point.
+        if ($apiResult !== null && $shop->carriers->contains('carrier', $apiResult)) {
+            $resolved = $apiResult;
+        } else {
+            // Carry forward so a single missing/unavailable implication does not wipe a good default.
             $previousAccount = $this->pdkAccountRepository->getAccount();
             $previousShop    = $previousAccount ? $previousAccount->shops->first() : null;
             $resolved        = $previousShop ? $previousShop->defaultCarrier : null;
@@ -121,6 +124,8 @@ class UpdateAccountAction implements ActionInterface
         if ($resolved !== null) {
             $shop->defaultCarrier = $resolved;
         }
+
+        Logger::debug(sprintf('Shop default carrier set to %s', $shop->defaultCarrier ?? 'null'));
     }
 
     /**
@@ -130,19 +135,14 @@ class UpdateAccountAction implements ActionInterface
      */
     protected function setShopCarriers(Account $account): void
     {
-        // Carriers are nested under shops, because one API key falls under one shop.
-        // The endpoint and our model implies more than one shop can be used. This in reality is never the case here since 1 API key = 1 Shop. We can safely use the first
-        $shop = $account->shops->first();
-        // Fetch the carriers available to the account and store them in the shop model for easy access throughout the plugin
+        // The API key always resolves to exactly one shop, despite the collection shape.
+        $shop           = $account->shops->first();
         $shop->carriers = $this->carrierCapabilitiesRepository->getContractDefinitions();
     }
 
     /**
-     * Stores the validity of the api key in the account, for use in
-     * src/App/Account/Repository/AbstractPdkAccountRepository.php
-     * When the user rotates the key in the backoffice, the plugin will start receiving 401 responses from the API,
-     * however for the purpose of the PDK the api key is still valid. Upon receiving the errors the user will no doubt
-     * update their api key in the settings at which point the validity is reassessed here (updateAndSaveAccount).
+     * Persist the API key's validity flag for {@see AbstractPdkAccountRepository} to consult.
+     * Re-evaluated whenever the user (re-)saves a key after a 401 surfaces in the backoffice.
      *
      * @param  bool $apiKeyIsValid
      *
@@ -165,19 +165,16 @@ class UpdateAccountAction implements ActionInterface
      */
     protected function updateAccountSettings(array $settings): AccountSettings
     {
-        // Get existing account settings to preserve them
         $existingSettings = $this->pdkSettingsRepository->all()->account;
-
-        // Always merge with existing settings
-        $existingData    = $existingSettings->toArray();
-        $mergedData      = array_merge($existingData, $settings);
-        $accountSettings = new AccountSettings($mergedData);
+        $mergedData       = array_merge($existingSettings->toArray(), $settings);
+        $accountSettings  = new AccountSettings($mergedData);
 
         $this->pdkSettingsRepository->storeSettings($accountSettings);
 
-        // The capabilitiesService only sets the API key from its constructor
-        // Call the refresh method to update the API key in the service so it can be used immediately after updating the account settings
+        // SDK services capture the API key on their Configuration at construction (DI-time, before
+        // this request stored the new key). Refresh each service that this request will still call.
         $this->capabilitiesService->refreshApiConfig();
+        $this->implicationsService->refreshApiConfig();
 
         return $accountSettings;
     }
@@ -196,7 +193,7 @@ class UpdateAccountAction implements ActionInterface
             return;
         }
 
-        // this try is for the case when the UI is no longer supplying an empty api key when you click "remove api key"
+        // Guards against legacy "remove API key" UI paths that surfaced as exceptions here.
         try {
             $account = $this->accountRepository->getAccount();
             Pdk::get(PropositionService::class)->setActivePropositionId($account->platformId);

--- a/src/Carrier/Model/Carrier.php
+++ b/src/Carrier/Model/Carrier.php
@@ -173,6 +173,27 @@ class Carrier extends SdkBackedModel
     }
 
     /**
+     * Translate a numeric carrier id (as exposed by external APIs in legacy CoreAPI shape)
+     * to its V2 carrier name (e.g. 1 → "POSTNL", 15 → "BRT"). Returns null when the id is
+     * not in the local id↔name mapping — typically a carrier that exists in the API enum
+     * but is not yet known to this PDK version.
+     *
+     * Pure static-map lookup with no shop/repository dependency, so it is safe to call
+     * before any carrier collection has been resolved or persisted.
+     *
+     * Currently backed by {@see self::CARRIER_NAME_ID_MAP}; switch to an
+     * SDK-provided definition when INT-1441 lands so call sites stay unchanged.
+     *
+     * @param  int $id Numeric carrier id from a legacy CoreAPI payload.
+     *
+     * @return null|string V2 carrier name, or null when the id is not in the local mapping.
+     */
+    public static function v2NameFromLegacyId(int $id): ?string
+    {
+        return array_search($id, self::CARRIER_NAME_ID_MAP, true) ?: null;
+    }
+
+    /**
      * Any attributes here extend/overwrite the data from RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2.
      * @see RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2
      */

--- a/src/Carrier/Repository/CarrierRepository.php
+++ b/src/Carrier/Repository/CarrierRepository.php
@@ -192,6 +192,6 @@ class CarrierRepository extends Repository implements CarrierRepositoryInterface
      */
     private function normalizeFromId(int $id): ?string
     {
-        return array_search($id, Carrier::CARRIER_NAME_ID_MAP, true) ?: null;
+        return Carrier::v2NameFromLegacyId($id);
     }
 }

--- a/src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php
+++ b/src/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\ShippingRule;
 
-use MyParcelNL\Pdk\Carrier\Contract\CarrierRepositoryInterface;
+use MyParcelNL\Pdk\Carrier\Model\Carrier;
 use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\AbstractCoreApiPrivateService;
 use MyParcelNL\Sdk\Client\Generated\CoreApiPrivate\Api\ShippingRuleApi;
@@ -21,26 +21,23 @@ class ImplicationsService extends AbstractCoreApiPrivateService
      */
     private $api;
 
-    /**
-     * @var CarrierRepositoryInterface
-     */
-    private $carrierRepository;
-
-    /**
-     * @param  CarrierRepositoryInterface $carrierRepository
-     */
-    public function __construct(CarrierRepositoryInterface $carrierRepository)
+    public function __construct()
     {
-        $this->api               = new ShippingRuleApi($this->createGuzzleClient(), $this->getApiConfig());
-        $this->carrierRepository = $carrierRepository;
+        $this->api = new ShippingRuleApi($this->createGuzzleClient(), $this->getApiConfig());
     }
 
     /**
      * Return the V2 carrier name implied by the shop's shipping rules, or null when unavailable.
      *
-     * Fetches the first implication returned for the shop, reads its carrier_id, and maps
-     * it to a V2 carrier name via CarrierRepository. Returns null when the implications list
-     * is empty, carrier_id is absent, the id is unmapped, or the API call fails.
+     * Fetches the first implication returned for the shop, reads its carrier_id, and translates
+     * it to a V2 carrier name via {@see Carrier::v2NameFromLegacyId()}. Returns null when the
+     * implications list is empty, carrier_id is absent, the id is not in the local mapping, or
+     * the API call fails.
+     *
+     * The returned name is not checked against the shop's available carrier contracts — that
+     * "is this carrier actually available to my shop?" check is the caller's responsibility,
+     * since it is the caller that holds the authoritative carrier collection (the just-fetched
+     * contract definitions are not yet persisted at the moment this service is consulted).
      *
      * @param  int $shopId
      *
@@ -66,9 +63,7 @@ class ImplicationsService extends AbstractCoreApiPrivateService
             }
 
             // @phpstan-ignore cast.int (same reason: container holds a raw int, not an instantiated RefTypesCarrier)
-            $carrier = $this->carrierRepository->findByLegacyId((int) $carrierId);
-
-            return $carrier ? $carrier->carrier : null;
+            return Carrier::v2NameFromLegacyId((int) $carrierId);
         } catch (ApiException $e) {
             // Expected SDK request failure — LoggingMiddleware already logged the HTTP error
             // at the Guzzle transport layer before the exception was rethrown.

--- a/tests/Bootstrap/MockImplicationsService.php
+++ b/tests/Bootstrap/MockImplicationsService.php
@@ -32,6 +32,20 @@ class MockImplicationsService extends ImplicationsService
     private static $callCount = 0;
 
     /**
+     * Order-preserving log of method invocations on this mock. Each entry is a method name
+     * ('refreshApiConfig' or 'getDefaultCarrierName'). Used by regression tests that need to
+     * assert that the API config was refreshed before any outbound call.
+     *
+     * @var string[]
+     */
+    private static $callLog = [];
+
+    /**
+     * @var int
+     */
+    private static $refreshCallCount = 0;
+
+    /**
      * Skip the parent constructor — we never call into the real ShippingRuleApi.
      */
     public function __construct()
@@ -59,12 +73,34 @@ class MockImplicationsService extends ImplicationsService
     }
 
     /**
+     * Return the number of times refreshApiConfig() has been called since the last reset().
+     *
+     * @return int
+     */
+    public static function getRefreshCallCount(): int
+    {
+        return self::$refreshCallCount;
+    }
+
+    /**
+     * Return the order-preserving log of mock method invocations since the last reset().
+     *
+     * @return string[]
+     */
+    public static function getCallLog(): array
+    {
+        return self::$callLog;
+    }
+
+    /**
      * Reset to the default null state. Call from afterEach hooks or test teardown.
      */
     public static function reset(): void
     {
         self::$defaultCarrierName = null;
         self::$callCount          = 0;
+        self::$refreshCallCount   = 0;
+        self::$callLog            = [];
     }
 
     /**
@@ -75,7 +111,21 @@ class MockImplicationsService extends ImplicationsService
     public function getDefaultCarrierName(int $shopId): ?string
     {
         self::$callCount++;
+        self::$callLog[] = 'getDefaultCarrierName';
 
         return self::$defaultCarrierName;
+    }
+
+    /**
+     * Override the inherited refresh: the parent implementation iterates the
+     * (real) SDK API clients on $this->api, but this mock skips the parent
+     * constructor so $this->api is never initialised. Just record the call.
+     *
+     * @return void
+     */
+    public function refreshApiConfig(): void
+    {
+        self::$refreshCallCount++;
+        self::$callLog[] = 'refreshApiConfig';
     }
 }

--- a/tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php
+++ b/tests/Unit/App/Action/Backend/Account/UpdateAccountActionTest.php
@@ -251,3 +251,85 @@ it('does not call ImplicationsService when the API key is empty', function () {
 
     expect(MockImplicationsService::getCallCount())->toBe(0);
 });
+
+it('falls back to carry-forward when the resolved carrier is not in the shop\'s contracts', function () {
+    // Regression for INT-1479: the shop's carrier collection is the authority for "available
+    // carriers". An implication pointing at a carrier the shop does not contract must be
+    // rejected (not silently persisted) so consumers downstream of $shop->defaultCarrier
+    // can rely on getting a Carrier the shop can actually use.
+    $previousAccount = new Account([
+        'id'         => 120,
+        'platformId' => 1,
+        'shops'      => [
+            [
+                'id'             => 2100,
+                'accountId'      => 120,
+                'platformId'     => 1,
+                'defaultCarrier' => 'DPD',
+            ],
+        ],
+    ]);
+    /** @var MockPdkAccountRepository $repo */
+    $repo = Pdk::get(PdkAccountRepositoryInterface::class);
+    $repo->store($previousAccount);
+
+    // GLS is a valid V2 carrier name in CARRIER_NAME_ID_MAP but absent from the fixture's
+    // contract definitions, so the in-memory shop's carrier collection does not contain it.
+    MockImplicationsService::setDefaultCarrierName('GLS');
+
+    executeUpdateAccount(['apiKey' => 'test-api-key']);
+
+    $shop = AccountSettings::getAccount()->shops->first();
+
+    expect($shop->defaultCarrier)->toBe('DPD');
+});
+
+it('uses the in-memory shop carriers (not the persisted account) as the availability authority', function () {
+    // Regression for INT-1479 root cause: the availability check must consult the just-
+    // resolved carrier collection on the in-memory $shop (set by setShopCarriers earlier in
+    // this same request), NOT the carrier collection on the persisted account. The persisted
+    // account is from the previous save and reflects a stale contract set; consulting it
+    // would reject implications pointing at carriers that ARE in the freshly-fetched
+    // contract definitions (the actual symptom reported on Italian API keys).
+    $previousAccount = new Account([
+        'id'         => 120,
+        'platformId' => 1,
+        'shops'      => [
+            [
+                'id'             => 2100,
+                'accountId'      => 120,
+                'platformId'     => 1,
+                'defaultCarrier' => 'DPD',
+                'carriers'       => [['carrier' => 'DPD']],
+            ],
+        ],
+    ]);
+    /** @var MockPdkAccountRepository $repo */
+    $repo = Pdk::get(PdkAccountRepositoryInterface::class);
+    $repo->store($previousAccount);
+
+    // BRT is NOT in the persisted account's stored carriers ([DPD] above), but IS in the
+    // fresh contract-definitions fixture used by setShopCarriers.
+    MockImplicationsService::setDefaultCarrierName('BRT');
+
+    executeUpdateAccount(['apiKey' => 'test-api-key']);
+
+    $shop = AccountSettings::getAccount()->shops->first();
+
+    expect($shop->defaultCarrier)->toBe('BRT');
+});
+
+it('refreshes ImplicationsService API config before calling it', function () {
+    // Regression for INT-1479: ImplicationsService is constructor-injected, so DI captures
+    // it (and the API key on its internal SDK Configuration) at request boot — before the
+    // new API key has been written to settings. If updateAccountSettings does not call
+    // refreshApiConfig on ImplicationsService, the outbound shipping-rules call carries a
+    // stale (or empty) Authorization header and the API returns 401 Permission Denied.
+    MockImplicationsService::setDefaultCarrierName('POSTNL');
+
+    executeUpdateAccount(['apiKey' => 'test-api-key']);
+
+    expect(MockImplicationsService::getRefreshCallCount())->toBeGreaterThan(0)
+        ->and(MockImplicationsService::getCallLog())
+        ->toBe(['refreshApiConfig', 'getDefaultCarrierName']);
+});

--- a/tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApiPrivate/ShippingRule/ImplicationsServiceTest.php
@@ -8,9 +8,6 @@ namespace MyParcelNL\Pdk\SdkApi\Service\CoreApiPrivate\ShippingRule;
 
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
-use Mockery;
-use MyParcelNL\Pdk\Carrier\Model\Carrier;
-use MyParcelNL\Pdk\Carrier\Contract\CarrierRepositoryInterface;
 use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
 use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
 use Psr\Http\Message\RequestInterface;
@@ -33,10 +30,10 @@ class MockableImplicationsService extends ImplicationsService
     /** @var RequestInterface[] */
     public $capturedRequests = [];
 
-    public function __construct(CarrierRepositoryInterface $carrierRepository)
+    public function __construct()
     {
         $this->mockHandler = new MockHandler();
-        parent::__construct($carrierRepository);
+        parent::__construct();
     }
 
     protected function createGuzzleClient(): \GuzzleHttp\Client
@@ -94,13 +91,8 @@ function emptyImplResponse(): string
 it('returns the V2 carrier name when implications contain a known carrier id', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
-    $carrierRepository->shouldReceive('findByLegacyId')
-        ->once()
-        ->with(1)
-        ->andReturn(new Carrier(['carrier' => 'POSTNL']));
-
-    $service = new MockableImplicationsService($carrierRepository);
+    // carrier_id 1 maps to "POSTNL" in Carrier::CARRIER_NAME_ID_MAP.
+    $service = new MockableImplicationsService();
     $service->mockHandler->append(new Response(200, [], implResponse(1)));
 
     expect($service->getDefaultCarrierName(42))->toBe('POSTNL');
@@ -110,10 +102,7 @@ it('returns the V2 carrier name when implications contain a known carrier id', f
 it('returns null when the implications array is empty', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
-    $carrierRepository->shouldNotReceive('findByLegacyId');
-
-    $service = new MockableImplicationsService($carrierRepository);
+    $service = new MockableImplicationsService();
     $service->mockHandler->append(new Response(200, [], emptyImplResponse()));
 
     expect($service->getDefaultCarrierName(42))->toBeNull();
@@ -123,30 +112,21 @@ it('returns null when the implications array is empty', function () {
 it('returns null when the first implication has no carrier_id', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
-    $carrierRepository->shouldNotReceive('findByLegacyId');
-
     // Omit carrier_id so the deserialized model has null for that field.
-    $service = new MockableImplicationsService($carrierRepository);
+    $service = new MockableImplicationsService();
     $service->mockHandler->append(new Response(200, [], implResponse()));
 
     expect($service->getDefaultCarrierName(42))->toBeNull();
 });
 
-// Test 4: returns null when carrier id is not found in CarrierRepository
-it('returns null when the carrier id is not found in the carrier repository', function () {
+// Test 4: returns null when the carrier id is not in the local V2 mapping
+it('returns null when the carrier id is not in the local V2 mapping', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    // Use a valid SDK enum value (2 = BPOST) that is not present in this shop's carriers.
-    // findByLegacyId returns null when the carrier is not in the account's carrier list.
-    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
-    $carrierRepository->shouldReceive('findByLegacyId')
-        ->once()
-        ->with(2)
-        ->andReturn(null);
-
-    $service = new MockableImplicationsService($carrierRepository);
-    $service->mockHandler->append(new Response(200, [], implResponse(2)));
+    // 9999 is not in Carrier::CARRIER_NAME_ID_MAP — simulates an API id this PDK version
+    // does not yet know about. Should yield null rather than throwing.
+    $service = new MockableImplicationsService();
+    $service->mockHandler->append(new Response(200, [], implResponse(9999)));
 
     expect($service->getDefaultCarrierName(42))->toBeNull();
 });
@@ -155,14 +135,11 @@ it('returns null when the carrier id is not found in the carrier repository', fu
 it('returns null on ApiException without re-logging at the service layer', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
-    $carrierRepository->shouldNotReceive('findByLegacyId');
-
     /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
     $logger = \MyParcelNL\Pdk\Facade\Pdk::get(\MyParcelNL\Pdk\Logger\Contract\PdkLoggerInterface::class);
     $logger->clear();
 
-    $service = new MockableImplicationsService($carrierRepository);
+    $service = new MockableImplicationsService();
     $service->mockHandler->append(new Response(500, [], '{"error":"internal server error"}'));
 
     expect($service->getDefaultCarrierName(42))->toBeNull();
@@ -177,20 +154,15 @@ it('returns null on ApiException without re-logging at the service layer', funct
 it('logs an unexpected error and returns null when a non-API exception bubbles up', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    // Force a TypeError out of CarrierRepository to simulate a programmer error somewhere
-    // inside the try block. The ApiException catch must NOT swallow this — the Throwable
-    // catch must log it before returning null so the bug is surfaced.
-    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
-    $carrierRepository->shouldReceive('findByLegacyId')
-        ->once()
-        ->andThrow(new \TypeError('unexpected boom'));
+    // Push a non-Guzzle Throwable into the handler queue. Guzzle's MockHandler will reject
+    // the request promise with it; the SDK's ApiException wrapper only catches GuzzleException,
+    // so this TypeError propagates into our Throwable catch and must be logged before nulling.
+    $service = new MockableImplicationsService();
+    $service->mockHandler->append(new \TypeError('unexpected boom'));
 
     /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
     $logger = \MyParcelNL\Pdk\Facade\Pdk::get(\MyParcelNL\Pdk\Logger\Contract\PdkLoggerInterface::class);
     $logger->clear();
-
-    $service = new MockableImplicationsService($carrierRepository);
-    $service->mockHandler->append(new Response(200, [], implResponse(1)));
 
     expect($service->getDefaultCarrierName(42))->toBeNull();
 
@@ -221,10 +193,7 @@ it('logs an unexpected error and returns null when a non-API exception bubbles u
 it('passes shop_id through unchanged and does not add extra query params', function () {
     TestBootstrapper::hasApiKey('test-key');
 
-    $carrierRepository = Mockery::mock(CarrierRepositoryInterface::class);
-    $carrierRepository->shouldReceive('findByLegacyId')->andReturn(new Carrier(['carrier' => 'POSTNL']));
-
-    $service = new MockableImplicationsService($carrierRepository);
+    $service = new MockableImplicationsService();
     $service->mockHandler->append(new Response(200, [], implResponse(1)));
 
     $service->getDefaultCarrierName(42);


### PR DESCRIPTION
The carrier id from the shipping-rules API was looked up in the previously-stored account, which on a key switch or first-time setup does not yet contain the new carrier — so the default silently fell through to carry-forward (or null). Lookup now uses the in-memory shop that holds the just-resolved contract definitions.

Also refreshes ImplicationsService's API config when settings change — without it, switching between acceptance and production environments left the shipping-rules call carrying a stale key and 401'd.

Resolves INT-1479
Resolves INT-1504

## Test plan
- [ ] Fresh install → enter Italian acceptance API key → admin Order V2 / delivery options shows BRT as default.
- [ ] Switch from a Dutch key to an Italian key → default carrier flips to BRT (not stale POSTNL).
- [ ] Switch acceptance ↔ production with a valid key in both → no 401 from shipping-rules, default carrier set correctly.
- [ ] Shipping-rules implication returns a carrier the shop does not contract → previously persisted default is preserved (carry-forward), not wiped.
- [ ] Re-saving the same API key on a shop that already had a default → default unchanged.