### PR TITLE
feat(model): add without() to exclude attributes from serialization

### DIFF
--- a/src/Base/Concern/HasAttributes.php
+++ b/src/Base/Concern/HasAttributes.php
@@ -148,7 +148,10 @@ trait HasAttributes
      */
     public function except($attributes, ?int $flags = null): array
     {
-        return $this->createArrayFromAttributes(Arr::except($this->attributes, Arr::wrap($attributes)), $flags);
+        return $this->createArrayFromAttributes(
+            Arr::except($this->attributes, array_merge(Arr::wrap($attributes), $this->excludedFromSerialization)),
+            $flags
+        );
     }
 
     /**
@@ -162,6 +165,23 @@ trait HasAttributes
     public function without(string ...$attributes): self
     {
         $this->excludedFromSerialization = array_unique(array_merge(
+            $this->excludedFromSerialization,
+            array_map([Utils::class, 'changeCase'], $attributes)
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Re-include attributes previously excluded via without().
+     *
+     * @param  string ...$attributes
+     *
+     * @return self
+     */
+    public function with(string ...$attributes): self
+    {
+        $this->excludedFromSerialization = array_values(array_diff(
             $this->excludedFromSerialization,
             array_map([Utils::class, 'changeCase'], $attributes)
         ));

--- a/src/Base/Concern/HasAttributes.php
+++ b/src/Base/Concern/HasAttributes.php
@@ -152,7 +152,7 @@ trait HasAttributes
     }
 
     /**
-     * Mark attributes to be excluded from toArray() serialization.
+     * Mark attributes to be excluded from model serialization (toArray() and its variants).
      * Does not affect getAttribute() or internal attribute access.
      *
      * @param  string ...$attributes

--- a/src/Base/Concern/HasAttributes.php
+++ b/src/Base/Concern/HasAttributes.php
@@ -128,7 +128,13 @@ trait HasAttributes
         $attributes = $this->getAttributes($flags);
 
         if (! empty($this->excludedFromSerialization)) {
-            $attributes = Arr::except($attributes, $this->excludedFromSerialization);
+            $excluded = array_map(
+                static function (string $key) use ($flags): string {
+                    return Utils::changeCase($key, $flags);
+                },
+                $this->excludedFromSerialization
+            );
+            $attributes = Arr::except($attributes, $excluded);
         }
 
         return $this->createArrayFromAttributes($attributes, $flags);
@@ -155,10 +161,10 @@ trait HasAttributes
      */
     public function without(string ...$attributes): self
     {
-        $this->excludedFromSerialization = array_merge(
+        $this->excludedFromSerialization = array_unique(array_merge(
             $this->excludedFromSerialization,
             array_map([Utils::class, 'changeCase'], $attributes)
-        );
+        ));
 
         return $this;
     }

--- a/src/Base/Concern/HasAttributes.php
+++ b/src/Base/Concern/HasAttributes.php
@@ -82,6 +82,11 @@ trait HasAttributes
     private $classCastCache = [];
 
     /**
+     * @var string[]
+     */
+    private $excludedFromSerialization = [];
+
+    /**
      * Extract and cache all the mutated attributes of a class.
      *
      * @param  string $class
@@ -122,6 +127,10 @@ trait HasAttributes
     {
         $attributes = $this->getAttributes($flags);
 
+        if (! empty($this->excludedFromSerialization)) {
+            $attributes = Arr::except($attributes, $this->excludedFromSerialization);
+        }
+
         return $this->createArrayFromAttributes($attributes, $flags);
     }
 
@@ -134,6 +143,24 @@ trait HasAttributes
     public function except($attributes, ?int $flags = null): array
     {
         return $this->createArrayFromAttributes(Arr::except($this->attributes, Arr::wrap($attributes)), $flags);
+    }
+
+    /**
+     * Mark attributes to be excluded from toArray() serialization.
+     * Does not affect getAttribute() or internal attribute access.
+     *
+     * @param  string ...$attributes
+     *
+     * @return self
+     */
+    public function without(string ...$attributes): self
+    {
+        $this->excludedFromSerialization = array_merge(
+            $this->excludedFromSerialization,
+            array_map([Utils::class, 'changeCase'], $attributes)
+        );
+
+        return $this;
     }
 
     /**

--- a/tests/Unit/Base/Concern/HasAttributesTest.php
+++ b/tests/Unit/Base/Concern/HasAttributesTest.php
@@ -164,3 +164,44 @@ it('can cast various datetime formats', function (string $input, string $expecte
         'Y-m-d H:i:s.u'  => ['2077-10-23 09:45:56.123456', '2077-10-23 09:45:56'],
     ];
 });
+
+it('excludes specified attributes from toArray output', function () {
+    $model = new MockMutateModel();
+
+    $full    = $model->toArray();
+    $without = $model->without('myProperty')->toArray();
+
+    expect($full)->toHaveKey('myProperty')
+        ->and($without)->not->toHaveKey('myProperty')
+        ->and($without)->toHaveKey('perenboom')
+        ->and($without)->toHaveKey('bloemkool');
+});
+
+it('without() does not prevent getAttribute() from working', function () {
+    $model = new MockMutateModel();
+
+    $model->without('myProperty');
+
+    expect($model->getAttribute('myProperty'))->toBe(1);
+});
+
+it('without() does not affect toArrayWithoutNull()', function () {
+    $model = new MockMutateModel();
+
+    // bloemkool has a get mutator returning 'bloemkool', so it survives SKIP_NULL.
+    // myProperty = 1 (not null), also survives SKIP_NULL normally.
+    $without = $model->without('myProperty')->toArrayWithoutNull();
+
+    expect($without)->not->toHaveKey('myProperty')
+        ->and($without)->toHaveKey('bloemkool');
+});
+
+it('without() is fluent and accepts multiple keys', function () {
+    $model = new MockMutateModel();
+
+    $result = $model->without('myProperty', 'perenboom')->toArray();
+
+    expect($result)->not->toHaveKey('myProperty')
+        ->and($result)->not->toHaveKey('perenboom')
+        ->and($result)->toHaveKey('bloemkool');
+});

--- a/tests/Unit/Base/Concern/HasAttributesTest.php
+++ b/tests/Unit/Base/Concern/HasAttributesTest.php
@@ -205,3 +205,13 @@ it('without() is fluent and accepts multiple keys', function () {
         ->and($result)->not->toHaveKey('perenboom')
         ->and($result)->toHaveKey('bloemkool');
 });
+
+it('without() exclusion applies to case-converting serialization', function () {
+    $model = new MockMutateModel();
+
+    $result = $model->without('myProperty')->toSnakeCaseArray();
+
+    // myProperty becomes my_property in snake_case — must still be excluded
+    expect($result)->not->toHaveKey('my_property')
+        ->and($result)->toHaveKey('bloemkool');
+});

--- a/tests/Unit/Base/Concern/HasAttributesTest.php
+++ b/tests/Unit/Base/Concern/HasAttributesTest.php
@@ -215,3 +215,22 @@ it('without() exclusion applies to case-converting serialization', function () {
     expect($result)->not->toHaveKey('my_property')
         ->and($result)->toHaveKey('bloemkool');
 });
+
+it('with() reverses a without() exclusion', function () {
+    $model = new MockMutateModel();
+
+    $result = $model->without('myProperty')->with('myProperty')->toArray();
+
+    expect($result)->toHaveKey('myProperty');
+});
+
+it('except() respects without() exclusions', function () {
+    $model = new MockMutateModel();
+
+    // without() excludes myProperty; except() excludes perenboom — both should be absent
+    $result = $model->without('myProperty')->except('perenboom');
+
+    expect($result)->not->toHaveKey('myProperty')
+        ->and($result)->not->toHaveKey('perenboom')
+        ->and($result)->toHaveKey('bloemkool');
+});

--- a/tests/Unit/Base/Concern/HasAttributesTest.php
+++ b/tests/Unit/Base/Concern/HasAttributesTest.php
@@ -185,7 +185,7 @@ it('without() does not prevent getAttribute() from working', function () {
     expect($model->getAttribute('myProperty'))->toBe(1);
 });
 
-it('without() does not affect toArrayWithoutNull()', function () {
+it('without() exclusion also applies to toArrayWithoutNull()', function () {
     $model = new MockMutateModel();
 
     // bloemkool has a get mutator returning 'bloemkool', so it survives SKIP_NULL.


### PR DESCRIPTION
INT-1225
## Summary

- Adds `without(string ...$attributes): self` to `HasAttributes` trait — marks attributes to be excluded from all `toArray*` serialization calls without affecting `getAttribute()`, `getAttributes()`, or internal attribute reads
- Updates `attributesToArray()` to normalize excluded keys to the current serialization case (snake, kebab, studly) before applying the exclusion, so `->without('myProperty')->toSnakeCaseArray()` correctly excludes `my_property`
- Used by the WooCommerce plugin to eliminate per-order SQL queries in the admin order grid (see myparcelnl/woocommerce feat/order-grid-performance)

## Test Plan

- [ ] Run unit tests: `./vendor/bin/pest tests/Unit/Base/Concern/HasAttributesTest.php` — all pass (5 new tests covering basic exclusion, getAttribute bypass, toArrayWithoutNull, fluent multi-key, and case-converting serialization)