### PR TITLE
refactor(shipment): remove dead/duplicated package & delivery type constants

### DIFF
--- a/src/Frontend/View/AbstractSettingsView.php
+++ b/src/Frontend/View/AbstractSettingsView.php
@@ -167,12 +167,14 @@ abstract class AbstractSettingsView implements Arrayable
     }
 
     /**
-     * @param  array $packageTypes
+     * @param  null|array $packageTypes
      *
      * @return array
      */
-    protected function createPackageTypeOptions(array $packageTypes = DeliveryOptions::PACKAGE_TYPES_NAMES): array
+    protected function createPackageTypeOptions(?array $packageTypes = null): array
     {
+        $packageTypes = $packageTypes ?? array_keys(DeliveryOptions::PACKAGE_TYPES_V2_MAP);
+
         $propositionService = Pdk::get(PropositionService::class);
         return $this->toSelectOptions(
             array_combine(

--- a/src/Shipment/Model/DeliveryOptions.php
+++ b/src/Shipment/Model/DeliveryOptions.php
@@ -83,30 +83,6 @@ class DeliveryOptions extends Model
     public const DELIVERY_OPTION_SATURDAY              = 'saturdayDelivery';
 
     /**
-     * @var int[]
-     */
-    public const DELIVERY_TYPES_IDS = [
-        self::DELIVERY_TYPE_MORNING_ID,
-        self::DELIVERY_TYPE_STANDARD_ID,
-        self::DELIVERY_TYPE_EVENING_ID,
-        self::DELIVERY_TYPE_PICKUP_ID,
-        self::DELIVERY_TYPE_EXPRESS_ID,
-        self::DELIVERY_TYPE_SAME_DAY_ID,
-        self::DELIVERY_TYPE_EARLY_MORNING_ID,
-    ];
-    /**
-     * @var string[]
-     */
-    public const DELIVERY_TYPES_NAMES = [
-        self::DELIVERY_TYPE_MORNING_NAME,
-        self::DELIVERY_TYPE_STANDARD_NAME,
-        self::DELIVERY_TYPE_EVENING_NAME,
-        self::DELIVERY_TYPE_PICKUP_NAME,
-        self::DELIVERY_TYPE_EXPRESS_NAME,
-        self::DELIVERY_TYPE_SAME_DAY_NAME,
-        self::DELIVERY_TYPE_EARLY_MORNING_NAME,
-    ];
-    /**
      * @var array
      */
     public const DELIVERY_TYPES_NAMES_IDS_MAP = [
@@ -135,13 +111,16 @@ class DeliveryOptions extends Model
     /**
      * Package types
      */
-    public const  PACKAGE_TYPE_PACKAGE_ID         = RefShipmentPackageType::PACKAGE;
-    public const  PACKAGE_TYPE_MAILBOX_ID         = RefShipmentPackageType::MAILBOX;
-    public const  PACKAGE_TYPE_LETTER_ID          = RefShipmentPackageType::UNFRANKED;
-    public const  PACKAGE_TYPE_DIGITAL_STAMP_ID   = RefShipmentPackageType::DIGITAL_STAMP;
-    public const  PACKAGE_TYPE_PACKAGE_SMALL_ID   = RefShipmentPackageType::SMALL_PACKAGE;
-    public const  PACKAGE_TYPE_PALLET_ID          = RefShipmentPackageType::PALLET;
-    public const  PACKAGE_TYPE_ENVELOPE_ID        = RefShipmentPackageType::ENVELOPE;
+    /**
+     * PDK-internal package-type names (also used by the delivery-options widget).
+     *
+     * @TODO: source these from the SDK delivery-options response enum
+     *   ShipmentResponsesDeliveryOptionsPackageTypeV2 once its OpenAPI spec is
+     *   corrected. The spec currently defines 'small_package' / 'unfranked' where
+     *   the live endpoint accepts 'package_small' / 'letter' (spec fix in progress
+     *   in core-api); sourcing from the SDK before that lands would import the
+     *   wrong values.
+     */
     public const  PACKAGE_TYPE_PACKAGE_NAME       = 'package';
     public const  PACKAGE_TYPE_MAILBOX_NAME       = 'mailbox';
     public const  PACKAGE_TYPE_LETTER_NAME        = 'letter';
@@ -150,33 +129,14 @@ class DeliveryOptions extends Model
     public const  PACKAGE_TYPE_PALLET_NAME        = 'pallet';
     public const  PACKAGE_TYPE_ENVELOPE_NAME      = 'envelope';
 
-    public const PACKAGE_TYPES_IDS = [
-        self::PACKAGE_TYPE_PACKAGE_ID,
-        self::PACKAGE_TYPE_MAILBOX_ID,
-        self::PACKAGE_TYPE_LETTER_ID,
-        self::PACKAGE_TYPE_DIGITAL_STAMP_ID,
-        self::PACKAGE_TYPE_PACKAGE_SMALL_ID,
-        self::PACKAGE_TYPE_PALLET_ID,
-        self::PACKAGE_TYPE_ENVELOPE_ID,
-    ];
-    public const PACKAGE_TYPES_NAMES = [
-        self::PACKAGE_TYPE_PACKAGE_NAME,
-        self::PACKAGE_TYPE_MAILBOX_NAME,
-        self::PACKAGE_TYPE_LETTER_NAME,
-        self::PACKAGE_TYPE_DIGITAL_STAMP_NAME,
-        self::PACKAGE_TYPE_PACKAGE_SMALL_NAME,
-        self::PACKAGE_TYPE_PALLET_NAME,
-        self::PACKAGE_TYPE_ENVELOPE_NAME,
-    ];
-
     public const PACKAGE_TYPES_NAMES_IDS_MAP     = [
-        self::PACKAGE_TYPE_PACKAGE_NAME       => self::PACKAGE_TYPE_PACKAGE_ID,
-        self::PACKAGE_TYPE_MAILBOX_NAME       => self::PACKAGE_TYPE_MAILBOX_ID,
-        self::PACKAGE_TYPE_LETTER_NAME        => self::PACKAGE_TYPE_LETTER_ID,
-        self::PACKAGE_TYPE_DIGITAL_STAMP_NAME => self::PACKAGE_TYPE_DIGITAL_STAMP_ID,
-        self::PACKAGE_TYPE_PACKAGE_SMALL_NAME => self::PACKAGE_TYPE_PACKAGE_SMALL_ID,
-        self::PACKAGE_TYPE_PALLET_NAME        => self::PACKAGE_TYPE_PALLET_ID,
-        self::PACKAGE_TYPE_ENVELOPE_NAME      => self::PACKAGE_TYPE_ENVELOPE_ID,
+        self::PACKAGE_TYPE_PACKAGE_NAME       => RefShipmentPackageType::PACKAGE,
+        self::PACKAGE_TYPE_MAILBOX_NAME       => RefShipmentPackageType::MAILBOX,
+        self::PACKAGE_TYPE_LETTER_NAME        => RefShipmentPackageType::UNFRANKED,
+        self::PACKAGE_TYPE_DIGITAL_STAMP_NAME => RefShipmentPackageType::DIGITAL_STAMP,
+        self::PACKAGE_TYPE_PACKAGE_SMALL_NAME => RefShipmentPackageType::SMALL_PACKAGE,
+        self::PACKAGE_TYPE_PALLET_NAME        => RefShipmentPackageType::PALLET,
+        self::PACKAGE_TYPE_ENVELOPE_NAME      => RefShipmentPackageType::ENVELOPE,
     ];
 
     public const PACKAGE_TYPES_V2_MAP = [
@@ -214,7 +174,7 @@ class DeliveryOptions extends Model
         return in_array($v2PackageType, self::PACKAGE_TYPES_V2_MAP, true);
     }
 
-    public const  DEFAULT_PACKAGE_TYPE_ID         = self::PACKAGE_TYPE_PACKAGE_ID;
+    public const  DEFAULT_PACKAGE_TYPE_ID         = RefShipmentPackageType::PACKAGE;
     public const  DEFAULT_PACKAGE_TYPE_NAME       = self::PACKAGE_TYPE_PACKAGE_NAME;
     public const  DEFAULT_PACKAGE_TYPE_V2         = RefShipmentPackageTypeV2::PACKAGE;
 

--- a/tests/Datasets/deliveryOptions.php
+++ b/tests/Datasets/deliveryOptions.php
@@ -33,7 +33,7 @@ dataset('packageTypeNames', function () {
         static function (string $name) {
             return [$name];
         },
-        DeliveryOptions::PACKAGE_TYPES_NAMES
+        array_keys(DeliveryOptions::PACKAGE_TYPES_V2_MAP)
     );
 });
 
@@ -42,7 +42,7 @@ dataset('deliveryTypeNames', function () {
         static function (string $name) {
             return [$name];
         },
-        DeliveryOptions::DELIVERY_TYPES_NAMES
+        array_keys(DeliveryOptions::DELIVERY_TYPES_V2_MAP)
     );
 });
 

--- a/tests/Unit/App/Action/Backend/Order/ExportOrderActionTest.php
+++ b/tests/Unit/App/Action/Backend/Order/ExportOrderActionTest.php
@@ -50,6 +50,7 @@ use MyParcelNL\Pdk\Tests\Uses\UsesSettingsMock;
 use MyParcelNL\Pdk\App\Order\Collection\PdkOrderLineCollection;
 use MyParcelNL\Pdk\Shipment\Model\ShipmentOptions;
 use MyParcelNL\Pdk\Types\Service\TriStateService;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageType;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageTypeV2;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrier;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesSharedCarrierV2;
@@ -479,7 +480,7 @@ it('exports multiple orders in a batch with per-shipment option resolution', fun
     expect($shipments)->toHaveLength(3);
 
     // Order 0: mailbox package type, no signature
-    expect($shipments[0]['options']['package_type'])->toBe(DeliveryOptions::PACKAGE_TYPE_MAILBOX_ID)
+    expect($shipments[0]['options']['package_type'])->toBe(RefShipmentPackageType::MAILBOX)
         ->and($shipments[0]['options'])->not->toHaveKey('signature');
 
     // Order 1: evening delivery type, signature and only_recipient present
@@ -1100,7 +1101,7 @@ it(
             // Carrier supports mailbox internationally and account has the contract — package type should be mailbox
             'assertions'                            => function () {
                 return function (array $shipment) {
-                    expect($shipment['options']['package_type'])->toBe(DeliveryOptions::PACKAGE_TYPE_MAILBOX_ID);
+                    expect($shipment['options']['package_type'])->toBe(RefShipmentPackageType::MAILBOX);
                 };
             },
         ],

--- a/tests/Unit/Fulfilment/Model/ShipmentOptionsTest.php
+++ b/tests/Unit/Fulfilment/Model/ShipmentOptionsTest.php
@@ -8,6 +8,7 @@ namespace MyParcelNL\Pdk\Fulfilment\Model;
 
 use MyParcelNL\Pdk\Shipment\Model\DeliveryOptions;
 use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageType;
 use function MyParcelNL\Pdk\Tests\factory;
 use function MyParcelNL\Pdk\Tests\usesShared;
 use MyParcelNL\Pdk\Tests\Uses\UsesAccountMock;
@@ -26,7 +27,7 @@ it('can create instance from pdk delivery options', function () {
 
     expect($created->toArray())->toEqual([
         'deliveryType'     => DeliveryOptions::DELIVERY_TYPE_MORNING_ID,
-        'packageType'      => DeliveryOptions::PACKAGE_TYPE_MAILBOX_ID,
+        'packageType'      => RefShipmentPackageType::MAILBOX,
         'deliveryDate'     => null,
         'insurance'        => 100,
         'labelDescription' => 'test',


### PR DESCRIPTION
Removes dead and duplicated package/delivery type constants from `DeliveryOptions`, surfaced while documenting how new entities are added.

- **Unused (no consumers anywhere):** `DELIVERY_TYPES_IDS`, `PACKAGE_TYPES_IDS` — removed.
- **Test/single-use only:** `DELIVERY_TYPES_NAMES` (only a test dataset) and `PACKAGE_TYPES_NAMES` (test dataset + the product-settings view) — removed; both now derived from the V2 maps (`array_keys(DELIVERY_TYPES_V2_MAP)` / `PACKAGE_TYPES_V2_MAP`).
- **Aliases:** `PACKAGE_TYPE_*_ID` (pure `RefShipmentPackageType::X` aliases) — removed; referenced directly in `PACKAGE_TYPES_NAMES_IDS_MAP` and `DEFAULT_PACKAGE_TYPE_ID`. 3 test references updated.
- **@TODO:** note to source `PACKAGE_TYPE_*_NAME` from the SDK delivery-options response enum once its OpenAPI spec is corrected (`letter`/`package_small`).

Value-preserving. PHPStan clean; full unit suite green (2614 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)