### PR TITLE
fix(settings): always render settings page when account fetch fails

### DIFF
--- a/src/App/Account/Repository/AbstractPdkAccountRepository.php
+++ b/src/App/Account/Repository/AbstractPdkAccountRepository.php
@@ -8,8 +8,12 @@ use MyParcelNL\Pdk\Account\Model\Account;
 use MyParcelNL\Pdk\Account\Repository\AccountRepository;
 use MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface;
 use MyParcelNL\Pdk\Base\Repository\Repository;
+use MyParcelNL\Pdk\Facade\Logger;
+use MyParcelNL\Pdk\Facade\Notifications;
+use MyParcelNL\Pdk\Notification\Model\Notification;
 use MyParcelNL\Pdk\Settings\Contract\PdkSettingsRepositoryInterface;
 use MyParcelNL\Pdk\Storage\Contract\StorageInterface;
+use Throwable;
 
 abstract class AbstractPdkAccountRepository extends Repository implements PdkAccountRepositoryInterface
 {
@@ -65,7 +69,23 @@ abstract class AbstractPdkAccountRepository extends Repository implements PdkAcc
                 return null;
             }
 
-            return $this->accountRepository->getAccount();
+            try {
+                return $this->accountRepository->getAccount();
+            } catch (Throwable $e) {
+                // Treat a failed account fetch as "no account" instead of letting the
+                // exception bubble up. Rendering must never break on an api failure,
+                // otherwise the settings page (including the api key form needed to
+                // fix the problem) would not be shown at all.
+                Logger::error('Failed to fetch account', ['exception' => $e]);
+
+                Notifications::error(
+                    'Failed to fetch account',
+                    $e->getMessage(),
+                    Notification::CATEGORY_API
+                );
+
+                return null;
+            }
         }, $force);
     }
 }

--- a/src/Context/Model/PluginSettingsViewContext.php
+++ b/src/Context/Model/PluginSettingsViewContext.php
@@ -6,6 +6,7 @@ namespace MyParcelNL\Pdk\Context\Model;
 
 use MyParcelNL\Pdk\Base\Contract\Arrayable;
 use MyParcelNL\Pdk\Facade\AccountSettings;
+use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\Facade\Notifications;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Frontend\View\CarrierSettingsView;
@@ -20,6 +21,7 @@ use MyParcelNL\Pdk\Settings\Model\CheckoutSettings;
 use MyParcelNL\Pdk\Settings\Model\CustomsSettings;
 use MyParcelNL\Pdk\Settings\Model\LabelSettings;
 use MyParcelNL\Pdk\Settings\Model\OrderSettings;
+use Throwable;
 
 /**
  * @property array{name: string, label: string, type: string}[]   $order
@@ -61,11 +63,26 @@ class PluginSettingsViewContext implements Arrayable
             return;
         }
 
-        foreach (self::ID_VIEW_MAP as $id => $viewClass) {
-            /** @var \MyParcelNL\Pdk\Frontend\View\AbstractSettingsView $view */
-            $view = Pdk::get($viewClass);
+        try {
+            foreach (self::ID_VIEW_MAP as $id => $viewClass) {
+                /** @var \MyParcelNL\Pdk\Frontend\View\AbstractSettingsView $view */
+                $view = Pdk::get($viewClass);
 
-            $this->views[$id] = $view->toArray();
+                $this->views[$id] = $view->toArray();
+            }
+        } catch (Throwable $e) {
+            // Never let a failing settings view prevent the page from rendering,
+            // otherwise the account settings (including the api key form) would
+            // not be shown at all.
+            Logger::error('Failed to create settings views', ['exception' => $e]);
+
+            Notifications::error(
+                'Failed to load settings',
+                $e->getMessage(),
+                Notification::CATEGORY_GENERAL
+            );
+
+            $this->views = [];
         }
     }
 

--- a/tests/Unit/App/Account/Repository/AbstractPdkAccountRepositoryTest.php
+++ b/tests/Unit/App/Account/Repository/AbstractPdkAccountRepositoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/** @noinspection StaticClosureCanBeUsedInspection,PhpUnhandledExceptionInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\App\Account\Repository;
+
+use MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface;
+use MyParcelNL\Pdk\Context\Context;
+use MyParcelNL\Pdk\Context\Service\ContextService;
+use MyParcelNL\Pdk\Facade\Notifications;
+use MyParcelNL\Pdk\Facade\Pdk;
+use MyParcelNL\Pdk\Tests\Api\Response\ExampleErrorResponse;
+use MyParcelNL\Pdk\Tests\Bootstrap\MockApi;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\Uses\UsesApiMock;
+use MyParcelNL\Pdk\Tests\Uses\UsesMockPdkInstance;
+
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+usesShared(new UsesMockPdkInstance(), new UsesApiMock());
+
+beforeEach(function () {
+    Notifications::clear();
+});
+
+it('returns null and adds a notification when fetching the account from the api fails', function () {
+    TestBootstrapper::hasApiKey('test-api-key');
+
+    MockApi::enqueue(new ExampleErrorResponse());
+
+    /** @var \MyParcelNL\Pdk\App\Account\Contract\PdkAccountRepositoryInterface $repository */
+    $repository = Pdk::get(PdkAccountRepositoryInterface::class);
+
+    $account = $repository->getAccount(true);
+
+    expect($account)
+        ->toBeNull()
+        ->and(Notifications::all()->isNotEmpty())
+        ->toBeTrue();
+});
+
+it('creates plugin settings view context when fetching the account fails', function () {
+    TestBootstrapper::hasApiKey('test-api-key');
+
+    MockApi::enqueue(new ExampleErrorResponse());
+
+    /** @var \MyParcelNL\Pdk\Context\Service\ContextService $service */
+    $service = Pdk::get(ContextService::class);
+
+    $context = $service->createContexts([Context::ID_PLUGIN_SETTINGS_VIEW]);
+
+    expect($context->pluginSettingsView->toArray())->toBe([]);
+});


### PR DESCRIPTION
## Problem

When fetching the account from the API fails (API down, network error, unexpected 5xx), the exception bubbled up into `FrontendRenderService::renderTemplate()`, which catches all throwables and renders an **empty string**. As a result the entire plugin settings page disappeared — including the API key form the merchant needs to fix the problem. The init script suffered the same fate via `DynamicContext`, so the admin app would not even boot.

Reported from WooCommerce, but this affects every PDK-based plugin.

## Solution

- **`AbstractPdkAccountRepository::getAccount()`**: treat a failed account fetch as "no account" — log the error, push an error notification and return `null`, matching the existing invalid-api-key semantics. Since `DynamicContext` uses the same repository, this fixes both the settings page render and the init script in one place.
- **`PluginSettingsViewContext`**: defensively catch throwables while building the settings views, so a single failing view can never blank the page either.

The admin frontend (js-pdk) already handles `account: null` correctly: `PluginSettings.vue` renders `<AccountSettings />` unconditionally and opens the API key tab, hiding only the remaining settings forms. So with this change the API key block is **always** visible, with an error notification explaining what went wrong.

## Tests

- New: `tests/Unit/App/Account/Repository/AbstractPdkAccountRepositoryTest.php`
  - API error → `getAccount()` returns `null` and adds a notification (fails without this fix)
  - API error → `createContexts([ID_PLUGIN_SETTINGS_VIEW])` no longer throws
- Full suite: 2678 passed; pre-existing local failures in `ZipService`/`AddressesApiService`/`DownloadLogs` also fail on `main` (PHP version issue, unrelated)
- PHPStan: no errors on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)