### PR TITLE
fix(settings): keep the page usable when a settings view fails to build

### DIFF
--- a/src/Context/Model/PluginSettingsViewContext.php
+++ b/src/Context/Model/PluginSettingsViewContext.php
@@ -6,6 +6,7 @@ namespace MyParcelNL\Pdk\Context\Model;
 
 use MyParcelNL\Pdk\Base\Contract\Arrayable;
 use MyParcelNL\Pdk\Facade\AccountSettings;
+use MyParcelNL\Pdk\Facade\Logger;
 use MyParcelNL\Pdk\Facade\Notifications;
 use MyParcelNL\Pdk\Facade\Pdk;
 use MyParcelNL\Pdk\Frontend\View\CarrierSettingsView;
@@ -20,6 +21,7 @@ use MyParcelNL\Pdk\Settings\Model\CheckoutSettings;
 use MyParcelNL\Pdk\Settings\Model\CustomsSettings;
 use MyParcelNL\Pdk\Settings\Model\LabelSettings;
 use MyParcelNL\Pdk\Settings\Model\OrderSettings;
+use Throwable;
 
 /**
  * @property array{name: string, label: string, type: string}[]   $order
@@ -62,10 +64,27 @@ class PluginSettingsViewContext implements Arrayable
         }
 
         foreach (self::ID_VIEW_MAP as $id => $viewClass) {
-            /** @var \MyParcelNL\Pdk\Frontend\View\AbstractSettingsView $view */
-            $view = Pdk::get($viewClass);
+            try {
+                /** @var \MyParcelNL\Pdk\Frontend\View\AbstractSettingsView $view */
+                $view = Pdk::get($viewClass);
 
-            $this->views[$id] = $view->toArray();
+                $this->views[$id] = $view->toArray();
+            } catch (Throwable $e) {
+                // A single broken settings view (e.g. corrupt carrier capabilities in the stored
+                // account) must not take down the whole settings page. Log the real cause, tell
+                // the user which section failed, and keep every other view - including the box
+                // that lets them re-save their API key or refresh their data to recover.
+                Logger::error(
+                    sprintf('Failed to build the "%s" settings view: %s', $id, $e->getMessage()),
+                    ['exception' => $e, 'trace' => $e->getTraceAsString()]
+                );
+
+                Notifications::error(
+                    sprintf('Could not load %s settings', $id),
+                    'Please try re-saving your API key or refreshing your data.',
+                    Notification::CATEGORY_GENERAL
+                );
+            }
         }
     }
 

--- a/tests/Unit/Context/Model/PluginSettingsViewContextTest.php
+++ b/tests/Unit/Context/Model/PluginSettingsViewContextTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection, StaticClosureCanBeUsedInspection */
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Pdk\Context\Model;
+
+use MyParcelNL\Pdk\Facade\Logger;
+use MyParcelNL\Pdk\Facade\Notifications;
+use MyParcelNL\Pdk\Frontend\View\CarrierSettingsView;
+use MyParcelNL\Pdk\Notification\Model\Notification;
+use MyParcelNL\Pdk\Settings\Model\CarrierSettings;
+use MyParcelNL\Pdk\Settings\Model\CheckoutSettings;
+use MyParcelNL\Pdk\Settings\Model\CustomsSettings;
+use MyParcelNL\Pdk\Settings\Model\LabelSettings;
+use MyParcelNL\Pdk\Settings\Model\OrderSettings;
+use MyParcelNL\Pdk\Settings\Model\Settings;
+use MyParcelNL\Pdk\Tests\Bootstrap\TestBootstrapper;
+use MyParcelNL\Pdk\Tests\Uses\UsesEachMockPdkInstance;
+use function MyParcelNL\Pdk\Tests\factory;
+use function MyParcelNL\Pdk\Tests\mockPdkProperty;
+use function MyParcelNL\Pdk\Tests\usesShared;
+
+// A fresh PDK instance per test so notifications and container bindings do not leak between tests.
+usesShared(new UsesEachMockPdkInstance());
+
+const BROKEN_CARRIER_MESSAGE = 'Call to a member function getMin() on null';
+
+beforeEach(function () {
+    factory(Settings::class)->store();
+    TestBootstrapper::hasAccount();
+});
+
+/**
+ * Replace the carrier settings view with one that fails the way corrupt account data does:
+ * a PHP Error (not an Exception) thrown while the view is built.
+ */
+function stubBrokenCarrierView(): void
+{
+    mockPdkProperty(CarrierSettingsView::class, new class {
+        public function toArray(): array
+        {
+            throw new \Error(BROKEN_CARRIER_MESSAGE);
+        }
+    });
+}
+
+it('drops only the failing section instead of aborting the whole settings page', function () {
+    stubBrokenCarrierView();
+
+    $views = (new PluginSettingsViewContext())->toArray();
+
+    expect($views)
+        ->not->toHaveKey(CarrierSettings::ID)
+        ->and($views)->toHaveKey(OrderSettings::ID)
+        ->and($views)->toHaveKey(LabelSettings::ID)
+        ->and($views)->toHaveKey(CustomsSettings::ID)
+        ->and($views)->toHaveKey(CheckoutSettings::ID);
+});
+
+it('shows a single error notification naming the section that failed', function () {
+    stubBrokenCarrierView();
+
+    new PluginSettingsViewContext();
+
+    $errors = array_values(array_filter(
+        Notifications::all()->toArrayWithoutNull(),
+        static fn (array $notification): bool => ($notification['variant'] ?? null) === Notification::VARIANT_ERROR
+    ));
+
+    expect($errors)->toHaveCount(1);
+    expect(strtolower((string) ($errors[0]['title'] ?? '')))->toContain(CarrierSettings::ID);
+});
+
+it('always logs the original error when a view fails', function () {
+    stubBrokenCarrierView();
+
+    new PluginSettingsViewContext();
+
+    $loggedOriginal = false;
+
+    foreach (Logger::getLogs() as $log) {
+        $exception = $log['context']['exception'] ?? null;
+
+        if ($exception instanceof \Throwable && $exception->getMessage() === BROKEN_CARRIER_MESSAGE) {
+            $loggedOriginal = true;
+            break;
+        }
+    }
+
+    expect($loggedOriginal)->toBeTrue();
+});


### PR DESCRIPTION
Stops one broken settings view from taking down the whole plugin settings page.

Corrupt account data - for example a mangled insurance format in the stored carrier capabilities - could make a single settings view throw while the page was being built, which crashed the entire page. That left the user unable to re-enter their API key or refresh their data, which are exactly the actions that would fix it. Each view is now built in isolation: a failing view is skipped, its original error is logged, and a notification names the section that failed, while every other section (including the API key / debug box) keeps working so the user can recover on their own.

Fixes INT-1722

🤖 Generated with [Claude Code](https://claude.com/claude-code)