### PR TITLE
chore(capabilities): remove unused deps and fix add-shipment-option skill

### DIFF
--- a/.claude/skills/add-shipment-option.md
+++ b/.claude/skills/add-shipment-option.md
@@ -69,17 +69,13 @@ Add null overrides for any settings the user opted out of.
 
 Add the new definition to the `orderOptionDefinitions` array in `config/pdk-business-logic.php`. Add the import at the top of the file.
 
-### 3. Add Deprecated Constant to ShipmentOptions
-
-Add a `@deprecated` constant to `src/Shipment/Model/ShipmentOptions.php` for backwards compatibility with platform integrations. Do NOT use this constant anywhere in PDK code — use the definition's `getShipmentOptionsKey()` instead.
-
-### 4. Run IDE Helper
+### 3. Run IDE Helper
 
 ```bash
 docker compose run php composer console generate:ide-helper
 ```
 
-### 5. Run Tests
+### 4. Run Tests
 
 ```bash
 yarn run test:unit
@@ -95,4 +91,4 @@ yarn test:unit:snapshot
 
 - The `Carrier` model filters serialized options to only include those with registered definitions. Adding a definition automatically makes the option visible to the frontend.
 - `CarrierSettings`, `ProductSettings`, `ShipmentOptions`, and `Fulfilment\ShipmentOptions` all build their option attributes dynamically from definitions — no manual attribute registration needed.
-- `CarrierSchema::canHaveShipmentOption()` checks capabilities for the option automatically via the definition's capabilities key.
+- `CarrierValidationService::supportsShipmentOption()` checks capabilities for the option automatically via the definition's capabilities key.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     "require": {
         "ext-zip": "*",
         "fruitcake/php-cors": "^1.2",
-        "justinrainbow/json-schema": "^5.2",
         "myparcelnl/sdk": "^11.0.0-beta.19@beta",
         "php": ">=7.4.0",
         "php-di/php-di": "^6.0.0",

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,7 @@
         "php": ">=7.4.0",
         "php-di/php-di": "^6.0.0",
         "psr/log": "^1.0.0 || ^2.0.0 || ^3.0.0",
-        "symfony/http-foundation": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-        "alcohol/iso4217": "^4.3",
-        "symfony/psr-http-message-bridge": "^2.3",
-        "league/openapi-psr7-validator": "^0.22.0"
+        "symfony/http-foundation": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
     },
     "platform": {
         "php": "7.4"
@@ -39,6 +36,7 @@
         "behat/behat": "^3.13",
         "brick/varexporter": "^0.4",
         "guzzlehttp/guzzle": "^7.5",
+        "league/openapi-psr7-validator": "^0.22.0",
         "myparcelnl/devtools": "^1.0.0",
         "nette/robot-loader": "^3.0.0",
         "pestphp/pest": "^1.0.0",


### PR DESCRIPTION
Lands three small cleanups that were committed locally during the capabilities work but never pushed.

## Dependencies (`composer.json`)
The capabilities release removed the JSON-schema validation layer (`CarrierSchema`/`SchemaRepository`) and the carrier-specific calculators, leaving several production dependencies unused. Verified there are **no `src/` references** to any of these:

- Remove `justinrainbow/json-schema` — was only used for order validation, which is now capabilities-driven.
- Remove `alcohol/iso4217` and `symfony/psr-http-message-bridge` — no longer referenced.
- Move `league/openapi-psr7-validator` to `require-dev` — only used in tests.

## Skill
- `.claude/skills/add-shipment-option.md` referenced the deleted `CarrierSchema::canHaveShipmentOption()`. Repointed to `CapabilitiesValidationService` and dropped the obsolete deprecated-const step.

CI validates that the dependency removals still resolve and the suite passes.

Resolves INT-1504