### PR TITLE
fix: update sdk beta test expectations

### DIFF
--- a/tests/Unit/Carrier/Model/CarrierTest.php
+++ b/tests/Unit/Carrier/Model/CarrierTest.php
@@ -129,9 +129,14 @@ it('creates carrier directly with constructor without lookup', function () {
         ->and($carrier->packageTypes)->toBeNull();
 });
 
-it('throws exception when carrier name does not match enum', function () {
-    new Carrier(['carrier' => 'NOT_AN_ENUM_VALUE']);
-})->throws(\InvalidArgumentException::class);
+it('marks unknown carrier names as unsupported', function () {
+    $carrier = new Carrier(['carrier' => 'NOT_AN_ENUM_VALUE']);
+
+    expect($carrier->carrier)
+        ->toBe('NOT_AN_ENUM_VALUE')
+        ->and(Carrier::isSupported($carrier->carrier))
+        ->toBeFalse();
+});
 
 it('factory can set option as required', function () {
     $carrier = factory(Carrier::class)
@@ -221,4 +226,3 @@ it('reports support only for carriers known to this PDK version', function () {
         ->and(Carrier::isSupported('UNSUPPORTED_FUTURE_CARRIER'))->toBeFalse()
         ->and(Carrier::isSupported(''))->toBeFalse();
 });
-

--- a/tests/Unit/SdkApi/Service/CoreApi/Shipment/CapabilitiesServiceTest.php
+++ b/tests/Unit/SdkApi/Service/CoreApi/Shipment/CapabilitiesServiceTest.php
@@ -14,7 +14,6 @@ use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Logger\Contract\PdkLoggerInterface;
 use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
 use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
-use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesPostContractDefinitionsRequestV2;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesSharedCarrierV2;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LogLevel;
@@ -290,10 +289,9 @@ it('getContractDefinitions rejects unknown carrier names before making a request
     TestBootstrapper::hasApiKey('valid-key');
 
     $service = new CapabilitiesService();
-    $allowedValuesString = implode("', '", (new CapabilitiesPostContractDefinitionsRequestV2())->getCarrierAllowableValues());
 
     expect(fn() => $service->getContractDefinitions('unknown_carrier'))
-        ->toThrow(\InvalidArgumentException::class, "Invalid value 'unknown_carrier' for 'carrier', must be one of '$allowedValuesString'");
+        ->toThrow(\InvalidArgumentException::class, 'carrier');
 });
 
 // Tests for LoggingMiddleware integration


### PR DESCRIPTION
- Update tests for SDK beta.29 validation behavior
- Avoid asserting the exact generated SDK exception message
- Keep unsupported carrier handling covered through Carrier::isSupported()