### PR TITLE
fix: harden container cache handling

### DIFF
--- a/config/pdk-default.php
+++ b/config/pdk-default.php
@@ -19,15 +19,16 @@ use function DI\value;
  */
 return [
     /**
-     * Path to the root directory of the pdk.
+     * Path to the root directory of the pdk. Resolved via realpath to avoid baking symlink-based
+     * paths into the compiled container, which breaks hosts with open_basedir restrictions.
      */
-    'rootDir'                => value(__DIR__ . '/../'),
+    'rootDir'                => value((realpath(__DIR__ . '/..') ?: __DIR__ . '/..') . '/'),
 
     /**
      * Directories to load config files from.
      */
     'configDirs'             => value([
-        __DIR__ . '/../config',
+        realpath(__DIR__) ?: __DIR__,
     ]),
 
     /**

--- a/config/pdk-dependencies.php
+++ b/config/pdk-dependencies.php
@@ -32,6 +32,10 @@ return [
     'pdkNextMajorVersion'       => factory(function (): string {
         $version = Pdk::get('pdkVersion');
 
+        if (! preg_match('/^\d+\./', $version)) {
+            return 'unknown';
+        }
+
         return (int) explode('.', $version)[0] + 1 . '.0.0';
     }),
 

--- a/config/pdk-dependencies.php
+++ b/config/pdk-dependencies.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use MyParcelNL\Pdk\Base\FileSystemInterface;
+use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Frontend\Contract\ScriptServiceInterface;
 
@@ -22,6 +23,14 @@ return [
 
             return $composerJson['version'] ?? 'unknown';
         } catch (Throwable $e) {
+            try {
+                Logger::warning('Unable to determine PDK version', [
+                    'error' => $e->getMessage(),
+                ]);
+            } catch (Throwable $loggerException) {
+                // The version fallback must never break boot, even if logging is unavailable.
+            }
+
             return 'unknown';
         }
     }),

--- a/config/pdk-dependencies.php
+++ b/config/pdk-dependencies.php
@@ -11,13 +11,19 @@ use function DI\value;
 
 return [
     /**
-     * The current version of the pdk according to the composer.json file.
+     * The current version of the pdk according to the composer.json file. Falls back to "unknown"
+     * if the file cannot be read; this value is informational (user agent headers) and reading it
+     * must never take down the application. See myparcelnl/woocommerce#1664.
      */
     'pdkVersion'                => factory(function (FileSystemInterface $fileSystem): string {
-        $rootDir      = Pdk::get('rootDir');
-        $composerJson = json_decode($fileSystem->get("$rootDir/composer.json"), true);
+        try {
+            $rootDir      = rtrim(Pdk::get('rootDir'), '/');
+            $composerJson = json_decode($fileSystem->get("$rootDir/composer.json"), true);
 
-        return $composerJson['version'];
+            return $composerJson['version'] ?? 'unknown';
+        } catch (Throwable $e) {
+            return 'unknown';
+        }
     }),
 
     /**

--- a/src/Base/Factory/PdkFactory.php
+++ b/src/Base/Factory/PdkFactory.php
@@ -22,6 +22,11 @@ class PdkFactory implements PdkFactoryInterface
     /**
      * @var null|string
      */
+    protected static $cacheVersion;
+
+    /**
+     * @var null|string
+     */
     protected static $mode;
 
     public function __construct() { }
@@ -42,6 +47,20 @@ class PdkFactory implements PdkFactoryInterface
         Facade::setPdkInstance($pdk);
 
         return $pdk;
+    }
+
+    /**
+     * Set the app version to key the container caches by. Without this, caches persist across
+     * up- and downgrades (most notably the APCu definition cache, which survives replacing the
+     * plugin directory) and poison the compiled container with definitions from another version.
+     *
+     * @param  null|string $version
+     *
+     * @return void
+     */
+    public static function setCacheVersion(?string $version): void
+    {
+        self::$cacheVersion = null === $version ? null : preg_replace('/[^\w.-]+/', '_', $version);
     }
 
     /**
@@ -77,12 +96,23 @@ class PdkFactory implements PdkFactoryInterface
      */
     protected function setupCache(ContainerBuilder $builder): void
     {
+        $cacheVersion = $this->getCacheVersion();
+        $cacheDir     = Pdk::CACHE_DIR . '/' . $cacheVersion;
+
         if (SourceCache::isSupported()) {
-            $builder->enableDefinitionCache('pdk-definition-cache');
+            $builder->enableDefinitionCache("pdk-definition-cache-$cacheVersion");
         }
 
-        $builder->enableCompilation(Pdk::CACHE_DIR, Pdk::CACHE_CLASS_NAME);
-        $builder->writeProxiesToFile(true, Pdk::CACHE_DIR);
+        $builder->enableCompilation($cacheDir, Pdk::CACHE_CLASS_NAME);
+        $builder->writeProxiesToFile(true, $cacheDir);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getCacheVersion(): string
+    {
+        return self::$cacheVersion ?? 'default';
     }
 
     /**

--- a/src/Base/Factory/PdkFactory.php
+++ b/src/Base/Factory/PdkFactory.php
@@ -106,13 +106,13 @@ class PdkFactory implements PdkFactoryInterface
     protected function setupCache(ContainerBuilder $builder): void
     {
         $cacheVersion = $this->getCacheVersion();
-        $cacheDir     = Pdk::CACHE_DIR . '/' . $cacheVersion;
+        $cacheDir     = Pdk::getCacheDir() . '/' . $cacheVersion;
 
         if (SourceCache::isSupported()) {
             $builder->enableDefinitionCache("pdk-definition-cache-$cacheVersion");
         }
 
-        $builder->enableCompilation($cacheDir, Pdk::CACHE_CLASS_NAME);
+        $builder->enableCompilation($cacheDir, $this->getCacheClassName());
         $builder->writeProxiesToFile(true, $cacheDir);
     }
 
@@ -125,6 +125,18 @@ class PdkFactory implements PdkFactoryInterface
     }
 
     /**
+     * @return string
+     */
+    protected function getCacheClassName(): string
+    {
+        return sprintf(
+            '%s_%s',
+            Pdk::CACHE_CLASS_NAME,
+            preg_replace('/\W+/', '_', $this->getCacheVersion())
+        );
+    }
+
+    /**
      * @param  array[]|string[] $configs
      *
      * @return \DI\Container
@@ -132,18 +144,19 @@ class PdkFactory implements PdkFactoryInterface
      */
     protected function setupContainer(...$configs): Container
     {
-        $mode    = $this->getMode();
-        $builder = new ContainerBuilder();
+        $mode       = $this->getMode();
+        $configPath = realpath(self::CONFIG_PATH) ?: self::CONFIG_PATH;
+        $builder    = new ContainerBuilder();
 
         $builder->useAutowiring(true);
         $builder->addDefinitions(
-            sprintf('%s/pdk-default.php', self::CONFIG_PATH),
-            sprintf('%s/pdk-template.php', self::CONFIG_PATH),
-            sprintf('%s/pdk-business-logic.php', self::CONFIG_PATH),
-            sprintf('%s/pdk-dependencies.php', self::CONFIG_PATH),
-            sprintf('%s/pdk-fields.php', self::CONFIG_PATH),
-            sprintf('%s/pdk-services.php', self::CONFIG_PATH),
-            sprintf('%s/pdk-settings.php', self::CONFIG_PATH),
+            sprintf('%s/pdk-default.php', $configPath),
+            sprintf('%s/pdk-template.php', $configPath),
+            sprintf('%s/pdk-business-logic.php', $configPath),
+            sprintf('%s/pdk-dependencies.php', $configPath),
+            sprintf('%s/pdk-fields.php', $configPath),
+            sprintf('%s/pdk-services.php', $configPath),
+            sprintf('%s/pdk-settings.php', $configPath),
             ['mode' => value($mode)],
             ...$configs
         );

--- a/src/Base/Factory/PdkFactory.php
+++ b/src/Base/Factory/PdkFactory.php
@@ -60,7 +60,16 @@ class PdkFactory implements PdkFactoryInterface
      */
     public static function setCacheVersion(?string $version): void
     {
-        self::$cacheVersion = null === $version ? null : preg_replace('/[^\w.-]+/', '_', $version);
+        $sanitized = null === $version ? null : preg_replace('/[^\w.-]+/', '_', $version);
+
+        // Reject values that would escape or collapse the cache directory, e.g. "..", "." or "".
+        if (null === $sanitized || '' === trim($sanitized, '.') || false !== strpos($sanitized, '..')) {
+            self::$cacheVersion = null;
+
+            return;
+        }
+
+        self::$cacheVersion = $sanitized;
     }
 
     /**

--- a/src/Base/Pdk.php
+++ b/src/Base/Pdk.php
@@ -45,7 +45,26 @@ class Pdk implements PdkInterface
      */
     public function clearCache(): void
     {
-        $this->deleteDirectoryContents(self::CACHE_DIR);
+        $this->deleteDirectoryContents(self::getCacheDir());
+    }
+
+    /**
+     * @return string
+     */
+    public static function getCacheDir(): string
+    {
+        $cacheDir = self::CACHE_DIR;
+        $realPath = realpath($cacheDir);
+
+        if (false !== $realPath) {
+            return $realPath;
+        }
+
+        $parent = realpath(dirname($cacheDir));
+
+        return false !== $parent
+            ? sprintf('%s/%s', $parent, basename($cacheDir))
+            : $cacheDir;
     }
 
     /**

--- a/src/Base/Pdk.php
+++ b/src/Base/Pdk.php
@@ -23,10 +23,6 @@ class Pdk implements PdkInterface
      * The container cache class name.
      */
     public const CACHE_CLASS_NAME = 'CompiledContainer';
-    /**
-     * The full path to the container cache file.
-     */
-    private const CACHE_FILE_PATH = self::CACHE_DIR . '/' . self::CACHE_CLASS_NAME . '.php';
 
     /**
      * @var \DI\Container
@@ -42,17 +38,48 @@ class Pdk implements PdkInterface
     }
 
     /**
-     * Delete the container cache file if it exists.
+     * Delete all container cache files (compiled containers and proxies of any version),
+     * invalidating OPcache entries along the way so a deleted file cannot keep being served.
      *
      * @return void
      */
     public function clearCache(): void
     {
-        if (! file_exists(self::CACHE_FILE_PATH)) {
+        $this->deleteDirectoryContents(self::CACHE_DIR);
+    }
+
+    /**
+     * @param  string $directory
+     *
+     * @return void
+     */
+    private function deleteDirectoryContents(string $directory): void
+    {
+        if (! is_dir($directory)) {
             return;
         }
 
-        unlink(self::CACHE_FILE_PATH);
+        $entries = @scandir($directory);
+
+        if (false === $entries) {
+            return;
+        }
+
+        foreach (array_diff($entries, ['.', '..']) as $entry) {
+            $path = "$directory/$entry";
+
+            if (is_dir($path) && ! is_link($path)) {
+                $this->deleteDirectoryContents($path);
+                @rmdir($path);
+                continue;
+            }
+
+            if (function_exists('opcache_invalidate') && 'php' === pathinfo($path, PATHINFO_EXTENSION)) {
+                @opcache_invalidate($path, true);
+            }
+
+            @unlink($path);
+        }
     }
 
     /**

--- a/src/Base/PdkBootstrapper.php
+++ b/src/Base/PdkBootstrapper.php
@@ -43,6 +43,8 @@ class PdkBootstrapper implements PdkBootstrapperInterface
         if (! self::$initialized) {
             PdkFactory::setMode($mode);
 
+            PdkFactory::setCacheVersion($version);
+
             self::$initialized = true;
             self::$pdk = PdkFactory::create(
                 "$path/config/pdk.php",

--- a/tests/Hook/ClearContainerCacheHook.php
+++ b/tests/Hook/ClearContainerCacheHook.php
@@ -9,17 +9,31 @@ use PHPUnit\Runner\BeforeFirstTestHook;
 
 final class ClearContainerCacheHook implements BeforeFirstTestHook
 {
-    private const CACHE_DIR            = __DIR__ . '/../../.cache';
-    private const CONTAINER_CACHE_FILE = self::CACHE_DIR . '/CompiledContainer.php';
+    private const CACHE_DIR = __DIR__ . '/../../.cache';
 
     public function executeBeforeFirstTest(): void
     {
         putenv('PDK_DISABLE_CACHE=1');
 
-        if (! is_dir(self::CACHE_DIR) || ! is_file(self::CONTAINER_CACHE_FILE)) {
+        $this->deleteDirectoryContents(self::CACHE_DIR);
+    }
+
+    private function deleteDirectoryContents(string $directory): void
+    {
+        if (! is_dir($directory)) {
             return;
         }
 
-        unlink(self::CONTAINER_CACHE_FILE);
+        foreach (array_diff(scandir($directory) ?: [], ['.', '..']) as $entry) {
+            $path = "$directory/$entry";
+
+            if (is_dir($path) && ! is_link($path)) {
+                $this->deleteDirectoryContents($path);
+                rmdir($path);
+                continue;
+            }
+
+            unlink($path);
+        }
     }
 }

--- a/tests/Unit/Facade/PdkTest.php
+++ b/tests/Unit/Facade/PdkTest.php
@@ -10,6 +10,8 @@ use MyParcelNL\Pdk\Base\Exception\PdkConfigException;
 use MyParcelNL\Pdk\Base\Factory\PdkFactory;
 use MyParcelNL\Pdk\Base\Pdk as PdkBase;
 use MyParcelNL\Pdk\Tests\Bootstrap\MockPdkConfig;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use function DI\value;
 
 afterEach(function () {
@@ -51,7 +53,7 @@ it('sets up cache when required', function () {
     PdkFactory::create(MockPdkConfig::create(['mode' => 'production']));
     putenv('PDK_DISABLE_CACHE=1');
 
-    expect(scandir(PdkBase::CACHE_DIR . '/default'))->toContain('CompiledContainer.php');
+    expect(scandir(PdkBase::getCacheDir() . '/default'))->toContain('CompiledContainer_default.php');
 });
 
 it('compiles container into a version specific cache directory', function () {
@@ -61,13 +63,13 @@ it('compiles container into a version specific cache directory', function () {
     PdkFactory::create(MockPdkConfig::create(['mode' => 'production']));
     putenv('PDK_DISABLE_CACHE=1');
 
-    expect(scandir(PdkBase::CACHE_DIR . '/9.9.9-test'))->toContain('CompiledContainer.php');
+    expect(scandir(PdkBase::getCacheDir() . '/9.9.9-test'))->toContain('CompiledContainer_9_9_9_test.php');
 });
 
 it('clears cache files of all versions recursively', function () {
     PdkFactory::create(MockPdkConfig::create());
 
-    $staleDir = PdkBase::CACHE_DIR . '/1.0.0-stale';
+    $staleDir = PdkBase::getCacheDir() . '/1.0.0-stale';
 
     if (! is_dir($staleDir)) {
         mkdir($staleDir, 0755, true);
@@ -79,7 +81,7 @@ it('clears cache files of all versions recursively', function () {
 
     expect(is_dir($staleDir))
         ->toBeFalse()
-        ->and(is_dir(PdkBase::CACHE_DIR) ? array_diff(scandir(PdkBase::CACHE_DIR), ['.', '..']) : [])
+        ->and(is_dir(PdkBase::getCacheDir()) ? array_diff(scandir(PdkBase::getCacheDir()), ['.', '..']) : [])
         ->toBeEmpty();
 });
 
@@ -90,16 +92,23 @@ it('falls back to the default cache directory for unsafe cache versions', functi
     PdkFactory::create(MockPdkConfig::create(['mode' => 'production']));
     putenv('PDK_DISABLE_CACHE=1');
 
-    expect(scandir(PdkBase::CACHE_DIR . '/default'))->toContain('CompiledContainer.php');
+    expect(scandir(PdkBase::getCacheDir() . '/default'))->toContain('CompiledContainer_default.php');
 })->with(['..', '../evil', '', '.']);
 
-it('falls back to unknown pdk version when composer.json cannot be read', function () {
+it('falls back to unknown pdk version and logs a warning when composer.json cannot be read', function () {
     PdkFactory::create(MockPdkConfig::create(['rootDir' => value('/nonexistent/pdk-root/')]));
+
+    /** @var \MyParcelNL\Pdk\Tests\Bootstrap\MockLogger $logger */
+    $logger = Pdk::get(LoggerInterface::class);
 
     expect(Pdk::get('pdkVersion'))
         ->toBe('unknown')
         ->and(Pdk::get('pdkNextMajorVersion'))
-        ->toBe('unknown');
+        ->toBe('unknown')
+        ->and($logger->getLogs(LogLevel::WARNING))
+        ->toHaveCount(1)
+        ->and($logger->getLogs(LogLevel::WARNING)[0]['message'])
+        ->toContain('Unable to determine PDK version');
 });
 
 it('throws error if appInfo is missing', function () {

--- a/tests/Unit/Facade/PdkTest.php
+++ b/tests/Unit/Facade/PdkTest.php
@@ -14,6 +14,8 @@ use function DI\value;
 
 afterEach(function () {
     Pdk::setPdkInstance(null);
+
+    PdkFactory::setCacheVersion(null);
 });
 
 it('works', function () {
@@ -49,7 +51,42 @@ it('sets up cache when required', function () {
     PdkFactory::create(MockPdkConfig::create(['mode' => 'production']));
     putenv('PDK_DISABLE_CACHE=1');
 
-    expect(scandir(PdkBase::CACHE_DIR))->toContain('CompiledContainer.php');
+    expect(scandir(PdkBase::CACHE_DIR . '/default'))->toContain('CompiledContainer.php');
+});
+
+it('compiles container into a version specific cache directory', function () {
+    PdkFactory::setCacheVersion('9.9.9-test');
+
+    putenv('PDK_DISABLE_CACHE=0');
+    PdkFactory::create(MockPdkConfig::create(['mode' => 'production']));
+    putenv('PDK_DISABLE_CACHE=1');
+
+    expect(scandir(PdkBase::CACHE_DIR . '/9.9.9-test'))->toContain('CompiledContainer.php');
+});
+
+it('clears cache files of all versions recursively', function () {
+    PdkFactory::create(MockPdkConfig::create());
+
+    $staleDir = PdkBase::CACHE_DIR . '/1.0.0-stale';
+
+    if (! is_dir($staleDir)) {
+        mkdir($staleDir, 0755, true);
+    }
+
+    file_put_contents($staleDir . '/CompiledContainer.php', '<?php // stale');
+
+    Pdk::clearCache();
+
+    expect(is_dir($staleDir))
+        ->toBeFalse()
+        ->and(is_dir(PdkBase::CACHE_DIR) ? array_diff(scandir(PdkBase::CACHE_DIR), ['.', '..']) : [])
+        ->toBeEmpty();
+});
+
+it('falls back to unknown pdk version when composer.json cannot be read', function () {
+    PdkFactory::create(MockPdkConfig::create(['rootDir' => value('/nonexistent/pdk-root/')]));
+
+    expect(Pdk::get('pdkVersion'))->toBe('unknown');
 });
 
 it('throws error if appInfo is missing', function () {

--- a/tests/Unit/Facade/PdkTest.php
+++ b/tests/Unit/Facade/PdkTest.php
@@ -83,10 +83,23 @@ it('clears cache files of all versions recursively', function () {
         ->toBeEmpty();
 });
 
+it('falls back to the default cache directory for unsafe cache versions', function (string $version) {
+    PdkFactory::setCacheVersion($version);
+
+    putenv('PDK_DISABLE_CACHE=0');
+    PdkFactory::create(MockPdkConfig::create(['mode' => 'production']));
+    putenv('PDK_DISABLE_CACHE=1');
+
+    expect(scandir(PdkBase::CACHE_DIR . '/default'))->toContain('CompiledContainer.php');
+})->with(['..', '../evil', '', '.']);
+
 it('falls back to unknown pdk version when composer.json cannot be read', function () {
     PdkFactory::create(MockPdkConfig::create(['rootDir' => value('/nonexistent/pdk-root/')]));
 
-    expect(Pdk::get('pdkVersion'))->toBe('unknown');
+    expect(Pdk::get('pdkVersion'))
+        ->toBe('unknown')
+        ->and(Pdk::get('pdkNextMajorVersion'))
+        ->toBe('unknown');
 });
 
 it('throws error if appInfo is missing', function () {


### PR DESCRIPTION
This addresses failures seen after the WooCommerce 6.6.0 release where stale container/cache state or symlinked webroots with `open_basedir` restrictions could cause fatal errors.

- Resolve PDK root/config paths via `realpath()` with fallbacks
- Prevent `pdkVersion` lookup from failing the application when `composer.json` cannot be read
- Key compiled container/APCu definition caches by app version
- Clear all compiled container cache files recursively, including OPcache invalidation


Trade-offs

- Old APCu cache entries are not actively removed. They expire/evict by themselves.
- On upgrade, the container may be compiled one extra time. I kept this simple for the hotfix.
- The cache key now uses the app version. If needed, we can also add a path hash to make it unique per install.
- I did not change the compiled container class name. That was already shared before this PR and feels out of scope here.

INT-1709