### PR TITLE
fix(settings): render same-day settings for carriers (trunkrs) with same-day delivery type

### DIFF
--- a/src/App/DeliveryOptions/Service/DeliveryOptionsService.php
+++ b/src/App/DeliveryOptions/Service/DeliveryOptionsService.php
@@ -150,10 +150,6 @@ class DeliveryOptionsService implements DeliveryOptionsServiceInterface
             ->pluck('weekday')
             ->toArray();
 
-        // Always use Europe/Amsterdam timezone for cutoff checks, because cutoff times are meant as local shop time.
-        // This prevents bugs when the server runs in a different timezone (e.g. UTC).
-        $now = new DateTimeImmutable('now', new DateTimeZone('Europe/Amsterdam'));
-
         $minimumDropOffDelay = -1 === $cart->shippingMethod->minimumDropOffDelay
             ? $carrierSettings['dropOffDelay']
             : $cart->shippingMethod->minimumDropOffDelay;
@@ -173,9 +169,6 @@ class DeliveryOptionsService implements DeliveryOptionsServiceInterface
             [
                 'deliveryDaysWindow'   => $carrierSettings->deliveryDaysWindow,
                 'dropOffDelay'         => max($minimumDropOffDelay, $carrierSettings->dropOffDelay),
-                'allowSameDayDelivery' => ($settings['allowSameDayDelivery'] ?? false)
-                    && 0 === $minimumDropOffDelay
-                    && $now->format('H:i') <= ($carrierSettings['cutoffTimeSameDay'] ?? '00:00'),
                 'cutoffTime'           => $dropOff->cutoffTime ?? null,
                 'cutoffTimeSameDay'    => $carrierSettings['cutoffTimeSameDay'] ?? null,
                 'dropOffDays'          => $dropOffDays,

--- a/src/App/Order/Calculator/General/CustomerInformationCalculator.php
+++ b/src/App/Order/Calculator/General/CustomerInformationCalculator.php
@@ -14,8 +14,8 @@ use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrierV2;
 final class CustomerInformationCalculator extends AbstractPdkOrderOptionCalculator
 {
     /*
-     * These carriers *requires* customer information to be shared, ignore any global setting.
-     * There is no API exposing this type of requirement at this point in time (july 2026)
+     * These carriers *require* customer information to be shared; ignore any global setting.
+     * There is no API exposing this type of requirement at this point in time (July 2026).
      */
     private const CARRIERS_WITH_MANDATORY_CUSTOMER_INFO = [
         RefTypesCarrierV2::DPD,

--- a/src/App/Order/Calculator/General/CustomerInformationCalculator.php
+++ b/src/App/Order/Calculator/General/CustomerInformationCalculator.php
@@ -19,7 +19,7 @@ final class CustomerInformationCalculator extends AbstractPdkOrderOptionCalculat
      */
     private const CARRIERS_WITH_MANDATORY_CUSTOMER_INFO = [
         RefTypesCarrierV2::DPD,
-        RefTypesCarrierV2::TRUNKRS
+        RefTypesCarrierV2::TRUNKRS,
     ];
 
     public function calculate(): void

--- a/src/App/Order/Calculator/General/CustomerInformationCalculator.php
+++ b/src/App/Order/Calculator/General/CustomerInformationCalculator.php
@@ -13,6 +13,15 @@ use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrierV2;
 
 final class CustomerInformationCalculator extends AbstractPdkOrderOptionCalculator
 {
+    /*
+     * These carriers *requires* customer information to be shared, ignore any global setting.
+     * There is no API exposing this type of requirement at this point in time (july 2026)
+     */
+    private const CARRIERS_WITH_MANDATORY_CUSTOMER_INFO = [
+        RefTypesCarrierV2::DPD,
+        RefTypesCarrierV2::TRUNKRS
+    ];
+
     public function calculate(): void
     {
         $orderCarrier = $this->order->deliveryOptions->carrier;
@@ -46,8 +55,7 @@ final class CustomerInformationCalculator extends AbstractPdkOrderOptionCalculat
     protected function sharingCustomerInformation(Carrier $carrier): bool
     {
         // @TODO this is a specific carrier check as there is currently no endpoint exposing this information
-        if ($carrier->carrier === RefTypesCarrierV2::DPD) {
-            // DPD *requires* customer information to be shared, ignore any global setting
+        if (\in_array($carrier->carrier, self::CARRIERS_WITH_MANDATORY_CUSTOMER_INFO, true)) {
             return true;
         }
 

--- a/src/Frontend/View/CarrierSettingsItemView.php
+++ b/src/Frontend/View/CarrierSettingsItemView.php
@@ -486,21 +486,33 @@ class CarrierSettingsItemView extends AbstractSettingsView
         // delivery type (e.g. Trunkrs), depending on the carrier's contract. This
         // section is the single owner of the same-day fields for both representations;
         // getDeliveryTypeSettings() and getShipmentOptionsSettings() skip same-day.
+        $definition = new SameDayDeliveryDefinition();
+
         $hasSameDayDeliveryType = $this->carrier->deliveryTypes
             && in_array(RefTypesDeliveryTypeV2::SAME_DAY, $this->carrier->deliveryTypes, true);
 
-        if (
-            ! $hasSameDayDeliveryType
-            && ! $this->carrierValidationService->supportsShipmentOption($this->carrier, SameDayDeliveryDefinition::class)
-        ) {
+        $hasSameDayShipmentOption = $this->carrierValidationService->supportsShipmentOption(
+            $this->carrier,
+            SameDayDeliveryDefinition::class
+        );
+
+        if (! $hasSameDayDeliveryType && ! $hasSameDayShipmentOption) {
             return [];
         }
 
+        $elements = $this->createSettingWithPriceFields(
+            $definition->getAllowSettingsKey(),
+            SettingKey::priceDeliveryType(RefTypesDeliveryTypeV2::SAME_DAY)
+        );
+
+        $capabilitiesKey = $definition->getCapabilitiesOptionsKey();
+
+        if ($capabilitiesKey) {
+            $this->makeReadOnlyWhenRequired($elements[0], $capabilitiesKey);
+        }
+
         return array_merge(
-            $this->createSettingWithPriceFields(
-                (new SameDayDeliveryDefinition())->getAllowSettingsKey(),
-                SettingKey::priceDeliveryType(RefTypesDeliveryTypeV2::SAME_DAY)
-            ),
+            $elements,
             [new InteractiveElement(CarrierSettings::CUTOFF_TIME_SAME_DAY, Components::INPUT_TIME)]
         );
     }

--- a/src/Frontend/View/CarrierSettingsItemView.php
+++ b/src/Frontend/View/CarrierSettingsItemView.php
@@ -482,7 +482,17 @@ class CarrierSettingsItemView extends AbstractSettingsView
      */
     private function getSameDayDeliverySettings(): array
     {
-        if (!$this->carrierValidationService->supportsShipmentOption($this->carrier, SameDayDeliveryDefinition::class)) {
+        // Same-day is exposed either as a shipment option (e.g. DHL For You) or as a
+        // delivery type (e.g. Trunkrs), depending on the carrier's contract. This
+        // section is the single owner of the same-day fields for both representations;
+        // getDeliveryTypeSettings() and getShipmentOptionsSettings() skip same-day.
+        $hasSameDayDeliveryType = $this->carrier->deliveryTypes
+            && in_array(RefTypesDeliveryTypeV2::SAME_DAY, $this->carrier->deliveryTypes, true);
+
+        if (
+            ! $hasSameDayDeliveryType
+            && ! $this->carrierValidationService->supportsShipmentOption($this->carrier, SameDayDeliveryDefinition::class)
+        ) {
             return [];
         }
 
@@ -547,8 +557,10 @@ class CarrierSettingsItemView extends AbstractSettingsView
         }
 
         foreach ($this->carrier->deliveryTypes as $deliveryType) {
-            // Pickup has its own section in getDeliveryOptionsFields(), so skip it here.
-            if ($deliveryType === RefTypesDeliveryTypeV2::PICKUP) {
+            // Pickup has its own section in getDeliveryOptionsFields() and same-day has its
+            // own section in getSameDayDeliverySettings() (with the cutoff time field), so
+            // skip both here.
+            if (in_array($deliveryType, [RefTypesDeliveryTypeV2::PICKUP, RefTypesDeliveryTypeV2::SAME_DAY], true)) {
                 continue;
             }
 
@@ -575,6 +587,12 @@ class CarrierSettingsItemView extends AbstractSettingsView
         $settings    = [];
 
         foreach ($definitions as $definition) {
+            // Same-day has its own section in getSameDayDeliverySettings() (with the
+            // cutoff time field), so skip it here to avoid a duplicate toggle.
+            if ($definition instanceof SameDayDeliveryDefinition) {
+                continue;
+            }
+
             $allowKey = $definition->getAllowSettingsKey();
             $priceKey = $definition->getPriceSettingsKey();
 

--- a/tests/Unit/App/DeliveryOptions/Service/DeliveryOptionsServiceTest.php
+++ b/tests/Unit/App/DeliveryOptions/Service/DeliveryOptionsServiceTest.php
@@ -339,3 +339,52 @@ it('uses international mailbox price when shipping address is non-local', functi
     $carrierId   = FrontendData::getLegacyCarrierIdentifier($fakeCarrier->carrier);
     expect($result['carrierSettings'][$carrierId]['pricePackageTypeMailbox'])->toBe(1.05);
 });
+
+it('passes allow* for deliveryTypes without looking at the cutoff times', function () {
+    $fakeCarrier = factory(Carrier::class)->withCarrier('POSTNL')->make();
+
+    // Same-day is switched on, and conditions are applied that in the past would block sameDayDelivery globally.
+    // Whether same-day is still achievable today is the widget's call, so the settings have to arrive as
+    // the merchant set them rather than pre-judged here.
+    factory(CarrierSettings::class, $fakeCarrier->carrier)
+        ->withDeliveryOptions()
+        ->withAllowSameDayDelivery(true)
+        ->withAllowMorningDelivery(true)
+        ->withAllowEveningDelivery(true)
+        ->withCutoffTimeSameDay('02:00')
+        ->withDropOffDelay(2)
+        ->store();
+
+    factory(Shop::class)
+        ->withCarriers(factory(CarrierCollection::class)->push(factory(Carrier::class)->withCarrier('POSTNL')))
+        ->store();
+
+    /** @var \MyParcelNL\Pdk\App\DeliveryOptions\Contract\DeliveryOptionsServiceInterface $service */
+    $service = Pdk::get(DeliveryOptionsServiceInterface::class);
+
+    $result = $service->createAllCarrierSettings(new PdkCart([
+        'lines' => [
+            [
+                'quantity' => 1,
+                'product'  => [
+                    'weight'        => 1,
+                    'isDeliverable' => true,
+                    'settings'      => [
+                        ProductSettings::DROP_OFF_DELAY => 5,
+                    ],
+                ],
+            ],
+        ],
+    ]));
+
+    $carrierId = FrontendData::getLegacyCarrierIdentifier($fakeCarrier->carrier);
+    $settings  = $result['carrierSettings'][$carrierId];
+
+    // dropOffDelay proves the delay really reached the service, so the same-day assertion cannot pass
+    // just because nothing was delaying drop-off in the first place.
+    expect($settings['dropOffDelay'])->toBe(5)
+        ->and($settings['allowSameDayDelivery'])->toBeTrue()
+        ->and($settings['allowMorningDelivery'])->toBeTrue()
+        ->and($settings['allowEveningDelivery'])->toBeTrue()
+        ->and($settings['cutoffTimeSameDay'])->toBe('02:00');
+});

--- a/tests/Unit/Frontend/View/CarrierSettingsItemViewTest.php
+++ b/tests/Unit/Frontend/View/CarrierSettingsItemViewTest.php
@@ -374,6 +374,39 @@ it('marks required option form elements as readOnly', function () {
     expect($hasReadOnly)->toBeTrue('required option form element must be readOnly');
 });
 
+it('marks a required same-day option as readOnly', function () {
+    $carrier = factory(Carrier::class)
+        ->withOptions(['sameDayDelivery' => ['enabled' => true]])
+        ->withOptionRequired('sameDayDelivery')
+        ->store()
+        ->make();
+
+    $view     = new CarrierSettingsItemView($carrier);
+    $elements = $view->toArray()['elements'];
+
+    $allowKey = (new SameDayDeliveryDefinition())->getAllowSettingsKey();
+    $element  = null;
+
+    foreach ($elements as $el) {
+        if (isset($el['name']) && $el['name'] === $allowKey) {
+            $element = $el;
+            break;
+        }
+    }
+
+    expect($element)->not->toBeNull();
+
+    $hasReadOnly = false;
+
+    foreach ($element['$builders'] ?? [] as $builder) {
+        if (array_key_exists('$readOnlyWhen', $builder)) {
+            $hasReadOnly = true;
+        }
+    }
+
+    expect($hasReadOnly)->toBeTrue('required same-day form element must be readOnly');
+});
+
 it('adds afterUpdate logic to delivery options enabled toggle', function () {
     $carrier = factory(Carrier::class)->make();
     $view    = new CarrierSettingsItemView($carrier);

--- a/tests/Unit/Frontend/View/CarrierSettingsItemViewTest.php
+++ b/tests/Unit/Frontend/View/CarrierSettingsItemViewTest.php
@@ -195,6 +195,18 @@ it('shows settings based on capabilities', function (CarrierFactory $carrierFact
         ],
     ],
 
+    'delivery type: same day' => [
+        function () {
+            return factory(Carrier::class)
+                ->withDeliveryTypes([RefTypesDeliveryTypeV2::SAME_DAY]);
+        },
+        [
+            (new SameDayDeliveryDefinition())->getAllowSettingsKey(),
+            SettingKey::priceDeliveryType(RefTypesDeliveryTypeV2::SAME_DAY),
+            CarrierSettings::CUTOFF_TIME_SAME_DAY,
+        ],
+    ],
+
     'shipment option: insurance' => [
         function () {
             return factory(Carrier::class)
@@ -223,6 +235,43 @@ it('shows settings based on capabilities', function (CarrierFactory $carrierFact
                 ->withOptions(['frozen' => ['enabled' => true]]);
         },
         [(new FrozenDefinition())->getCarrierSettingsKey()],
+    ],
+]);
+
+it('renders same day delivery settings exactly once', function (CarrierFactory $carrierFactory) {
+    $names  = getViewSettings($carrierFactory);
+    $counts = array_count_values(array_filter($names));
+
+    $sameDayKeys = [
+        (new SameDayDeliveryDefinition())->getAllowSettingsKey(),
+        SettingKey::priceDeliveryType(RefTypesDeliveryTypeV2::SAME_DAY),
+        CarrierSettings::CUTOFF_TIME_SAME_DAY,
+    ];
+
+    foreach ($sameDayKeys as $key) {
+        expect($counts[$key] ?? 0)->toBe(1);
+    }
+})->with([
+    'as shipment option' => [
+        function () {
+            return factory(Carrier::class)
+                ->withOptions(['sameDayDelivery' => ['enabled' => true]]);
+        },
+    ],
+
+    'as delivery type' => [
+        function () {
+            return factory(Carrier::class)
+                ->withDeliveryTypes([RefTypesDeliveryTypeV2::SAME_DAY]);
+        },
+    ],
+
+    'as both delivery type and shipment option' => [
+        function () {
+            return factory(Carrier::class)
+                ->withDeliveryTypes([RefTypesDeliveryTypeV2::SAME_DAY])
+                ->withOptions(['sameDayDelivery' => ['enabled' => true]]);
+        },
     ],
 ]);
 

--- a/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_plugin_settings__1.json
+++ b/tests/__snapshots__/FrontendRenderServiceTest__it_renders_component_with_data_set_plugin_settings__1.json
@@ -3099,57 +3099,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -3377,30 +3326,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -4881,57 +4806,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -5159,30 +5033,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -6663,57 +6513,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -6941,30 +6740,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -8445,57 +8220,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -8723,30 +8447,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -10227,57 +9927,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -10505,30 +10154,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -12009,57 +11634,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -12287,30 +11861,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -13791,57 +13341,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -14069,30 +13568,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -15573,57 +15048,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -15851,30 +15275,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -17355,57 +16755,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -17633,30 +16982,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -19137,57 +18462,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -19415,30 +18689,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -20970,57 +20220,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -21248,30 +20447,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -22752,57 +21927,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -23030,30 +22154,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -24534,57 +23634,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -24812,30 +23861,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -26316,57 +25341,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -26594,30 +25568,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -28098,57 +27048,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -28376,30 +27275,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",
@@ -29880,57 +28755,6 @@
                             "description": "settings_carrier_price_delivery_type_evening_description"
                         },
                         {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
-                        },
-                        {
-                            "name": "priceDeliveryTypeSameDay",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$target": "allowSameDayDelivery"
-                                            },
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "CurrencyInput",
-                            "label": "settings_carrier_price_delivery_type_same_day",
-                            "description": "settings_carrier_price_delivery_type_same_day_description"
-                        },
-                        {
                             "name": "allowDeliveryTypeExpress",
                             "$builders": [
                                 {
@@ -30158,30 +28982,6 @@
                             "$component": "CurrencyInput",
                             "label": "settings_carrier_price_priority_delivery",
                             "description": "settings_carrier_price_priority_delivery_description"
-                        },
-                        {
-                            "name": "allowSameDayDelivery",
-                            "$builders": [
-                                {
-                                    "$visibleWhen": {
-                                        "$if": [
-                                            {
-                                                "$and": [
-                                                    {
-                                                        "$target": "deliveryOptionsEnabled"
-                                                    },
-                                                    {
-                                                        "$target": "allowDeliveryOptions"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "$component": "ToggleInput",
-                            "label": "settings_carrier_allow_same_day_delivery",
-                            "description": "settings_carrier_allow_same_day_delivery_description"
                         },
                         {
                             "name": "allowSaturdayDelivery",

--- a/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_carrier_settings__1.json
+++ b/tests/__snapshots__/SettingsViewTest__it_gets_settings_view_with_data_set_carrier_settings__1.json
@@ -1352,57 +1352,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -1630,30 +1579,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -3134,57 +3059,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -3412,30 +3286,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -4916,57 +4766,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -5194,30 +4993,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -6698,57 +6473,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -6976,30 +6700,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -8480,57 +8180,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -8758,30 +8407,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -10262,57 +9887,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -10540,30 +10114,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -12044,57 +11594,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -12322,30 +11821,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -13826,57 +13301,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -14104,30 +13528,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -15608,57 +15008,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -15886,30 +15235,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -17390,57 +16715,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -17668,30 +16942,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -19223,57 +18473,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -19501,30 +18700,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -21005,57 +20180,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -21283,30 +20407,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -22787,57 +21887,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -23065,30 +22114,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -24569,57 +23594,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -24847,30 +23821,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -26351,57 +25301,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -26629,30 +25528,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",
@@ -28133,57 +27008,6 @@
                     "description": "settings_carrier_price_delivery_type_evening_description"
                 },
                 {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
-                },
-                {
-                    "name": "priceDeliveryTypeSameDay",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$target": "allowSameDayDelivery"
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "CurrencyInput",
-                    "label": "settings_carrier_price_delivery_type_same_day",
-                    "description": "settings_carrier_price_delivery_type_same_day_description"
-                },
-                {
                     "name": "allowDeliveryTypeExpress",
                     "$builders": [
                         {
@@ -28411,30 +27235,6 @@
                     "$component": "CurrencyInput",
                     "label": "settings_carrier_price_priority_delivery",
                     "description": "settings_carrier_price_priority_delivery_description"
-                },
-                {
-                    "name": "allowSameDayDelivery",
-                    "$builders": [
-                        {
-                            "$visibleWhen": {
-                                "$if": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "$target": "deliveryOptionsEnabled"
-                                            },
-                                            {
-                                                "$target": "allowDeliveryOptions"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "$component": "ToggleInput",
-                    "label": "settings_carrier_allow_same_day_delivery",
-                    "description": "settings_carrier_allow_same_day_delivery_description"
                 },
                 {
                     "name": "allowSaturdayDelivery",


### PR DESCRIPTION
renders the same-day delivery settings for carriers that expose same-day as a delivery type instead of a shipment option.

Some carriers (like Trunkrs) advertise same-day delivery as a delivery type in their contract, while others (like DHL For You) advertise it as a shipment option. The carrier settings view only checked the shipment option, so for delivery-type carriers the cutoff time field never rendered and the same-day cutoff silently stayed at the 10:00 default. When same-day is all the carrier offers, that hides the carrier from checkout after the cutoff with no way to fix it in the admin. The same-day section now renders for both representations and is the single owner of these fields. This also removes a duplicate same-day toggle that was rendered for shipment-option carriers.

Fixes INT-1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)