### PR TITLE
ci(dependabot): exclude myparcel packages from cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
     commit-message:
       prefix: 'build'
       include: 'scope'
+    cooldown:
+      exclude:
+        - 'myparcelnl/*'
     groups:
       minor-php-updates:
         applies-to: version-updates


### PR DESCRIPTION
This change excludes our own packages from the Dependabot cooldown for composer and npm.

Dependabot applies a cooldown of 3 days to version updates, also when no cooldown block is set. That delays the update PRs for our own releases, which we want immediately. The exclude list holds our own scopes, so those PRs open as soon as we publish. Third-party packages keep the default cooldown.

Patterns are matched with `File.fnmatch?` against the full dependency name, so a scope glob such as `@myparcel-dev/*` matches every package in that scope.

Aligns this repo with myparcelnl/prestashop@3b76767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
